### PR TITLE
fix: sync window snap state across all monitors on Tab key toggle

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -1737,6 +1737,15 @@ extension AppDelegate: OverlayWindowControllerDelegate {
         return stitchCrossScreenCapture(primary: controller, others: others)
     }
 
+    func overlayDidChangeWindowSnapState(_ controller: OverlayWindowController) {
+        // Notify all other overlays to redraw (for multi-monitor setups)
+        // When window snap state changes via Tab key, all overlays need to update
+        // their helper text to show the new ON/OFF state
+        for other in overlayControllers where other !== controller {
+            other.triggerRedraw()
+        }
+    }
+
     private func handleScrollCaptureCompleted(finalImage: NSImage?) {
         scrollCapturePreviewPanel?.close()
         scrollCapturePreviewPanel = nil

--- a/macshot/UI/Editor/DetachedEditorWindowController.swift
+++ b/macshot/UI/Editor/DetachedEditorWindowController.swift
@@ -498,6 +498,7 @@ extension DetachedEditorWindowController: OverlayViewDelegate {
     func overlayViewDidRequestToggleAutoScroll() {}
     func overlayViewDidRequestAccessibilityPermission() {}
     func overlayViewDidRequestInputMonitoringPermission() {}
+    func overlayViewDidChangeWindowSnapState() {}  // Not applicable in editor mode
 
     func overlayViewDidRequestAddCapture() {
         guard let editorWindow = window else { return }
@@ -666,5 +667,12 @@ private class AddCaptureOverlayHandler: NSObject, OverlayWindowControllerDelegat
         }
         guard let cgImage = cgCtx.makeImage() else { return nil }
         return NSImage(cgImage: cgImage, size: globalRect.size)
+    }
+
+    func overlayDidChangeWindowSnapState(_ controller: OverlayWindowController) {
+        // Notify all other overlays to redraw (for multi-monitor setups during "Add Capture" in editor)
+        for other in overlayControllers where other !== controller {
+            other.triggerRedraw()
+        }
     }
 }

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -28,6 +28,7 @@ protocol OverlayViewDelegate: AnyObject {
     func overlayViewDidRequestInputMonitoringPermission()
     func overlayViewDidBeginSelection()
     func overlayViewRemoteSelectionDidChange(_ rect: NSRect)
+    func overlayViewDidChangeWindowSnapState()
     func overlayViewRemoteSelectionDidFinish(_ rect: NSRect)
     func overlayViewDidRequestAddCapture()
 }
@@ -6890,6 +6891,8 @@ class OverlayView: NSView {
                 windowSnapEnabled = !windowSnapEnabled
                 hoveredWindowRect = nil
                 needsDisplay = true
+                // Notify other overlays to redraw (for multi-monitor setups)
+                overlayDelegate?.overlayViewDidChangeWindowSnapState()
             }
         case 3:  // F — full screen capture (only in idle state with snap on)
             if state == .idle && windowSnapEnabled {

--- a/macshot/UI/Overlay/OverlayWindowController.swift
+++ b/macshot/UI/Overlay/OverlayWindowController.swift
@@ -30,6 +30,7 @@ protocol OverlayWindowControllerDelegate: AnyObject {
     func overlayDidRemoteResizeSelection(_ controller: OverlayWindowController, globalRect: NSRect)
     func overlayDidFinishRemoteResize(_ controller: OverlayWindowController, globalRect: NSRect)
     func overlayCrossScreenImage(_ controller: OverlayWindowController) -> NSImage?
+    func overlayDidChangeWindowSnapState(_ controller: OverlayWindowController)
 }
 
 /// Manages one fullscreen overlay per screen.
@@ -116,6 +117,10 @@ class OverlayWindowController {
 
     func clearSelection() {
         overlayView?.clearSelection()
+    }
+
+    func triggerRedraw() {
+        overlayView?.needsDisplay = true
     }
 
     func setRemoteSelection(_ rect: NSRect, fullRect: NSRect = .zero) {
@@ -527,6 +532,10 @@ extension OverlayWindowController: OverlayViewDelegate {
 
     func overlayViewDidBeginSelection() {
         overlayDelegate?.overlayDidBeginSelection(self)
+    }
+
+    func overlayViewDidChangeWindowSnapState() {
+        overlayDelegate?.overlayDidChangeWindowSnapState(self)
     }
 
     func overlayViewDidRequestAddCapture() {}  // editor-only


### PR DESCRIPTION
## Problem

In multi-monitor setups, pressing Tab to toggle window snap mode (window snapping: ON/OFF) only updated the helper text on the monitor receiving the keyboard event. Other monitors continued displaying the previous state, creating inconsistency across screens.

## Root Cause

The `windowSnapEnabled` state is stored in `UserDefaults` (shared across all overlay instances), but when the Tab key toggles the state, only the active overlay calls `needsDisplay = true`. The other overlays never receive a redraw notification, so they continue displaying the stale helper text.

## Solution

Added cross-monitor synchronization when window snap state changes:

1. **New delegate method**: `overlayViewDidChangeWindowSnapState()` in `OverlayViewDelegate`
2. **Tab key handler**: Calls the delegate method after toggling state
3. **OverlayWindowController**: Forwards the call and provides `triggerRedraw()` public method
4. **AppDelegate**: Implements sync by calling `triggerRedraw()` on all other overlays

## Testing

1. Connect two or more monitors
2. Trigger screenshot capture (Cmd+Shift+X)
3. Press Tab to toggle window snap mode
4. Verify: All monitors show the same ON/OFF state in helper text
5. Press Tab again
6. Verify: All monitors update to the new state

## Files Changed

- `macshot/UI/Overlay/OverlayView.swift`: Added delegate method call in Tab handler
- `macshot/UI/Overlay/OverlayWindowController.swift`: Added forwarding and `triggerRedraw()` method
- `macshot/AppDelegate.swift`: Implemented cross-monitor sync
- `macshot/UI/Editor/DetachedEditorWindowController.swift\}: Added protocol implementation