### PR TITLE
settings: regroup preferences tabs by workflow

### DIFF
--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -746,6 +746,39 @@ class OverlayView: NSView {
     var snappedWindowImage: NSImage? = nil
     private var windowSnapQueryInFlight: Bool = false
 
+    /// Perform a window snap query at the given screen point (AppKit screen coordinates).
+    private func queryWindowSnap(at screenPoint: NSPoint) {
+        guard !windowSnapQueryInFlight,
+            state == .idle && windowSnapEnabled,
+            !(remoteSelectionRect.width >= 1 && remoteSelectionRect.height >= 1),
+            let viewWindow = window
+        else { return }
+        let overlayWindowNumber = viewWindow.windowNumber
+        let windowOrigin = viewWindow.frame.origin
+        let viewBounds = bounds
+        let screenH = NSScreen.screens.first?.frame.height ?? NSScreen.main?.frame.height ?? 0
+        windowSnapQueryInFlight = true
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+            let result = Self.windowRectOnBackground(
+                screenPoint: screenPoint,
+                overlayWindowNumber: overlayWindowNumber,
+                windowOrigin: windowOrigin,
+                viewBounds: viewBounds,
+                screenH: screenH
+            )
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.windowSnapQueryInFlight = false
+                let newRect = result?.rect
+                if newRect != self.hoveredWindowRect {
+                    self.hoveredWindowRect = newRect
+                    self.hoveredWindowID = result?.windowID
+                    self.needsDisplay = true
+                }
+            }
+        }
+    }
+
     // Mic level monitor (volume meter shown when mic is enabled before recording)
     private var micLevelEngine: AVAudioEngine?
     private var micLevelTimer: Timer?
@@ -789,10 +822,17 @@ class OverlayView: NSView {
             owner: self, userInfo: nil)
         addTrackingArea(area)
 
-        // Let the overlay render before starting expensive window snap queries
+        // Brief cooldown so the window server finishes compositing the overlay
+        // before we query CGWindowListCopyWindowInfo.
         windowSnapCooldown = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-            self?.windowSnapCooldown = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [weak self] in
+            guard let self = self else { return }
+            self.windowSnapCooldown = false
+            // Perform an initial snap query at the current mouse position so the
+            // highlight appears immediately without requiring the user to move the mouse.
+            if self.state == .idle && self.windowSnapEnabled && !self.windowSnapQueryInFlight {
+                self.queryWindowSnap(at: NSEvent.mouseLocation)
+            }
         }
 
         NotificationCenter.default.addObserver(
@@ -873,33 +913,9 @@ class OverlayView: NSView {
             guard
                 let screenPoint = window.map({
                     NSPoint(x: $0.frame.origin.x + point.x, y: $0.frame.origin.y + point.y)
-                }),
-                let viewWindow = window
+                })
             else { return }
-            let overlayWindowNumber = viewWindow.windowNumber
-            let windowOrigin = viewWindow.frame.origin
-            let viewBounds = bounds
-            let screenH = NSScreen.screens.first?.frame.height ?? NSScreen.main?.frame.height ?? 0
-            windowSnapQueryInFlight = true
-            DispatchQueue.global(qos: .userInteractive).async { [weak self] in
-                let result = Self.windowRectOnBackground(
-                    screenPoint: screenPoint,
-                    overlayWindowNumber: overlayWindowNumber,
-                    windowOrigin: windowOrigin,
-                    viewBounds: viewBounds,
-                    screenH: screenH
-                )
-                DispatchQueue.main.async {
-                    guard let self = self else { return }
-                    self.windowSnapQueryInFlight = false
-                    let newRect = result?.rect
-                    if newRect != self.hoveredWindowRect {
-                        self.hoveredWindowRect = newRect
-                        self.hoveredWindowID = result?.windowID
-                        self.needsDisplay = true
-                    }
-                }
-            }
+            queryWindowSnap(at: screenPoint)
         }
 
         // Track cursor for loupe live preview (use canvas space for zoom correctness)

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -124,25 +124,30 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         generalTab.view = makeGeneralTabView()
         tabView.addTabViewItem(generalTab)
 
-        let shortcutsTab = NSTabViewItem(identifier: "shortcuts")
-        shortcutsTab.label = L("Shortcuts")
-        shortcutsTab.view = makeShortcutsTabView()
-        tabView.addTabViewItem(shortcutsTab)
+        let captureTab = NSTabViewItem(identifier: "capture")
+        captureTab.label = L("Capture")
+        captureTab.view = makeCaptureTabView()
+        tabView.addTabViewItem(captureTab)
 
-        let toolsTab = NSTabViewItem(identifier: "tools")
-        toolsTab.label = L("Tools")
-        toolsTab.view = makeToolsTabView()
-        tabView.addTabViewItem(toolsTab)
+        let editorTab = NSTabViewItem(identifier: "editor")
+        editorTab.label = L("Editor")
+        editorTab.view = makeEditorTabView()
+        tabView.addTabViewItem(editorTab)
+
+        let outputTab = NSTabViewItem(identifier: "output")
+        outputTab.label = L("Output")
+        outputTab.view = makeOutputTabView()
+        tabView.addTabViewItem(outputTab)
 
         let recordingTab = NSTabViewItem(identifier: "recording")
         recordingTab.label = L("Recording")
         recordingTab.view = makeRecordingTabView()
         tabView.addTabViewItem(recordingTab)
 
-        let uploadsTab = NSTabViewItem(identifier: "uploads")
-        uploadsTab.label = L("Uploads")
-        uploadsTab.view = makeUploadsTabView()
-        tabView.addTabViewItem(uploadsTab)
+        let shortcutsTab = NSTabViewItem(identifier: "shortcuts")
+        shortcutsTab.label = L("Shortcuts")
+        shortcutsTab.view = makeShortcutsTabView()
+        tabView.addTabViewItem(shortcutsTab)
 
         let aboutTab = NSTabViewItem(identifier: "about")
         aboutTab.label = L("About")
@@ -249,7 +254,74 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         stack.addArrangedSubview(indented(langNote))
         stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
 
-        // ── Capture ──────────────────────────────────────────
+        // ── Application ──────────────────────────────────────
+        stack.addArrangedSubview(sectionHeader(L("Application")))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        copySoundCheckbox = NSButton(checkboxWithTitle: L("Play sound on capture"), target: self, action: #selector(copySoundChanged(_:)))
+        rememberToolCheckbox = NSButton(checkboxWithTitle: L("Remember last selected tool"), target: self, action: #selector(rememberToolChanged(_:)))
+        launchAtLoginCheckbox = NSButton(checkboxWithTitle: L("Launch at login"), target: self, action: #selector(launchAtLoginChanged(_:)))
+
+        for cb in [copySoundCheckbox!, rememberToolCheckbox!, launchAtLoginCheckbox!] {
+            stack.addArrangedSubview(indented(cb))
+            stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
+        }
+
+        hideMenuBarIconCheckbox = NSButton(checkboxWithTitle: L("Hide menu bar icon"), target: self, action: #selector(hideMenuBarIconChanged(_:)))
+        stack.addArrangedSubview(indented(hideMenuBarIconCheckbox))
+        stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
+
+        let hideNote = NSTextField(wrappingLabelWithString: L("Hotkeys still work. To show the icon again, re-launch macshot."))
+        hideNote.font = NSFont.systemFont(ofSize: 10)
+        hideNote.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(indented(hideNote))
+        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
+
+        autoUpdateCheckbox = NSButton(checkboxWithTitle: L("Check for updates automatically"), target: self, action: #selector(autoUpdateChanged(_:)))
+        stack.addArrangedSubview(indented(autoUpdateCheckbox))
+        stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
+
+        betaUpdateCheckbox = NSButton(checkboxWithTitle: L("Check for beta updates"), target: self, action: #selector(betaUpdateChanged(_:)))
+        stack.addArrangedSubview(indented(betaUpdateCheckbox))
+        stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.fittingSizeCompression, for: .vertical)
+        stack.addArrangedSubview(spacer)
+
+        // Make stack fill scroll width
+        let clipView = scroll.contentView
+        scroll.documentView = stack
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: clipView.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: clipView.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: clipView.trailingAnchor),
+            stack.heightAnchor.constraint(greaterThanOrEqualTo: clipView.heightAnchor),
+        ])
+
+        return scroll
+    }
+
+    // MARK: - Capture Tab
+
+    private func makeCaptureTabView() -> NSView {
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = true
+        scroll.autohidesScrollers = true
+        scroll.borderType = .noBorder
+        scroll.drawsBackground = false
+        scroll.autoresizingMask = [.width, .height]
+
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 0
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.edgeInsets = NSEdgeInsets(top: 0, left: 20, bottom: 16, right: 20)
+
+        // ── Capture Actions ──────────────────────────────────
         stack.addArrangedSubview(sectionHeader(L("Capture")))
         stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
 
@@ -280,19 +352,20 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         stack.setCustomSpacing(12, after: stack.arrangedSubviews.last!)
 
         // Checkboxes
-        copySoundCheckbox = NSButton(checkboxWithTitle: L("Play sound on capture"), target: self, action: #selector(copySoundChanged(_:)))
         rememberSelectionCheckbox = NSButton(checkboxWithTitle: L("Remember last selection area"), target: self, action: #selector(rememberSelectionChanged(_:)))
-        rememberToolCheckbox = NSButton(checkboxWithTitle: L("Remember last selected tool"), target: self, action: #selector(rememberToolChanged(_:)))
         thumbnailCheckbox = NSButton(checkboxWithTitle: L("Show floating thumbnail after capture"), target: self, action: #selector(thumbnailChanged(_:)))
-        launchAtLoginCheckbox = NSButton(checkboxWithTitle: L("Launch at login"), target: self, action: #selector(launchAtLoginChanged(_:)))
         snapGuidesCheckbox = NSButton(checkboxWithTitle: L("Show snap alignment guides"), target: self, action: #selector(snapGuidesChanged(_:)))
         captureCursorCheckbox = NSButton(checkboxWithTitle: L("Capture mouse cursor in screenshot"), target: self, action: #selector(captureCursorChanged(_:)))
         windowTitleCheckbox = NSButton(checkboxWithTitle: L("Use window title in saved filename"), target: self, action: #selector(windowTitleChanged(_:)))
 
-        for cb in [copySoundCheckbox!, rememberSelectionCheckbox!, rememberToolCheckbox!, thumbnailCheckbox!] {
+        for cb in [rememberSelectionCheckbox!, thumbnailCheckbox!, snapGuidesCheckbox!, captureCursorCheckbox!, windowTitleCheckbox!] {
             stack.addArrangedSubview(indented(cb))
             stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
         }
+
+        // ── Thumbnails ───────────────────────────────────────
+        stack.addArrangedSubview(sectionHeader(L("Floating Thumbnail")))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
 
         // Thumbnail auto-dismiss stepper
         thumbnailAutoDismissField = NSTextField()
@@ -312,7 +385,7 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         dismissNote.font = NSFont.systemFont(ofSize: 11)
         dismissNote.textColor = .secondaryLabelColor
 
-        stack.addArrangedSubview(indented(labeledRow(L("  Dismiss after:"), controls: [thumbnailAutoDismissField!, thumbnailAutoDismissStepper!, dismissNote])))
+        stack.addArrangedSubview(labeledRow(L("Dismiss after:"), controls: [thumbnailAutoDismissField!, thumbnailAutoDismissStepper!, dismissNote]))
         stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
 
         // Thumbnail stacking popup
@@ -321,7 +394,7 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         thumbnailStackingPopup.target = self
         thumbnailStackingPopup.action = #selector(thumbnailStackingChanged(_:))
 
-        stack.addArrangedSubview(indented(labeledRow(L("  Multiple previews:"), controls: [thumbnailStackingPopup!])))
+        stack.addArrangedSubview(labeledRow(L("Multiple previews:"), controls: [thumbnailStackingPopup!]))
         stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
 
         let sizeSlider = NSSlider(value: UserDefaults.standard.object(forKey: "thumbnailScale") as? Double ?? 1.0,
@@ -331,137 +404,49 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         thumbnailScaleLabel = NSTextField(labelWithString: scalePercentString(sizeSlider.doubleValue))
         thumbnailScaleLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
         thumbnailScaleLabel.textColor = .secondaryLabelColor
-        stack.addArrangedSubview(indented(labeledRow(L("  Preview size:"), controls: [sizeSlider, thumbnailScaleLabel])))
-        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
-
-        stack.addArrangedSubview(indented(snapGuidesCheckbox))
-        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
-
-        stack.addArrangedSubview(indented(captureCursorCheckbox))
-        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
-
-        stack.addArrangedSubview(indented(windowTitleCheckbox))
-        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
-
-        stack.addArrangedSubview(indented(launchAtLoginCheckbox))
-        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
-
-        hideMenuBarIconCheckbox = NSButton(checkboxWithTitle: L("Hide menu bar icon"), target: self, action: #selector(hideMenuBarIconChanged(_:)))
-        stack.addArrangedSubview(indented(hideMenuBarIconCheckbox))
-        stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
-
-        let hideNote = NSTextField(wrappingLabelWithString: L("Hotkeys still work. To show the icon again, re-launch macshot."))
-        hideNote.font = NSFont.systemFont(ofSize: 10)
-        hideNote.textColor = .secondaryLabelColor
-        stack.addArrangedSubview(indented(hideNote))
-        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
-
-        autoUpdateCheckbox = NSButton(checkboxWithTitle: L("Check for updates automatically"), target: self, action: #selector(autoUpdateChanged(_:)))
-        stack.addArrangedSubview(indented(autoUpdateCheckbox))
-        stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
-
-        betaUpdateCheckbox = NSButton(checkboxWithTitle: L("Check for beta updates"), target: self, action: #selector(betaUpdateChanged(_:)))
-        stack.addArrangedSubview(indented(betaUpdateCheckbox))
-        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
-
+        stack.addArrangedSubview(labeledRow(L("Preview size:"), controls: [sizeSlider, thumbnailScaleLabel]))
         stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
 
-        // ── Output ───────────────────────────────────────────
-        stack.addArrangedSubview(sectionHeader(L("Output")))
+        // ── Scroll Capture ───────────────────────────────────
+        stack.addArrangedSubview(sectionHeader(L("Scroll Capture")))
         stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
 
-        // Save folder
-        savePathField = NSTextField()
-        savePathField.isEditable = false
-        savePathField.isSelectable = false
-        savePathField.lineBreakMode = .byTruncatingMiddle
-
-        let browseBtn = NSButton(title: L("Browse…"), target: self, action: #selector(browseSavePath(_:)))
-        browseBtn.bezelStyle = .rounded
-
-        stack.addArrangedSubview(labeledRow(L("Save folder:"), controls: [savePathField, browseBtn]))
+        scrollAutoScrollCheckbox = NSButton(checkboxWithTitle: L("Auto-scroll (sends synthetic scroll events)"),
+                                            target: self, action: #selector(scrollAutoScrollChanged(_:)))
+        stack.addArrangedSubview(indented(scrollAutoScrollCheckbox))
         stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
 
-        // Image format
-        imageFormatPopup = NSPopUpButton()
-        imageFormatPopup.addItems(withTitles: ["PNG", "JPEG", "HEIC", "WebP"])
-        imageFormatPopup.target = self
-        imageFormatPopup.action = #selector(imageFormatChanged(_:))
-
-        stack.addArrangedSubview(labeledRow(L("Image format:"), controls: [imageFormatPopup]))
+        scrollSpeedPopup = NSPopUpButton()
+        scrollSpeedPopup.addItems(withTitles: [L("Slow"), L("Medium"), L("Fast"), L("Very fast")])
+        scrollSpeedPopup.target = self
+        scrollSpeedPopup.action = #selector(scrollSpeedChanged(_:))
+        stack.addArrangedSubview(labeledRow(L("Scroll speed:"), controls: [scrollSpeedPopup]))
         stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
 
-        // Quality (applies to JPEG and HEIC)
-        qualitySlider = NSSlider()
-        qualitySlider.minValue = 10
-        qualitySlider.maxValue = 100
-        qualitySlider.target = self
-        qualitySlider.action = #selector(qualityChanged(_:))
-        qualitySlider.widthAnchor.constraint(equalToConstant: 160).isActive = true
+        scrollMaxHeightField = NSTextField()
+        scrollMaxHeightField.isEditable = false
+        scrollMaxHeightField.isSelectable = false
+        scrollMaxHeightField.font = .monospacedDigitSystemFont(ofSize: 13, weight: .regular)
+        scrollMaxHeightField.translatesAutoresizingMaskIntoConstraints = false
+        scrollMaxHeightField.widthAnchor.constraint(equalToConstant: 60).isActive = true
 
-        qualityLabel = NSTextField(labelWithString: String(format: L("%d%%"), 85))
-        qualityLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .regular)
-        qualityLabel.widthAnchor.constraint(equalToConstant: 44).isActive = true
+        scrollMaxHeightStepper = NSStepper()
+        scrollMaxHeightStepper.minValue = 0
+        scrollMaxHeightStepper.maxValue = 100000
+        scrollMaxHeightStepper.increment = 5000
+        scrollMaxHeightStepper.valueWraps = false
+        scrollMaxHeightStepper.target = self
+        scrollMaxHeightStepper.action = #selector(scrollMaxHeightChanged(_:))
 
-        qualityRowLabel = NSTextField(labelWithString: L("Quality:"))
-        qualityRowLabel.font = NSFont.systemFont(ofSize: 13)
-        qualityRowLabel.alignment = .right
-        qualityRowLabel.translatesAutoresizingMaskIntoConstraints = false
-        qualityRowLabel.widthAnchor.constraint(equalToConstant: 140).isActive = true
-
-        let qualityRow = NSStackView(views: [qualityRowLabel, qualitySlider, qualityLabel])
-        qualityRow.orientation = .horizontal
-        qualityRow.spacing = 8
-        qualityRow.alignment = .centerY
-        qualityRow.translatesAutoresizingMaskIntoConstraints = false
-
-        stack.addArrangedSubview(qualityRow)
+        let maxHeightNote = NSTextField(labelWithString: L("px (0 = unlimited)"))
+        maxHeightNote.font = .systemFont(ofSize: 11)
+        maxHeightNote.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(labeledRow(L("Max height:"), controls: [scrollMaxHeightField, scrollMaxHeightStepper, maxHeightNote]))
         stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
 
-        // Downscale Retina
-        downscaleRetinaCheckbox = NSButton(checkboxWithTitle: L("Save at standard resolution (1x)"), target: self, action: #selector(downscaleRetinaChanged(_:)))
-        stack.addArrangedSubview(indented(downscaleRetinaCheckbox))
-        stack.setCustomSpacing(2, after: stack.arrangedSubviews.last!)
-
-        let downscaleNote = NSTextField(labelWithString: L("Halves dimensions on Retina displays, ~4x smaller files"))
-        downscaleNote.font = NSFont.systemFont(ofSize: 10)
-        downscaleNote.textColor = .tertiaryLabelColor
-        stack.addArrangedSubview(indented(downscaleNote))
-        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
-
-        // Embed color profile
-        embedColorProfileCheckbox = NSButton(checkboxWithTitle: L("Embed sRGB color profile"), target: self, action: #selector(embedColorProfileChanged(_:)))
-        stack.addArrangedSubview(indented(embedColorProfileCheckbox))
-        stack.setCustomSpacing(2, after: stack.arrangedSubviews.last!)
-
-        let profileNote = NSTextField(labelWithString: L("Ensures consistent colors across different displays"))
-        profileNote.font = NSFont.systemFont(ofSize: 10)
-        profileNote.textColor = .tertiaryLabelColor
-        stack.addArrangedSubview(indented(profileNote))
-        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
-
-        // History size
-        historySizeField = NSTextField()
-        historySizeField.isEditable = false
-        historySizeField.isSelectable = false
-        historySizeField.alignment = .center
-        historySizeField.widthAnchor.constraint(equalToConstant: 40).isActive = true
-
-        historySizeStepper = NSStepper()
-        historySizeStepper.minValue = 0
-        historySizeStepper.maxValue = 50
-        historySizeStepper.increment = 1
-        historySizeStepper.target = self
-        historySizeStepper.action = #selector(historySizeChanged(_:))
-
-        historyUnlimitedCheckbox = NSButton(checkboxWithTitle: L("Unlimited"), target: self, action: #selector(historyUnlimitedChanged(_:)))
-        historyUnlimitedCheckbox.font = NSFont.systemFont(ofSize: 11)
-
-        let histNote = NSTextField(labelWithString: L("(0 = off)"))
-        histNote.font = NSFont.systemFont(ofSize: 11)
-        histNote.textColor = .secondaryLabelColor
-
-        stack.addArrangedSubview(labeledRow(L("History size:"), controls: [historySizeField, historySizeStepper, histNote, historyUnlimitedCheckbox]))
+        scrollFrozenDetectionCheckbox = NSButton(checkboxWithTitle: L("Detect fixed/sticky headers"),
+                                                 target: self, action: #selector(scrollFrozenDetectionChanged(_:)))
+        stack.addArrangedSubview(indented(scrollFrozenDetectionCheckbox))
         stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
 
         // ── Translation ──────────────────────────────────────
@@ -495,32 +480,11 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
             stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
         }
 
-        // ── Appearance ───────────────────────────────────────
-        stack.addArrangedSubview(sectionHeader(L("Appearance")))
-        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.fittingSizeCompression, for: .vertical)
+        stack.addArrangedSubview(spacer)
 
-        accentColorWell = NSColorWell(frame: NSRect(x: 0, y: 0, width: 36, height: 24))
-        accentColorWell.color = ToolbarLayout.accentColor
-        accentColorWell.target = self
-        accentColorWell.action = #selector(accentColorChanged(_:))
-
-        iconColorWell = NSColorWell(frame: NSRect(x: 0, y: 0, width: 36, height: 24))
-        iconColorWell.color = ToolbarLayout.iconColor
-        iconColorWell.target = self
-        iconColorWell.action = #selector(iconColorChanged(_:))
-
-        let resetColorsBtn = NSButton(title: L("Reset"), target: self, action: #selector(resetToolbarColors(_:)))
-        resetColorsBtn.bezelStyle = .rounded
-        resetColorsBtn.controlSize = .small
-
-        stack.addArrangedSubview(indented(labeledRow(L("Accent color:"), controls: [accentColorWell])))
-        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
-        stack.addArrangedSubview(indented(labeledRow(L("Icon color:"), controls: [iconColorWell])))
-        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
-        stack.addArrangedSubview(indented(labeledRow("", controls: [resetColorsBtn])))
-        stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
-
-        // Make stack fill scroll width
         let clipView = scroll.contentView
         scroll.documentView = stack
 
@@ -528,7 +492,7 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
             stack.topAnchor.constraint(equalTo: clipView.topAnchor),
             stack.leadingAnchor.constraint(equalTo: clipView.leadingAnchor),
             stack.trailingAnchor.constraint(equalTo: clipView.trailingAnchor),
-            // no bottom constraint — stack grows to fit content, scroll handles overflow
+            stack.heightAnchor.constraint(greaterThanOrEqualTo: clipView.heightAnchor),
         ])
 
         return scroll
@@ -798,7 +762,7 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
 
     // MARK: - Tools Tab
 
-    private func makeToolsTabView() -> NSView {
+    private func makeEditorTabView() -> NSView {
         let scroll = NSScrollView()
         scroll.hasVerticalScroller = true
         scroll.autohidesScrollers = true
@@ -879,6 +843,31 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         let rightActionsGrid = makeToggleGrid(items: rightActionItems,
                                               defaultsKey: "enabledActions", enabledValues: enabledActions)
         stack.addArrangedSubview(rightActionsGrid)
+        stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
+
+        // ── Appearance ───────────────────────────────────────
+        stack.addArrangedSubview(sectionHeader(L("Appearance")))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        accentColorWell = NSColorWell(frame: NSRect(x: 0, y: 0, width: 36, height: 24))
+        accentColorWell.color = ToolbarLayout.accentColor
+        accentColorWell.target = self
+        accentColorWell.action = #selector(accentColorChanged(_:))
+
+        iconColorWell = NSColorWell(frame: NSRect(x: 0, y: 0, width: 36, height: 24))
+        iconColorWell.color = ToolbarLayout.iconColor
+        iconColorWell.target = self
+        iconColorWell.action = #selector(iconColorChanged(_:))
+
+        let resetColorsBtn = NSButton(title: L("Reset"), target: self, action: #selector(resetToolbarColors(_:)))
+        resetColorsBtn.bezelStyle = .rounded
+        resetColorsBtn.controlSize = .small
+
+        stack.addArrangedSubview(indented(labeledRow(L("Accent color:"), controls: [accentColorWell])))
+        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
+        stack.addArrangedSubview(indented(labeledRow(L("Icon color:"), controls: [iconColorWell])))
+        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
+        stack.addArrangedSubview(indented(labeledRow("", controls: [resetColorsBtn])))
 
         let clipView = scroll.contentView
         scroll.documentView = stack
@@ -979,48 +968,6 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         stack.addArrangedSubview(labeledRow(L("Shape:"), controls: [webcamShapePopup]))
         stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
 
-        // ── Scroll Capture ────────────────────────────────────
-        stack.addArrangedSubview(sectionHeader(L("Scroll Capture")))
-        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
-
-        scrollAutoScrollCheckbox = NSButton(checkboxWithTitle: L("Auto-scroll (sends synthetic scroll events)"),
-                                            target: self, action: #selector(scrollAutoScrollChanged(_:)))
-        stack.addArrangedSubview(scrollAutoScrollCheckbox)
-        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
-
-        scrollSpeedPopup = NSPopUpButton()
-        scrollSpeedPopup.addItems(withTitles: [L("Slow"), L("Medium"), L("Fast"), L("Very fast")])
-        scrollSpeedPopup.target = self
-        scrollSpeedPopup.action = #selector(scrollSpeedChanged(_:))
-        stack.addArrangedSubview(labeledRow(L("Scroll speed:"), controls: [scrollSpeedPopup]))
-        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
-
-        scrollMaxHeightField = NSTextField()
-        scrollMaxHeightField.isEditable = false
-        scrollMaxHeightField.isSelectable = false
-        scrollMaxHeightField.font = .monospacedDigitSystemFont(ofSize: 13, weight: .regular)
-        scrollMaxHeightField.translatesAutoresizingMaskIntoConstraints = false
-        scrollMaxHeightField.widthAnchor.constraint(equalToConstant: 60).isActive = true
-
-        scrollMaxHeightStepper = NSStepper()
-        scrollMaxHeightStepper.minValue = 0
-        scrollMaxHeightStepper.maxValue = 100000
-        scrollMaxHeightStepper.increment = 5000
-        scrollMaxHeightStepper.valueWraps = false
-        scrollMaxHeightStepper.target = self
-        scrollMaxHeightStepper.action = #selector(scrollMaxHeightChanged(_:))
-
-        let maxHeightNote = NSTextField(labelWithString: L("px (0 = unlimited)"))
-        maxHeightNote.font = .systemFont(ofSize: 11)
-        maxHeightNote.textColor = .secondaryLabelColor
-        stack.addArrangedSubview(labeledRow(L("Max height:"), controls: [scrollMaxHeightField, scrollMaxHeightStepper, maxHeightNote]))
-        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
-
-        scrollFrozenDetectionCheckbox = NSButton(checkboxWithTitle: L("Detect fixed/sticky headers"),
-                                                 target: self, action: #selector(scrollFrozenDetectionChanged(_:)))
-        stack.addArrangedSubview(scrollFrozenDetectionCheckbox)
-        stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
-
         // Spacer to absorb remaining height, keeping content pinned to top
         let spacer = NSView()
         spacer.translatesAutoresizingMaskIntoConstraints = false
@@ -1040,9 +987,9 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         return scroll
     }
 
-    // MARK: - Uploads Tab
+    // MARK: - Output Tab
 
-    private func makeUploadsTabView() -> NSView {
+    private func makeOutputTabView() -> NSView {
         let scroll = NSScrollView()
         scroll.hasVerticalScroller = true
         scroll.autohidesScrollers = true
@@ -1053,11 +1000,112 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         let stack = NSStackView()
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 6
+        stack.spacing = 0
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.edgeInsets = NSEdgeInsets(top: 0, left: 20, bottom: 16, right: 20)
 
-        // ── Upload Provider ──
+        // ── Image Output ─────────────────────────────────────
+        stack.addArrangedSubview(sectionHeader(L("Image")))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        // Image format
+        imageFormatPopup = NSPopUpButton()
+        imageFormatPopup.addItems(withTitles: ["PNG", "JPEG", "HEIC", "WebP"])
+        imageFormatPopup.target = self
+        imageFormatPopup.action = #selector(imageFormatChanged(_:))
+
+        stack.addArrangedSubview(labeledRow(L("Image format:"), controls: [imageFormatPopup]))
+        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
+
+        // Quality (applies to JPEG and HEIC)
+        qualitySlider = NSSlider()
+        qualitySlider.minValue = 10
+        qualitySlider.maxValue = 100
+        qualitySlider.target = self
+        qualitySlider.action = #selector(qualityChanged(_:))
+        qualitySlider.widthAnchor.constraint(equalToConstant: 160).isActive = true
+
+        qualityLabel = NSTextField(labelWithString: String(format: L("%d%%"), 85))
+        qualityLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .regular)
+        qualityLabel.widthAnchor.constraint(equalToConstant: 44).isActive = true
+
+        qualityRowLabel = NSTextField(labelWithString: L("Quality:"))
+        qualityRowLabel.font = NSFont.systemFont(ofSize: 13)
+        qualityRowLabel.alignment = .right
+        qualityRowLabel.translatesAutoresizingMaskIntoConstraints = false
+        qualityRowLabel.widthAnchor.constraint(equalToConstant: 140).isActive = true
+
+        let qualityRow = NSStackView(views: [qualityRowLabel, qualitySlider, qualityLabel])
+        qualityRow.orientation = .horizontal
+        qualityRow.spacing = 8
+        qualityRow.alignment = .centerY
+        qualityRow.translatesAutoresizingMaskIntoConstraints = false
+
+        stack.addArrangedSubview(qualityRow)
+        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
+
+        // Downscale Retina
+        downscaleRetinaCheckbox = NSButton(checkboxWithTitle: L("Save at standard resolution (1x)"), target: self, action: #selector(downscaleRetinaChanged(_:)))
+        stack.addArrangedSubview(indented(downscaleRetinaCheckbox))
+        stack.setCustomSpacing(2, after: stack.arrangedSubviews.last!)
+
+        let downscaleNote = NSTextField(labelWithString: L("Halves dimensions on Retina displays, ~4x smaller files"))
+        downscaleNote.font = NSFont.systemFont(ofSize: 10)
+        downscaleNote.textColor = .tertiaryLabelColor
+        stack.addArrangedSubview(indented(downscaleNote))
+        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
+
+        // Embed color profile
+        embedColorProfileCheckbox = NSButton(checkboxWithTitle: L("Embed sRGB color profile"), target: self, action: #selector(embedColorProfileChanged(_:)))
+        stack.addArrangedSubview(indented(embedColorProfileCheckbox))
+        stack.setCustomSpacing(2, after: stack.arrangedSubviews.last!)
+
+        let profileNote = NSTextField(labelWithString: L("Ensures consistent colors across different displays"))
+        profileNote.font = NSFont.systemFont(ofSize: 10)
+        profileNote.textColor = .tertiaryLabelColor
+        stack.addArrangedSubview(indented(profileNote))
+        stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
+
+        // ── Save Location ────────────────────────────────────
+        stack.addArrangedSubview(sectionHeader(L("Save Location")))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        savePathField = NSTextField()
+        savePathField.isEditable = false
+        savePathField.isSelectable = false
+        savePathField.lineBreakMode = .byTruncatingMiddle
+
+        let browseBtn = NSButton(title: L("Browse…"), target: self, action: #selector(browseSavePath(_:)))
+        browseBtn.bezelStyle = .rounded
+
+        stack.addArrangedSubview(labeledRow(L("Save folder:"), controls: [savePathField, browseBtn]))
+        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
+
+        // History size
+        historySizeField = NSTextField()
+        historySizeField.isEditable = false
+        historySizeField.isSelectable = false
+        historySizeField.alignment = .center
+        historySizeField.widthAnchor.constraint(equalToConstant: 40).isActive = true
+
+        historySizeStepper = NSStepper()
+        historySizeStepper.minValue = 0
+        historySizeStepper.maxValue = 50
+        historySizeStepper.increment = 1
+        historySizeStepper.target = self
+        historySizeStepper.action = #selector(historySizeChanged(_:))
+
+        historyUnlimitedCheckbox = NSButton(checkboxWithTitle: L("Unlimited"), target: self, action: #selector(historyUnlimitedChanged(_:)))
+        historyUnlimitedCheckbox.font = NSFont.systemFont(ofSize: 11)
+
+        let histNote = NSTextField(labelWithString: L("(0 = off)"))
+        histNote.font = NSFont.systemFont(ofSize: 11)
+        histNote.textColor = .secondaryLabelColor
+
+        stack.addArrangedSubview(labeledRow(L("History size:"), controls: [historySizeField, historySizeStepper, histNote, historyUnlimitedCheckbox]))
+        stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
+
+        // ── Upload Provider ──────────────────────────────────
         stack.addArrangedSubview(sectionHeader(L("Upload Provider")))
         stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
 
@@ -1210,14 +1258,12 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
         stack.addArrangedSubview(sectionHeader(L("Upload History")))
         stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
 
-        // Placeholder for upload history rows
         let historyContainer = NSStackView()
         historyContainer.orientation = .vertical
         historyContainer.alignment = .width
         historyContainer.spacing = 6
         historyContainer.translatesAutoresizingMaskIntoConstraints = false
         stack.addArrangedSubview(historyContainer)
-        // Stretch to full stack width
         historyContainer.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -40).isActive = true
         self.uploadsStack = historyContainer
 
@@ -2005,7 +2051,7 @@ class SettingsWindowController: NSWindowController, NSTabViewDelegate, NSWindowD
     // MARK: - NSTabViewDelegate
 
     func tabView(_ tabView: NSTabView, didSelect tabViewItem: NSTabViewItem?) {
-        if tabViewItem?.identifier as? String == "uploads" {
+        if tabViewItem?.identifier as? String == "output" {
             reloadUploadsTab()
         }
     }

--- a/macshot/ar.lproj/Localizable.strings
+++ b/macshot/ar.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "يتم تحميل الملفات إلى مجلد \"macshot\" في Google Drive الخاص بك. كل شيء يبقى خاصًا — لا يُشارك أي شيء بشكل عام.";
 
 "Pressure" = "الضغط";
+"Editor" = "المحرر";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "التطبيق";
+"Image" = "الصورة";
+"Save Location" = "موقع الحفظ";

--- a/macshot/bg.lproj/Localizable.strings
+++ b/macshot/bg.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Файловете се качват в папка \"macshot\" във вашия Google Drive. Всичко остава поверително — нищо не се споделя публично.";
 
 "Pressure" = "Натиск";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/bn.lproj/Localizable.strings
+++ b/macshot/bn.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "ফাইলগুলি আপনার Google Drive-এর \"macshot\" ফোল্ডারে আপলোড করা হয়। সব কিছু ব্যক্তিগত থাকে — কিছুই প্রকাশ্যে শেয়ার করা হয় না।";
 
 "Pressure" = "চাপ";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/ca.lproj/Localizable.strings
+++ b/macshot/ca.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Els fitxers es pugen a una carpeta \"macshot\" del vostre Google Drive. Tot és privat — res no es comparteix públicament.";
 
 "Pressure" = "Pressió";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/cs.lproj/Localizable.strings
+++ b/macshot/cs.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Soubory jsou nahrávány do složky \"macshot\" na vašem Disku Google. Vše zůstává soukromé — nic není veřejně sdíleno.";
 
 "Pressure" = "Přítlak";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/da.lproj/Localizable.strings
+++ b/macshot/da.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Filer uploades til en \"macshot\"-mappe på dit Google Drev. Alt forbliver privat — intet deles offentligt.";
 
 "Pressure" = "Tryk";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/de.lproj/Localizable.strings
+++ b/macshot/de.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Dateien werden in einen \"macshot\"-Ordner in deinem Google Drive hochgeladen. Alles bleibt privat — nichts wird öffentlich geteilt.";
 
 "Pressure" = "Druck";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Anwendung";
+"Image" = "Bild";
+"Save Location" = "Speicherort";

--- a/macshot/el.lproj/Localizable.strings
+++ b/macshot/el.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Τα αρχεία ανεβαίνουν σε έναν φάκελο \"macshot\" στο Google Drive σου. Όλα παραμένουν ιδιωτικά — τίποτα δεν κοινοποιείται δημόσια.";
 
 "Pressure" = "Πίεση";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -492,3 +492,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly.";
 
 "Pressure" = "Pressure";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/es.lproj/Localizable.strings
+++ b/macshot/es.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Los archivos se suben a una carpeta \"macshot\" en tu Google Drive. Todo permanece privado — nada se comparte públicamente.";
 
 "Pressure" = "Presión";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/fa.lproj/Localizable.strings
+++ b/macshot/fa.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "فایل‌ها در پوشه‌ای به نام \"macshot\" در Google Drive شما بارگذاری می‌شوند. همه چیز خصوصی می‌ماند — هیچ چیز به‌صورت عمومی به اشتراک گذاشته نمی‌شود.";
 
 "Pressure" = "فشار";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/fi.lproj/Localizable.strings
+++ b/macshot/fi.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Tiedostot ladataan \"macshot\"-kansioon Google Drivessasi. Kaikki pysyy yksityisenä — mitään ei jaeta julkisesti.";
 
 "Pressure" = "Paine";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/fil.lproj/Localizable.strings
+++ b/macshot/fil.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Ina-upload ang mga file sa isang \"macshot\" na folder sa iyong Google Drive. Nananatiling pribado ang lahat — walang ibinabahagi nang publiko.";
 
 "Pressure" = "Pressure";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/fr.lproj/Localizable.strings
+++ b/macshot/fr.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Les fichiers sont téléversés dans un dossier \"macshot\" de votre Google Drive. Tout reste privé — rien n'est partagé publiquement.";
 
 "Pressure" = "Pression";
+"Editor" = "Éditeur";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Emplacement d'enregistrement";

--- a/macshot/he.lproj/Localizable.strings
+++ b/macshot/he.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "הקבצים מועלים לתיקייה \"macshot\" ב-Google Drive שלך. הכל נשאר פרטי — שום דבר אינו משותף באופן ציבורי.";
 
 "Pressure" = "לחץ";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/hi.lproj/Localizable.strings
+++ b/macshot/hi.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "फ़ाइलें आपके Google Drive में एक \"macshot\" फ़ोल्डर में अपलोड की जाती हैं। सब कुछ निजी रहता है — कुछ भी सार्वजनिक रूप से साझा नहीं किया जाता।";
 
 "Pressure" = "दबाव";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/hr.lproj/Localizable.strings
+++ b/macshot/hr.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Datoteke se učitavaju u mapu \"macshot\" na vašem Google Disku. Sve ostaje privatno — ništa se ne dijeli javno.";
 
 "Pressure" = "Pritisak";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/hu.lproj/Localizable.strings
+++ b/macshot/hu.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "A fájlok a Google Drive-on lévő \"macshot\" mappába töltődnek fel. Minden privát marad — semmi nem kerül nyilvános megosztásra.";
 
 "Pressure" = "Nyomás";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/id.lproj/Localizable.strings
+++ b/macshot/id.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "File diunggah ke folder \"macshot\" di Google Drive Anda. Semuanya tetap privat — tidak ada yang dibagikan secara publik.";
 
 "Pressure" = "Tekanan";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/it.lproj/Localizable.strings
+++ b/macshot/it.lproj/Localizable.strings
@@ -476,3 +476,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "I file vengono caricati in una cartella \"macshot\" nel tuo Google Drive. Tutto rimane privato — nulla viene condiviso pubblicamente.";
 
 "Pressure" = "Pressione";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/ja.lproj/Localizable.strings
+++ b/macshot/ja.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "ファイルはGoogle Driveの \"macshot\" フォルダにアップロードされます。すべてプライベートに保たれ、公開されることはありません。";
 
 "Pressure" = "筆圧";
+"Editor" = "エディタ";
+"Floating Thumbnail" = "フローティングサムネイル";
+"Application" = "アプリケーション";
+"Image" = "画像";
+"Save Location" = "保存場所";

--- a/macshot/ko.lproj/Localizable.strings
+++ b/macshot/ko.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "파일은 Google Drive의 \"macshot\" 폴더에 업로드됩니다. 모든 것은 비공개로 유지되며 공개적으로 공유되지 않습니다.";
 
 "Pressure" = "필압";
+"Editor" = "에디터";
+"Floating Thumbnail" = "플로팅 썸네일";
+"Application" = "애플리케이션";
+"Image" = "이미지";
+"Save Location" = "저장 위치";

--- a/macshot/ms.lproj/Localizable.strings
+++ b/macshot/ms.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Fail dimuat naik ke folder \"macshot\" dalam Google Drive anda. Semua maklumat kekal peribadi — tiada apa yang dikongsi secara awam.";
 
 "Pressure" = "Tekanan";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/nb.lproj/Localizable.strings
+++ b/macshot/nb.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Filer lastes opp til en \"macshot\"-mappe i Google Disk. Alt forblir privat — ingenting deles offentlig.";
 
 "Pressure" = "Trykk";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/nl.lproj/Localizable.strings
+++ b/macshot/nl.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Bestanden worden geüpload naar een \"macshot\"-map in uw Google Drive. Alles blijft privé — er wordt niets openbaar gedeeld.";
 
 "Pressure" = "Druk";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/pl.lproj/Localizable.strings
+++ b/macshot/pl.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Pliki są przesyłane do folderu \"macshot\" na Dysku Google. Pliki pozostają prywatne — nic nie jest udostępniane publicznie.";
 
 "Pressure" = "Nacisk";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/pt-BR.lproj/Localizable.strings
+++ b/macshot/pt-BR.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Os arquivos são enviados para uma pasta \"macshot\" no seu Google Drive. Tudo permanece privado — nada é compartilhado publicamente.";
 
 "Pressure" = "Pressão";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/pt.lproj/Localizable.strings
+++ b/macshot/pt.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Os ficheiros são carregados para uma pasta \"macshot\" no seu Google Drive. Tudo permanece privado — nada é partilhado publicamente.";
 
 "Pressure" = "Pressão";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/ro.lproj/Localizable.strings
+++ b/macshot/ro.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Fișierele sunt încărcate într-un folder \"macshot\" din Google Drive-ul tău. Totul rămâne privat — nimic nu este distribuit public.";
 
 "Pressure" = "Presiune";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/ru.lproj/Localizable.strings
+++ b/macshot/ru.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Файлы загружаются в папку \"macshot\" на вашем Google Drive. Всё остаётся приватным — ничего не публикуется в открытый доступ.";
 
 "Pressure" = "Нажим";
+"Editor" = "Редактор";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Приложение";
+"Image" = "Изображение";
+"Save Location" = "Место сохранения";

--- a/macshot/sk.lproj/Localizable.strings
+++ b/macshot/sk.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Súbory sa nahrajú do priečinka \"macshot\" na vašom Google Drive. Všetko zostáva súkromné — nič nie je verejne zdieľané.";
 
 "Pressure" = "Tlak";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/sr.lproj/Localizable.strings
+++ b/macshot/sr.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Fajlovi se otpremaju u fasciklu \"macshot\" na vašem Google disku. Sve ostaje privatno — ništa se ne deli javno.";
 
 "Pressure" = "Pritisak";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/sv.lproj/Localizable.strings
+++ b/macshot/sv.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Filer laddas upp till en \"macshot\"-mapp i din Google Drive. Allt förblir privat — inget delas offentligt.";
 
 "Pressure" = "Tryck";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/ta.lproj/Localizable.strings
+++ b/macshot/ta.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "கோப்புகள் உங்கள் Google Drive-ல் உள்ள \"macshot\" கோப்புறையில் பதிவேற்றப்படும். அனைத்தும் தனிப்பட்டதாக இருக்கும் — எதுவும் பொதுவில் பகிரப்படாது.";
 
 "Pressure" = "அழுத்தம்";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/th.lproj/Localizable.strings
+++ b/macshot/th.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "ไฟล์จะถูกอัปโหลดไปยังโฟลเดอร์ \"macshot\" ใน Google Drive ของคุณ ทุกอย่างเป็นส่วนตัว — ไม่มีการแชร์สาธารณะ";
 
 "Pressure" = "แรงกด";
+"Editor" = "ตัวแก้ไข";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/tr.lproj/Localizable.strings
+++ b/macshot/tr.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Dosyalar, Google Drive'ınızdaki \"macshot\" klasörüne yüklenir. Her şey gizli kalır — hiçbir şey herkesle paylaşılmaz.";
 
 "Pressure" = "Basınç";
+"Editor" = "Editor";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/uk.lproj/Localizable.strings
+++ b/macshot/uk.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Файли завантажуються до папки \"macshot\" на вашому Google Диску. Все залишається приватним — нічого не публікується у відкритому доступі.";
 
 "Pressure" = "Тиск";
+"Editor" = "Редактор";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Застосунок";
+"Image" = "Изображение";
+"Save Location" = "Місце збереження";

--- a/macshot/vi.lproj/Localizable.strings
+++ b/macshot/vi.lproj/Localizable.strings
@@ -493,3 +493,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Các tệp được tải lên thư mục \"macshot\" trong Google Drive của bạn. Mọi thứ đều được giữ bí mật — không có gì được chia sẻ công khai.";
 
 "Pressure" = "Lực nhấn";
+"Editor" = "Trình chỉnh sửa";
+"Floating Thumbnail" = "Floating Thumbnail";
+"Application" = "Application";
+"Image" = "Image";
+"Save Location" = "Save Location";

--- a/macshot/zh-Hans.lproj/Localizable.strings
+++ b/macshot/zh-Hans.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "文件将上传到您 Google Drive 中的\"macshot\"文件夹。所有内容均保持私密——不会公开共享任何内容。";
 
 "Pressure" = "压感";
+"Editor" = "编辑器";
+"Floating Thumbnail" = "浮动缩略图";
+"Application" = "应用程序";
+"Image" = "图片";
+"Save Location" = "保存位置";

--- a/macshot/zh-Hant.lproj/Localizable.strings
+++ b/macshot/zh-Hant.lproj/Localizable.strings
@@ -495,3 +495,8 @@
 "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "檔案將上傳至您 Google Drive 中的\"macshot\"資料夾。所有內容均保持私密——不會公開分享任何內容。";
 
 "Pressure" = "壓感";
+"Editor" = "編輯器";
+"Floating Thumbnail" = "浮動縮圖";
+"Application" = "應用程式";
+"Image" = "圖片";
+"Save Location" = "儲存位置";


### PR DESCRIPTION
## Summary

- Reorganize Preferences from 6 tabs (General, Shortcuts, Tools, Recording, Uploads, About) into 7 logically grouped tabs (General, Capture, Editor, Output, Recording, Shortcuts, About)
- **General** — Language, application-level settings (sound, remember tool, launch at login, menu bar icon, auto-update)
- **Capture** — Capture actions (quick capture, OCR), selection/cursor options, floating thumbnail, scroll capture, translation engine
- **Editor** — Annotation tool visibility, toolbar action visibility, accent/icon color
- **Output** — Image format/quality/resolution, save location, history, upload providers (imgbb, Google Drive, S3)
- **Recording** — FPS, save folder, behavior, webcam (scroll capture removed to Capture)
- **Shortcuts** / **About** — Unchanged

## Test plan

- [x] Build Debug succeeds with `xcodebuild`
- [x] All 7 tabs display correct content in each section
- [x] Settings persist across Preferences open/close
- [x] Upload history refreshes when Output tab is selected
- [x] Translation section shows conditionally (macOS 15+)
- [x] Tab bar fits within 480pt window width
- [x] Content pinned to top on tabs with fewer settings (General, Capture, Editor)
- [ ] Verify Release build passes (`xcodebuild -scheme macshot -configuration Release build`)