### PR TITLE
Fix silent screenshot save authorization flow

### DIFF
--- a/macshot/Services/SaveDirectoryAccess.swift
+++ b/macshot/Services/SaveDirectoryAccess.swift
@@ -20,24 +20,28 @@ enum SaveDirectoryAccess {
 
     /// Resolve the save directory URL and start sandbox-scoped access.
     /// Caller **must** call `stopAccessing(url:)` when done writing.
-    static func resolve() -> URL {
-        if let bookmarkData = UserDefaults.standard.data(forKey: bookmarkKey) {
-            var isStale = false
-            if let url = try? URL(resolvingBookmarkData: bookmarkData,
-                                   options: .withSecurityScope,
-                                   relativeTo: nil,
-                                   bookmarkDataIsStale: &isStale) {
-                if isStale {
-                    if let fresh = try? url.bookmarkData(options: .withSecurityScope,
-                                                          includingResourceValuesForKeys: nil,
-                                                          relativeTo: nil) {
-                        UserDefaults.standard.set(fresh, forKey: bookmarkKey)
-                    }
-                }
-                _ = url.startAccessingSecurityScopedResource()
-                return url
+    static func resolveIfAccessible() -> URL? {
+        guard let bookmarkData = UserDefaults.standard.data(forKey: bookmarkKey) else { return nil }
+        var isStale = false
+        guard let url = try? URL(resolvingBookmarkData: bookmarkData,
+                                  options: .withSecurityScope,
+                                  relativeTo: nil,
+                                  bookmarkDataIsStale: &isStale) else { return nil }
+        if isStale {
+            if let fresh = try? url.bookmarkData(options: .withSecurityScope,
+                                                  includingResourceValuesForKeys: nil,
+                                                  relativeTo: nil) {
+                UserDefaults.standard.set(fresh, forKey: bookmarkKey)
             }
         }
+        guard url.startAccessingSecurityScopedResource() else { return nil }
+        return url
+    }
+
+    /// Resolve the configured save directory, falling back to a display-only hint.
+    /// Prefer `resolveIfAccessible()` for writes that must work in the sandbox.
+    static func resolve() -> URL {
+        if let url = resolveIfAccessible() { return url }
         if let path = UserDefaults.standard.string(forKey: pathKey) {
             return URL(fileURLWithPath: path)
         }

--- a/macshot/UI/Editor/DetachedEditorWindowController.swift
+++ b/macshot/UI/Editor/DetachedEditorWindowController.swift
@@ -462,16 +462,66 @@ extension DetachedEditorWindowController: OverlayViewDelegate {
     }
 
     private func saveImageToDirectory(_ image: NSImage) {
-        let dirURL = SaveDirectoryAccess.resolve()
+        guard let dirURL = SaveDirectoryAccess.resolveIfAccessible() else {
+            requestSaveDirectoryAccess { dirURL, securityScoped in
+                defer {
+                    if securityScoped {
+                        SaveDirectoryAccess.stopAccessing(url: dirURL)
+                    }
+                }
+                Self.writeImage(image, toDirectory: dirURL)
+            }
+            return
+        }
+        saveImage(image, toDirectory: dirURL, securityScoped: true)
+    }
+
+    private func saveImage(_ image: NSImage, toDirectory dirURL: URL, securityScoped: Bool) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer {
+                if securityScoped {
+                    SaveDirectoryAccess.stopAccessing(url: dirURL)
+                }
+            }
+            Self.writeImage(image, toDirectory: dirURL)
+        }
+    }
+
+    private static func writeImage(_ image: NSImage, toDirectory dirURL: URL) {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd 'at' HH.mm.ss"
         let filename = "Screenshot \(formatter.string(from: Date())).\(ImageEncoder.fileExtension)"
         let fileURL = dirURL.appendingPathComponent(filename)
+        guard let imageData = ImageEncoder.encode(image) else { return }
+        do {
+            try imageData.write(to: fileURL)
+        } catch {
+            #if DEBUG
+            NSLog("macshot: failed to save image to \(fileURL.path): \(error.localizedDescription)")
+            #endif
+        }
+    }
 
-        DispatchQueue.global(qos: .userInitiated).async {
-            guard let imageData = ImageEncoder.encode(image) else { return }
-            try? imageData.write(to: fileURL)
-            SaveDirectoryAccess.stopAccessing(url: dirURL)
+    private func requestSaveDirectoryAccess(completion: @escaping (URL, Bool) -> Void) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = L("Choose a folder")
+        panel.directoryURL = SaveDirectoryAccess.directoryHint()
+        panel.beginSheetModal(for: window!) { response in
+            guard response == .OK, let url = panel.url else { return }
+            SaveDirectoryAccess.save(url: url)
+
+            // Prefer reopening through the freshly saved bookmark so first-save
+            // behavior matches all later saves in sandbox mode.
+            if let scopedURL = SaveDirectoryAccess.resolveIfAccessible() {
+                completion(scopedURL, true)
+                return
+            }
+
+            let securityScoped = url.startAccessingSecurityScopedResource()
+            completion(url, securityScoped)
         }
     }
     func overlayViewDidRequestUpload() {

--- a/macshot/UI/Overlay/OverlayWindowController.swift
+++ b/macshot/UI/Overlay/OverlayWindowController.swift
@@ -793,17 +793,68 @@ extension OverlayWindowController: OverlayViewDelegate {
     }
 
     private func saveImageToDirectory(_ image: NSImage) {
-        let dirURL = SaveDirectoryAccess.resolve()
+        guard let dirURL = SaveDirectoryAccess.resolveIfAccessible() else {
+            let windowTitle = capturedWindowTitle
+            requestSaveDirectoryAccess { dirURL, securityScoped in
+                defer {
+                    if securityScoped {
+                        SaveDirectoryAccess.stopAccessing(url: dirURL)
+                    }
+                }
+                Self.writeImage(image, toDirectory: dirURL, windowTitle: windowTitle)
+            }
+            return
+        }
+        let windowTitle = capturedWindowTitle
+        saveImage(image, toDirectory: dirURL, securityScoped: true, windowTitle: windowTitle)
+    }
 
+    private func saveImage(_ image: NSImage, toDirectory dirURL: URL, securityScoped: Bool, windowTitle: String?) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer {
+                if securityScoped {
+                    SaveDirectoryAccess.stopAccessing(url: dirURL)
+                }
+            }
+            Self.writeImage(image, toDirectory: dirURL, windowTitle: windowTitle)
+        }
+    }
+
+    private static func writeImage(_ image: NSImage, toDirectory dirURL: URL, windowTitle: String?) {
         let template = UserDefaults.standard.string(forKey: FilenameFormatter.userDefaultsKey) ?? FilenameFormatter.defaultTemplate
-        let base = FilenameFormatter.format(template: template, windowTitle: capturedWindowTitle)
+        let base = FilenameFormatter.format(template: template, windowTitle: windowTitle)
         let filename = "\(base).\(ImageEncoder.fileExtension)"
         let fileURL = dirURL.appendingPathComponent(filename)
+        guard let imageData = ImageEncoder.encode(image) else { return }
+        do {
+            try imageData.write(to: fileURL)
+        } catch {
+            #if DEBUG
+            NSLog("macshot: failed to save image to \(fileURL.path): \(error.localizedDescription)")
+            #endif
+        }
+    }
 
-        DispatchQueue.global(qos: .userInitiated).async {
-            guard let imageData = ImageEncoder.encode(image) else { return }
-            try? imageData.write(to: fileURL)
-            SaveDirectoryAccess.stopAccessing(url: dirURL)
+    private func requestSaveDirectoryAccess(completion: @escaping (URL, Bool) -> Void) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = L("Choose a folder")
+        panel.directoryURL = SaveDirectoryAccess.directoryHint()
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            SaveDirectoryAccess.save(url: url)
+
+            // Prefer reopening through the freshly saved bookmark so first-save
+            // behavior matches all later saves in sandbox mode.
+            if let scopedURL = SaveDirectoryAccess.resolveIfAccessible() {
+                completion(scopedURL, true)
+                return
+            }
+
+            let securityScoped = url.startAccessingSecurityScopedResource()
+            completion(url, securityScoped)
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes silent screenshot saving in the sandboxed app when no save directory has been authorized yet.

## What was broken

Clicking the save button attempted to write directly to the configured/default save directory. When the app did not have a valid security-scoped bookmark, the write could fail silently, especially for the default Pictures fallback.

## What changed

- Added an explicit `resolveIfAccessible()` path for save directories with valid security-scoped access.
- When no save directory is authorized, prompt the user once to choose a save folder.
- Save the selected folder as a security-scoped bookmark.
- Save the current screenshot after authorization, then silently save future screenshots to the same folder.
- Replaced silent `try?` writes with `do/catch` logging in debug builds.
- Applied the same behavior to the detached editor save path.

## Testing

- run locally.