### PR TITLE
Add zg.is upload provider

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -843,6 +843,26 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
                     toast.showError(message: error.localizedDescription)
                 }
             }
+        } else if provider == "zgis" {
+            ImageUploader.upload(image: image, endpoint: "https://zg.is/1/upload") { result in
+                switch result {
+                case .success(let uploadResult):
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    pasteboard.setString(uploadResult.link, forType: .string)
+
+                    var uploads = UserDefaults.standard.array(forKey: "imgbbUploads") as? [[String: String]] ?? []
+                    uploads.append([
+                        "deleteURL": uploadResult.deleteURL,
+                        "link": uploadResult.link,
+                    ])
+                    UserDefaults.standard.set(uploads, forKey: "imgbbUploads")
+
+                    toast.showSuccess(link: uploadResult.link, deleteURL: uploadResult.deleteURL)
+                case .failure(let error):
+                    toast.showError(message: error.localizedDescription)
+                }
+            }
         } else {
             ImageUploader.upload(image: image) { result in
                 switch result {

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -5530,6 +5530,7 @@ class OverlayView: NSView {
                 switch provider {
                 case "gdrive": title = L("Upload to Google Drive?")
                 case "s3": title = L("Upload to S3?")
+                case "zgis": title = L("Upload to zg.is?")
                 default: title = L("Upload to imgbb.com?")
                 }
                 let alert = NSAlert()

--- a/macshot/UI/Windows/PreferencesWindowController.swift
+++ b/macshot/UI/Windows/PreferencesWindowController.swift
@@ -870,11 +870,12 @@ class PreferencesWindowController: NSWindowController, NSTabViewDelegate, NSWind
         stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
 
         providerPopup = NSPopUpButton()
-        providerPopup.addItems(withTitles: [L("imgbb (images only)"), L("Google Drive (images + videos)"), L("S3-Compatible (images + videos)")])
+        providerPopup.addItems(withTitles: [L("imgbb (images only)"), L("Google Drive (images + videos)"), L("S3-Compatible (images + videos)"), L("zg.is (images only, 30d auto-delete)")])
         let currentProvider = UserDefaults.standard.string(forKey: "uploadProvider") ?? "imgbb"
         switch currentProvider {
         case "gdrive": providerPopup.selectItem(at: 1)
         case "s3": providerPopup.selectItem(at: 2)
+        case "zgis": providerPopup.selectItem(at: 3)
         default: providerPopup.selectItem(at: 0)
         }
         providerPopup.target = self
@@ -1012,6 +1013,16 @@ class PreferencesWindowController: NSWindowController, NSTabViewDelegate, NSWind
         imgbbNote.font = NSFont.systemFont(ofSize: 10)
         imgbbNote.textColor = .secondaryLabelColor
         stack.addArrangedSubview(indented(imgbbNote))
+        stack.setCustomSpacing(16, after: stack.arrangedSubviews.last!)
+
+        // ── zg.is ──
+        stack.addArrangedSubview(sectionHeader("zg.is"))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        let zgisNote = NSTextField(wrappingLabelWithString: L("Uses the same API key as imgbb. Images only (no video support). Uploaded images are automatically deleted after 30 days."))
+        zgisNote.font = NSFont.systemFont(ofSize: 10)
+        zgisNote.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(indented(zgisNote))
         stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
 
         // ── Upload History ──
@@ -1141,6 +1152,7 @@ class PreferencesWindowController: NSWindowController, NSTabViewDelegate, NSWind
         switch sender.indexOfSelectedItem {
         case 1: provider = "gdrive"
         case 2: provider = "s3"
+        case 3: provider = "zgis"
         default: provider = "imgbb"
         }
         UserDefaults.standard.set(provider, forKey: "uploadProvider")

--- a/macshot/Upload/ImgbbUploader.swift
+++ b/macshot/Upload/ImgbbUploader.swift
@@ -16,7 +16,7 @@ enum ImageUploader {
         return defaultAPIKey
     }
 
-    static func upload(image: NSImage, completion: @escaping (Result<ImageUploadResult, Error>) -> Void) {
+    static func upload(image: NSImage, endpoint: String = "https://api.imgbb.com/1/upload", completion: @escaping (Result<ImageUploadResult, Error>) -> Void) {
         guard let tiffData = image.tiffRepresentation,
               let bitmap = NSBitmapImageRep(data: tiffData),
               let pngData = bitmap.representation(using: .png, properties: [:]) else {
@@ -26,7 +26,7 @@ enum ImageUploader {
 
         let base64String = pngData.base64EncodedString()
 
-        let urlString = "https://api.imgbb.com/1/upload?key=\(apiKey)"
+        let urlString = "\(endpoint)?key=\(apiKey)"
         guard let url = URL(string: urlString) else {
             completion(.failure(NSError(domain: "ImageUploader", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"])))
             return

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -291,6 +291,7 @@
 "Google Drive (images + videos)" = "Google Drive (images + videos)";
 "imgbb (images only)" = "imgbb (images only)";
 "S3-Compatible (images + videos)" = "S3-Compatible (images + videos)";
+"zg.is (images only, 30d auto-delete)" = "zg.is (images only, 30d auto-delete)";
 "S3-Compatible Storage" = "S3-Compatible Storage";
 "Sign In with Google" = "Sign In with Google";
 "Sign Out" = "Sign Out";
@@ -314,6 +315,7 @@
 "No uploads yet." = "No uploads yet.";
 "Base URL for public access. If empty, the S3 endpoint URL is used (may not be publicly accessible)." = "Base URL for public access. If empty, the S3 endpoint URL is used (may not be publicly accessible).";
 "A shared key is included — get your own free key at imgbb.com/api if you hit rate limits. Images only (no video support)." = "A shared key is included — get your own free key at imgbb.com/api if you hit rate limits. Images only (no video support).";
+"Uses the same API key as imgbb. Images only (no video support). Uploaded images are automatically deleted after 30 days." = "Uses the same API key as imgbb. Images only (no video support). Uploaded images are automatically deleted after 30 days.";
 "Works with AWS S3, Cloudflare R2, MinIO, DigitalOcean Spaces, Backblaze B2, and other S3-compatible services. Supports images and videos." = "Works with AWS S3, Cloudflare R2, MinIO, DigitalOcean Spaces, Backblaze B2, and other S3-compatible services. Supports images and videos.";
 "Configure S3 in Preferences" = "Configure S3 in Preferences";
 "Sign in to Google Drive in Preferences" = "Sign in to Google Drive in Preferences";
@@ -340,6 +342,7 @@
 "Upload to Google Drive?" = "Upload to Google Drive?";
 "Upload to S3?" = "Upload to S3?";
 "Upload to imgbb.com?" = "Upload to imgbb.com?";
+"Upload to zg.is?" = "Upload to zg.is?";
 "Your screenshot will be uploaded." = "Your screenshot will be uploaded.";
 
 /* Permission Onboarding */


### PR DESCRIPTION
## Summary
- Adds [zg.is](https://zg.is) as a new image upload provider (images only, auto-deletes after 30 days)
- zg.is uses an imgbb-compatible API, so the existing `ImageUploader` is reused with a configurable `endpoint` parameter — no new files or duplicated logic
- Uses the same API key as imgbb

## Changes
- **ImgbbUploader.swift**: Add `endpoint` parameter (defaults to imgbb, so existing callers are unaffected)
- **AppDelegate.swift**: Add `zgis` provider dispatch block
- **PreferencesWindowController.swift**: Add zg.is to provider dropdown + info section
- **OverlayView.swift**: Add upload confirmation dialog title for zg.is
- **Localizable.strings**: Add English strings

## Test plan
- [ ] Select "zg.is" in Preferences → Uploads → Provider
- [ ] Take a screenshot and upload — verify link is copied to clipboard
- [ ] Verify upload history shows the zg.is upload
- [ ] Switch back to imgbb and verify it still works