### PR TITLE
fix (settings): shortcut recorder gets stuck on “Waiting…” after cancel

### DIFF
--- a/macshot/PreferencesWindowController.swift
+++ b/macshot/PreferencesWindowController.swift
@@ -504,6 +504,7 @@ class PreferencesWindowController: NSWindowController, NSTabViewDelegate, NSWind
     private func stopShortcutRecording() {
         if let slot = recordingSlot {
             hotkeyButtons[slot]?.title = "Record"
+            hotkeyFields[slot]?.stringValue = HotkeyManager.displayString(for: slot)
         }
         recordingSlot = nil
         if let m = localMonitor { NSEvent.removeMonitor(m); localMonitor = nil }


### PR DESCRIPTION
Fixes a small bug in the settings UI where the shortcut recorder could leave the shortcut field stuck on `Waiting...` after canceling recording.

## Before
The button would return to `Record`, but the shortcut field remained stuck `Waiting...`.

![Bug Preview](https://github.com/user-attachments/assets/5841629d-8962-4c72-877c-c7083777cbee)

## After
Both the button and the shortcut field return to their normal state when recording is canceled.

![Fixed](https://github.com/user-attachments/assets/047784b6-ff59-49e8-baf8-58b8278898e1)



> I couldn’t find a contributing guide in the repository, so I tried to keep this change minimal. Happy to adjust anything if needed.