### PR TITLE
Add custom imgbb-compatible endpoint support

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -843,6 +843,31 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
                     toast.showError(message: error.localizedDescription)
                 }
             }
+        } else if provider == "custom" {
+            let endpoint = UserDefaults.standard.string(forKey: "customEndpoint") ?? "https://api.imgbb.com/1/upload"
+            let customKey: String? = {
+                if let k = UserDefaults.standard.string(forKey: "customAPIKey"), !k.isEmpty { return k }
+                return nil
+            }()
+            ImageUploader.upload(image: image, endpoint: endpoint, apiKey: customKey) { result in
+                switch result {
+                case .success(let uploadResult):
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    pasteboard.setString(uploadResult.link, forType: .string)
+
+                    var uploads = UserDefaults.standard.array(forKey: "imgbbUploads") as? [[String: String]] ?? []
+                    uploads.append([
+                        "deleteURL": uploadResult.deleteURL,
+                        "link": uploadResult.link,
+                    ])
+                    UserDefaults.standard.set(uploads, forKey: "imgbbUploads")
+
+                    toast.showSuccess(link: uploadResult.link, deleteURL: uploadResult.deleteURL)
+                case .failure(let error):
+                    toast.showError(message: error.localizedDescription)
+                }
+            }
         } else {
             ImageUploader.upload(image: image) { result in
                 switch result {

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -5530,6 +5530,7 @@ class OverlayView: NSView {
                 switch provider {
                 case "gdrive": title = L("Upload to Google Drive?")
                 case "s3": title = L("Upload to S3?")
+                case "custom": title = L("Upload to custom endpoint?")
                 default: title = L("Upload to imgbb.com?")
                 }
                 let alert = NSAlert()

--- a/macshot/UI/Windows/PreferencesWindowController.swift
+++ b/macshot/UI/Windows/PreferencesWindowController.swift
@@ -46,6 +46,8 @@ class PreferencesWindowController: NSWindowController, NSTabViewDelegate, NSWind
     private var downscaleRetinaCheckbox: NSButton!
     private var embedColorProfileCheckbox: NSButton!
     private var imgbbKeyField: NSTextField!
+    private var customEndpointField: NSTextField!
+    private var customAPIKeyField: NSTextField!
     private var localMonitor: Any?
     private weak var uploadsStack: NSStackView?
     private var providerPopup: NSPopUpButton!
@@ -870,11 +872,12 @@ class PreferencesWindowController: NSWindowController, NSTabViewDelegate, NSWind
         stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
 
         providerPopup = NSPopUpButton()
-        providerPopup.addItems(withTitles: [L("imgbb (images only)"), L("Google Drive (images + videos)"), L("S3-Compatible (images + videos)")])
+        providerPopup.addItems(withTitles: [L("imgbb (images only)"), L("Google Drive (images + videos)"), L("S3-Compatible (images + videos)"), L("Custom (imgbb-compatible)")])
         let currentProvider = UserDefaults.standard.string(forKey: "uploadProvider") ?? "imgbb"
         switch currentProvider {
         case "gdrive": providerPopup.selectItem(at: 1)
         case "s3": providerPopup.selectItem(at: 2)
+        case "custom": providerPopup.selectItem(at: 3)
         default: providerPopup.selectItem(at: 0)
         }
         providerPopup.target = self
@@ -1012,6 +1015,37 @@ class PreferencesWindowController: NSWindowController, NSTabViewDelegate, NSWind
         imgbbNote.font = NSFont.systemFont(ofSize: 10)
         imgbbNote.textColor = .secondaryLabelColor
         stack.addArrangedSubview(indented(imgbbNote))
+        stack.setCustomSpacing(16, after: stack.arrangedSubviews.last!)
+
+        // ── Custom (imgbb-compatible) ──
+        stack.addArrangedSubview(sectionHeader(L("Custom (imgbb-compatible)")))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        customEndpointField = NSTextField()
+        customEndpointField.placeholderString = "https://api.imgbb.com/1/upload"
+        customEndpointField.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        customEndpointField.target = self
+        customEndpointField.action = #selector(customEndpointChanged(_:))
+        if let ep = UserDefaults.standard.string(forKey: "customEndpoint") {
+            customEndpointField.stringValue = ep
+        }
+        stack.addArrangedSubview(labeledRow(L("Endpoint URL:"), controls: [customEndpointField]))
+
+        customAPIKeyField = NSTextField()
+        customAPIKeyField.placeholderString = L("Leave empty to use default")
+        customAPIKeyField.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        customAPIKeyField.target = self
+        customAPIKeyField.action = #selector(customAPIKeyChanged(_:))
+        if let key = UserDefaults.standard.string(forKey: "customAPIKey") {
+            customAPIKeyField.stringValue = key
+        }
+        stack.addArrangedSubview(labeledRow(L("API key:"), controls: [customAPIKeyField]))
+        stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
+
+        let customNote = NSTextField(wrappingLabelWithString: L("Use any imgbb-compatible API endpoint. Works with self-hosted Chevereto instances and other compatible services."))
+        customNote.font = NSFont.systemFont(ofSize: 10)
+        customNote.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(indented(customNote))
         stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
 
         // ── Upload History ──
@@ -1141,6 +1175,7 @@ class PreferencesWindowController: NSWindowController, NSTabViewDelegate, NSWind
         switch sender.indexOfSelectedItem {
         case 1: provider = "gdrive"
         case 2: provider = "s3"
+        case 3: provider = "custom"
         default: provider = "imgbb"
         }
         UserDefaults.standard.set(provider, forKey: "uploadProvider")
@@ -1627,6 +1662,16 @@ class PreferencesWindowController: NSWindowController, NSTabViewDelegate, NSWind
         let key = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         if key.isEmpty { UserDefaults.standard.removeObject(forKey: "imgbbAPIKey") }
         else { UserDefaults.standard.set(key, forKey: "imgbbAPIKey") }
+    }
+    @objc private func customEndpointChanged(_ sender: NSTextField) {
+        let value = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.isEmpty { UserDefaults.standard.removeObject(forKey: "customEndpoint") }
+        else { UserDefaults.standard.set(value, forKey: "customEndpoint") }
+    }
+    @objc private func customAPIKeyChanged(_ sender: NSTextField) {
+        let key = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if key.isEmpty { UserDefaults.standard.removeObject(forKey: "customAPIKey") }
+        else { UserDefaults.standard.set(key, forKey: "customAPIKey") }
     }
     @objc private func historySizeChanged(_ sender: NSStepper) {
         historySizeField.integerValue = sender.integerValue

--- a/macshot/Upload/ImgbbUploader.swift
+++ b/macshot/Upload/ImgbbUploader.swift
@@ -16,7 +16,7 @@ enum ImageUploader {
         return defaultAPIKey
     }
 
-    static func upload(image: NSImage, completion: @escaping (Result<ImageUploadResult, Error>) -> Void) {
+    static func upload(image: NSImage, endpoint: String = "https://api.imgbb.com/1/upload", apiKey overrideKey: String? = nil, completion: @escaping (Result<ImageUploadResult, Error>) -> Void) {
         guard let tiffData = image.tiffRepresentation,
               let bitmap = NSBitmapImageRep(data: tiffData),
               let pngData = bitmap.representation(using: .png, properties: [:]) else {
@@ -26,7 +26,7 @@ enum ImageUploader {
 
         let base64String = pngData.base64EncodedString()
 
-        let urlString = "https://api.imgbb.com/1/upload?key=\(apiKey)"
+        let urlString = "\(endpoint)?key=\(overrideKey ?? Self.apiKey)"
         guard let url = URL(string: urlString) else {
             completion(.failure(NSError(domain: "ImageUploader", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"])))
             return

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -291,6 +291,7 @@
 "Google Drive (images + videos)" = "Google Drive (images + videos)";
 "imgbb (images only)" = "imgbb (images only)";
 "S3-Compatible (images + videos)" = "S3-Compatible (images + videos)";
+"Custom (imgbb-compatible)" = "Custom (imgbb-compatible)";
 "S3-Compatible Storage" = "S3-Compatible Storage";
 "Sign In with Google" = "Sign In with Google";
 "Sign Out" = "Sign Out";
@@ -314,6 +315,8 @@
 "No uploads yet." = "No uploads yet.";
 "Base URL for public access. If empty, the S3 endpoint URL is used (may not be publicly accessible)." = "Base URL for public access. If empty, the S3 endpoint URL is used (may not be publicly accessible).";
 "A shared key is included — get your own free key at imgbb.com/api if you hit rate limits. Images only (no video support)." = "A shared key is included — get your own free key at imgbb.com/api if you hit rate limits. Images only (no video support).";
+"Use any imgbb-compatible API endpoint. Works with self-hosted Chevereto instances and other compatible services." = "Use any imgbb-compatible API endpoint. Works with self-hosted Chevereto instances and other compatible services.";
+"Endpoint URL:" = "Endpoint URL:";
 "Works with AWS S3, Cloudflare R2, MinIO, DigitalOcean Spaces, Backblaze B2, and other S3-compatible services. Supports images and videos." = "Works with AWS S3, Cloudflare R2, MinIO, DigitalOcean Spaces, Backblaze B2, and other S3-compatible services. Supports images and videos.";
 "Configure S3 in Preferences" = "Configure S3 in Preferences";
 "Sign in to Google Drive in Preferences" = "Sign in to Google Drive in Preferences";
@@ -340,6 +343,7 @@
 "Upload to Google Drive?" = "Upload to Google Drive?";
 "Upload to S3?" = "Upload to S3?";
 "Upload to imgbb.com?" = "Upload to imgbb.com?";
+"Upload to custom endpoint?" = "Upload to custom endpoint?";
 "Your screenshot will be uploaded." = "Your screenshot will be uploaded.";
 
 /* Permission Onboarding */


### PR DESCRIPTION
## Summary
- Adds a **"Custom (imgbb-compatible)"** upload provider option in Preferences
- Users can configure any imgbb-compatible API endpoint URL and API key
- Works with self-hosted [Chevereto](https://chevereto.com) instances (imgbb.com itself runs on Chevereto) and other compatible services
- Reuses existing `ImageUploader` with configurable `endpoint` and `apiKey` parameters — no new files, no duplicated logic

## Changes
- **ImgbbUploader.swift** (+2 lines): Add `endpoint` and `apiKey` parameters with defaults (existing callers unaffected)
- **AppDelegate.swift** (+25 lines): Add `custom` provider dispatch reading endpoint/key from UserDefaults
- **PreferencesWindowController.swift** (+45 lines): Add provider dropdown entry, config section (endpoint URL + API key fields + note), action handlers
- **OverlayView.swift** (+1 line): Upload confirmation dialog title
- **Localizable.strings** (+4 lines): English strings

## Test plan
- [x] Select "Custom (imgbb-compatible)" in Preferences → Uploads → Provider
- [x] Enter a custom endpoint URL and API key
- [x] Take a screenshot and upload — verify link is copied to clipboard
- [x] Verify upload history shows the upload with delete URL
- [x] Switch back to imgbb and verify it still works (regression)
- [x] Verify Google Drive and S3 providers are unaffected