### PR TITLE
fix (recording): correct ScreenCaptureKit crop rect's y conversion

### DIFF
--- a/macshot/RecordingEngine.swift
+++ b/macshot/RecordingEngine.swift
@@ -79,7 +79,7 @@ final class RecordingEngine: NSObject {
         let flippedY = displayBounds.maxY - rect.maxY
         // Scale to points — SCStream works in points on the display
         self.cropRect = CGRect(x: rect.minX - displayBounds.minX,
-                               y: flippedY - displayBounds.minY,
+                               y: flippedY,
                                width: rect.width,
                                height: rect.height)
 


### PR DESCRIPTION
Fixes a screen recording issue where starting a recording would immediately close the recording flow instead of starting capture.

### Root Cause

`RecordingEngine.swift` builds `SCStreamConfiguration.sourceRect` with an incorrect Y offset. The selected rect is flipped into ScreenCaptureKit space correctly, but `displayBounds.minY` is then subtracted a second time, which can shift the crop rect out of display-local bounds.

```swift
let flippedY = displayBounds.maxY - rect.maxY // transformed correctly here

self.cropRect = CGRect(
    x: rect.minX - displayBounds.minX,
    y: flippedY - displayBounds.minY,    // transformed a second time here
    width: rect.width,
    height: rect.height
)
```

### Fix

This is pretty straight-forward... Use the already-flipped Y coordinate directly:
```swift
let flippedY = displayBounds.maxY - rect.maxY

self.cropRect = CGRect(
    x: rect.minX - displayBounds.minX,
    y: flippedY,
    width: rect.width,
    height: rect.height
)
```

> Please let me know if you require any screen-recordings to confirm.