### PR TITLE
fix: reset zoom anchors when returning to 1x to prevent coordinate misalignment

### DIFF
--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -3347,11 +3347,20 @@ class OverlayView: NSView {
         // Canvas point currently under cursor (before zoom change)
         let canvasUnderCursor = viewToCanvas(cursorView)
         zoomLevel = max(zoomMin, min(zoomMax, level))
-        // After zoom change, pin that canvas point to the cursor's view position.
-        // because applyZoomTransform runs after the editor translate.
-        zoomAnchorCanvas = canvasUnderCursor
-        zoomAnchorView = cursorView
-        clampZoomAnchor()
+
+        // When zooming back to 1×, reset anchors to avoid floating-point drift
+        // that causes visual misalignment between background and annotations.
+        if abs(zoomLevel - 1.0) < 0.005 {
+            zoomLevel = 1.0
+            zoomAnchorCanvas = .zero
+            zoomAnchorView = .zero
+        } else {
+            // After zoom change, pin that canvas point to the cursor's view position.
+            // because applyZoomTransform runs after the editor translate.
+            zoomAnchorCanvas = canvasUnderCursor
+            zoomAnchorView = cursorView
+            clampZoomAnchor()
+        }
         showZoomLabel()
         needsDisplay = true
     }


### PR DESCRIPTION
## Problem

When zooming in (e.g., to 2x) and then zooming back to 1x using the mouse wheel, the background screenshot and annotation layers became misaligned. Moving the selection rectangle after zooming back to 1x revealed a "gap" or offset between the background image and the annotations, as if they were on separate layers.

## Root Cause

The issue was in the `setZoom()` method. When zooming back to 1x, the code set `zoomLevel = 1.0` but did not reset `zoomAnchorCanvas` and `zoomAnchorView` to zero. This caused:

1. The coordinate transform functions to still apply translations even though zoom was 1x
2. Floating-point precision errors to accumulate (e.g., `100.00000001 - 99.99999999`)
3. Visual misalignment between background and annotation layers

## Solution

Modified `setZoom()` to explicitly reset zoom anchors to zero when the zoom level returns to 1x:

```swift
if abs(zoomLevel - 1.0) < 0.005 {
    zoomLevel = 1.0
    zoomAnchorCanvas = .zero
    zoomAnchorView = .zero
}
```

This ensures that:
- Coordinate transform functions short-circuit correctly when zoom is 1x
- No floating-point drift accumulates
- Background and annotation layers remain perfectly aligned

## Testing

1. Zoom in to 2x using mouse wheel
2. Zoom back to 1x using mouse wheel
3. Move the selection rectangle
4. Verify no visual gap/misalignment between background and annotations