### PR TITLE
Add pin from clipboard

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -656,6 +656,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         HotkeyManager.applyMenuShortcut(for: .openFromClipboard, to: pasteImageItem)
         menu.addItem(pasteImageItem)
 
+        let pinClipboardItem = NSMenuItem(title: L("Pin from Clipboard"), action: #selector(pinFromClipboard), keyEquivalent: "")
+        pinClipboardItem.target = self
+        pinClipboardItem.image = NSImage(systemSymbolName: "pin.fill", accessibilityDescription: nil)
+        HotkeyManager.applyMenuShortcut(for: .pinFromClipboard, to: pinClipboardItem)
+        menu.addItem(pinClipboardItem)
+
         menu.addItem(NSMenuItem.separator())
 
         let prefsItem = NSMenuItem(title: L("Settings..."), action: #selector(openSettings), keyEquivalent: ",")
@@ -743,6 +749,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             captureLastArea: { [weak self] in
                 stamp()
                 self?.perform(#selector(AppDelegate.captureLastAreaFromHotkey))
+            },
+            pinFromClipboard: { [weak self] in
+                DispatchQueue.main.async { self?.pinFromClipboard() }
             }
         )
     }
@@ -1771,6 +1780,29 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             return
         }
         DetachedEditorWindowController.open(image: image)
+    }
+
+    @objc private func pinFromClipboard() {
+        guard let item = NSPasteboard.general.pasteboardItems?.first else {
+            showNoPinClipboardContentAlert()
+            return
+        }
+
+        switch ClipboardPinService.image(from: item) {
+        case .image(let image):
+            showPin(image: image)
+        case .unsupported:
+            showNoPinClipboardContentAlert()
+        }
+    }
+
+    private func showNoPinClipboardContentAlert() {
+        let alert = NSAlert()
+        alert.messageText = L("No Image or Text on Clipboard")
+        alert.informativeText = L("Copy an image or text to the clipboard first, then try again.")
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: L("OK"))
+        alert.runModal()
     }
 
     private func openImageWithPanel() {

--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -656,9 +656,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         HotkeyManager.applyMenuShortcut(for: .openFromClipboard, to: pasteImageItem)
         menu.addItem(pasteImageItem)
 
-        let pinClipboardItem = NSMenuItem(title: L("Pin from Clipboard"), action: #selector(pinFromClipboard), keyEquivalent: "")
+        let pinClipboardTitle = L("Pin from Clipboard")
+        let pinClipboardItem = NSMenuItem(title: pinClipboardTitle, action: #selector(pinFromClipboard), keyEquivalent: "")
         pinClipboardItem.target = self
-        pinClipboardItem.image = NSImage(systemSymbolName: "pin.fill", accessibilityDescription: nil)
+        pinClipboardItem.image = NSImage(systemSymbolName: "pin.fill", accessibilityDescription: pinClipboardTitle)
         HotkeyManager.applyMenuShortcut(for: .pinFromClipboard, to: pinClipboardItem)
         menu.addItem(pinClipboardItem)
 

--- a/macshot/Services/ClipboardPinService.swift
+++ b/macshot/Services/ClipboardPinService.swift
@@ -46,8 +46,10 @@ enum ClipboardPinService {
     private static func textImageFromItem(_ item: NSPasteboardItem) -> NSImage? {
         if let data = item.data(forType: .html),
            let attributed = ClipboardTextPinRenderer.attributedString(html: data),
-           let image = ClipboardTextPinRenderer.render(attributed) {
-            return image
+           !ClipboardTextPinRenderer.containsAttachments(attributed) {
+            if let image = ClipboardTextPinRenderer.render(attributed) {
+                return image
+            }
         }
 
         if let data = item.data(forType: .rtf),
@@ -74,7 +76,8 @@ enum ClipboardPinService {
 
     private static func fileURLFromItem(_ item: NSPasteboardItem) -> URL? {
         if let value = item.string(forType: .fileURL),
-           let url = URL(string: value) {
+           let url = URL(string: value),
+           url.isFileURL {
             return url
         }
 
@@ -84,7 +87,8 @@ enum ClipboardPinService {
         ]
         for type in urlTypes {
             if let value = item.string(forType: type),
-               let url = URL(string: value) {
+               let url = URL(string: value),
+               url.isFileURL {
                 return url
             }
         }

--- a/macshot/Services/ClipboardPinService.swift
+++ b/macshot/Services/ClipboardPinService.swift
@@ -1,0 +1,98 @@
+import AppKit
+
+enum ClipboardPinResult {
+    case image(NSImage)
+    case unsupported
+}
+
+enum ClipboardPinService {
+
+    static func image(from item: NSPasteboardItem) -> ClipboardPinResult {
+        if let image = imageFromItem(item) {
+            return .image(image)
+        }
+        if let image = textImageFromItem(item) {
+            return .image(image)
+        }
+        return .unsupported
+    }
+
+    private static func imageFromItem(_ item: NSPasteboardItem) -> NSImage? {
+        let imageTypes: [NSPasteboard.PasteboardType] = [
+            .png,
+            .tiff,
+            NSPasteboard.PasteboardType("public.jpeg"),
+            NSPasteboard.PasteboardType("public.heic"),
+            NSPasteboard.PasteboardType("public.heif"),
+            NSPasteboard.PasteboardType("com.compuserve.gif"),
+        ]
+
+        for type in imageTypes {
+            guard let data = item.data(forType: type),
+                  let image = NSImage(data: data),
+                  isUsable(image) else { continue }
+            return image
+        }
+
+        if let fileURL = fileURLFromItem(item),
+           let image = NSImage(contentsOf: fileURL),
+           isUsable(image) {
+            return image
+        }
+
+        return nil
+    }
+
+    private static func textImageFromItem(_ item: NSPasteboardItem) -> NSImage? {
+        if let data = item.data(forType: .html),
+           let attributed = ClipboardTextPinRenderer.attributedString(html: data),
+           let image = ClipboardTextPinRenderer.render(attributed) {
+            return image
+        }
+
+        if let data = item.data(forType: .rtf),
+           let attributed = ClipboardTextPinRenderer.attributedString(rtf: data),
+           let image = ClipboardTextPinRenderer.render(attributed) {
+            return image
+        }
+
+        let rtfdType = NSPasteboard.PasteboardType("com.apple.flat-rtfd")
+        if let data = item.data(forType: rtfdType),
+           let attributed = ClipboardTextPinRenderer.attributedString(rtfd: data),
+           let image = ClipboardTextPinRenderer.render(attributed) {
+            return image
+        }
+
+        if let string = item.string(forType: .string),
+           !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let attributed = ClipboardTextPinRenderer.plainAttributedString(string)
+            return ClipboardTextPinRenderer.render(attributed, fallbackBackground: .white)
+        }
+
+        return nil
+    }
+
+    private static func fileURLFromItem(_ item: NSPasteboardItem) -> URL? {
+        if let value = item.string(forType: .fileURL),
+           let url = URL(string: value) {
+            return url
+        }
+
+        let urlTypes: [NSPasteboard.PasteboardType] = [
+            NSPasteboard.PasteboardType("public.file-url"),
+            NSPasteboard.PasteboardType("NSURLPboardType"),
+        ]
+        for type in urlTypes {
+            if let value = item.string(forType: type),
+               let url = URL(string: value) {
+                return url
+            }
+        }
+
+        return nil
+    }
+
+    private static func isUsable(_ image: NSImage) -> Bool {
+        image.isValid && image.size.width > 0 && image.size.height > 0
+    }
+}

--- a/macshot/Services/ClipboardTextPinRenderer.swift
+++ b/macshot/Services/ClipboardTextPinRenderer.swift
@@ -1,0 +1,169 @@
+import AppKit
+
+enum ClipboardTextPinRenderer {
+
+    private static let padding = NSEdgeInsets(top: 22, left: 24, bottom: 22, right: 24)
+    private static let plainFont = NSFont.monospacedSystemFont(ofSize: 18, weight: .regular)
+    private static let maxPixelArea: CGFloat = 24_000_000
+
+    static func attributedString(html data: Data) -> NSAttributedString? {
+        attributedString(
+            data: data,
+            options: [
+                .documentType: NSAttributedString.DocumentType.html,
+                .characterEncoding: String.Encoding.utf8.rawValue,
+            ]
+        )
+    }
+
+    static func attributedString(rtf data: Data) -> NSAttributedString? {
+        attributedString(
+            data: data,
+            options: [.documentType: NSAttributedString.DocumentType.rtf]
+        )
+    }
+
+    static func attributedString(rtfd data: Data) -> NSAttributedString? {
+        attributedString(
+            data: data,
+            options: [.documentType: NSAttributedString.DocumentType.rtfd]
+        )
+    }
+
+    private static func attributedString(
+        data: Data,
+        options: [NSAttributedString.DocumentReadingOptionKey: Any]
+    ) -> NSAttributedString? {
+        var documentAttributes: NSDictionary?
+        guard let attributed = try? NSAttributedString(
+            data: data,
+            options: options,
+            documentAttributes: &documentAttributes
+        ) else { return nil }
+
+        let documentAttributesDict = documentAttributes as? [NSAttributedString.DocumentAttributeKey: Any]
+        guard let backgroundColor = documentAttributesDict?[.backgroundColor] as? NSColor,
+              attributed.length > 0 else {
+            return attributed
+        }
+
+        let mutable = NSMutableAttributedString(attributedString: attributed)
+        mutable.addAttribute(.backgroundColor, value: backgroundColor, range: NSRange(location: 0, length: mutable.length))
+        return mutable
+    }
+
+    static func plainAttributedString(_ string: String) -> NSAttributedString {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineBreakMode = .byWordWrapping
+        paragraph.alignment = .left
+
+        return NSAttributedString(
+            string: string,
+            attributes: [
+                .font: plainFont,
+                .foregroundColor: NSColor.black,
+                .paragraphStyle: paragraph,
+            ]
+        )
+    }
+
+    static func render(_ attributed: NSAttributedString, fallbackBackground: NSColor = .white) -> NSImage? {
+        guard attributed.length > 0 else { return nil }
+
+        let screenFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let maxContentWidth = max(320, min(980, screenFrame.width * 0.72))
+        let maxImageHeight = max(240, screenFrame.height * 0.82)
+
+        let normalized = NSMutableAttributedString(attributedString: attributed)
+        normalizeParagraphs(in: normalized)
+
+        let contentSize = measuredSize(for: normalized, maxWidth: maxContentWidth)
+        guard contentSize.width > 0, contentSize.height > 0 else { return nil }
+
+        var imageWidth = ceil(contentSize.width + padding.left + padding.right)
+        var imageHeight = ceil(contentSize.height + padding.top + padding.bottom)
+
+        if imageHeight > maxImageHeight {
+            imageHeight = maxImageHeight
+        }
+
+        if imageWidth * imageHeight > maxPixelArea {
+            let scale = sqrt(maxPixelArea / (imageWidth * imageHeight))
+            imageWidth = max(320, floor(imageWidth * scale))
+            imageHeight = max(180, floor(imageHeight * scale))
+        }
+
+        let imageSize = NSSize(width: imageWidth, height: imageHeight)
+        let drawRect = NSRect(
+            x: padding.left,
+            y: padding.top,
+            width: max(1, imageWidth - padding.left - padding.right),
+            height: max(1, imageHeight - padding.top - padding.bottom)
+        )
+
+        return NSImage(size: imageSize, flipped: true) { rect in
+            let background = dominantBackgroundColor(in: normalized) ?? fallbackBackground
+            background.setFill()
+            NSBezierPath(rect: rect).fill()
+
+            normalized.draw(
+                with: drawRect,
+                options: [.usesLineFragmentOrigin, .usesFontLeading]
+            )
+            return true
+        }
+    }
+
+    private static func normalizeParagraphs(in attributed: NSMutableAttributedString) {
+        let fullRange = NSRange(location: 0, length: attributed.length)
+        attributed.enumerateAttribute(.paragraphStyle, in: fullRange) { value, range, _ in
+            let paragraph = (value as? NSParagraphStyle)?.mutableCopy() as? NSMutableParagraphStyle
+                ?? NSMutableParagraphStyle()
+            paragraph.lineBreakMode = .byWordWrapping
+            attributed.addAttribute(.paragraphStyle, value: paragraph, range: range)
+        }
+
+        attributed.enumerateAttribute(.font, in: fullRange) { value, range, _ in
+            if value == nil {
+                attributed.addAttribute(.font, value: plainFont, range: range)
+            }
+        }
+
+        attributed.enumerateAttribute(.foregroundColor, in: fullRange) { value, range, _ in
+            if value == nil {
+                attributed.addAttribute(.foregroundColor, value: NSColor.black, range: range)
+            }
+        }
+    }
+
+    private static func measuredSize(for attributed: NSAttributedString, maxWidth: CGFloat) -> NSSize {
+        let rect = attributed.boundingRect(
+            with: NSSize(width: maxWidth, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        )
+        return NSSize(width: ceil(rect.width), height: ceil(rect.height))
+    }
+
+    private static func dominantBackgroundColor(in attributed: NSAttributedString) -> NSColor? {
+        let fullRange = NSRange(location: 0, length: attributed.length)
+        var counts: [String: (color: NSColor, length: Int)] = [:]
+
+        attributed.enumerateAttribute(.backgroundColor, in: fullRange) { value, range, _ in
+            guard let color = value as? NSColor, color.alphaComponent > 0.01 else { return }
+            let resolved = color.usingColorSpace(.sRGB) ?? color
+            let key = String(
+                format: "%.3f:%.3f:%.3f:%.3f",
+                resolved.redComponent,
+                resolved.greenComponent,
+                resolved.blueComponent,
+                resolved.alphaComponent
+            )
+            var entry = counts[key] ?? (resolved, 0)
+            entry.length += range.length
+            counts[key] = entry
+        }
+
+        return counts.values.max { $0.length < $1.length }?.color
+    }
+}

--- a/macshot/Services/ClipboardTextPinRenderer.swift
+++ b/macshot/Services/ClipboardTextPinRenderer.swift
@@ -41,13 +41,15 @@ enum ClipboardTextPinRenderer {
             documentAttributes: &documentAttributes
         ) else { return nil }
 
+        let mutable = NSMutableAttributedString(attributedString: attributed)
+        normalizeImportedListMarkers(in: mutable)
+
         let documentAttributesDict = documentAttributes as? [NSAttributedString.DocumentAttributeKey: Any]
         guard let backgroundColor = documentAttributesDict?[.backgroundColor] as? NSColor,
-              attributed.length > 0 else {
-            return attributed
+              mutable.length > 0 else {
+            return mutable
         }
 
-        let mutable = NSMutableAttributedString(attributedString: attributed)
         mutable.addAttribute(.backgroundColor, value: backgroundColor, range: NSRange(location: 0, length: mutable.length))
         return mutable
     }
@@ -135,6 +137,78 @@ enum ClipboardTextPinRenderer {
                 attributed.addAttribute(.foregroundColor, value: NSColor.black, range: range)
             }
         }
+    }
+
+    private static func normalizeImportedListMarkers(in attributed: NSMutableAttributedString) {
+        let nsString = attributed.string as NSString
+        let fullRange = NSRange(location: 0, length: nsString.length)
+        var paragraphRanges: [NSRange] = []
+
+        nsString.enumerateSubstrings(in: fullRange, options: [.byParagraphs, .substringNotRequired]) { _, _, enclosingRange, _ in
+            paragraphRanges.append(enclosingRange)
+        }
+
+        for range in paragraphRanges.reversed() where range.location < attributed.length {
+            normalizeImportedListMarker(in: range, attributed: attributed)
+        }
+    }
+
+    private static func normalizeImportedListMarker(in range: NSRange, attributed: NSMutableAttributedString) {
+        guard let paragraph = attributed.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle,
+              let textList = paragraph.textLists.last else {
+            return
+        }
+
+        let paragraphText = (attributed.string as NSString).substring(with: range)
+        guard paragraphText.hasPrefix("\t"),
+              let secondTabIndex = paragraphText.dropFirst().firstIndex(of: "\t") else {
+            return
+        }
+
+        let marker = String(paragraphText[paragraphText.index(after: paragraphText.startIndex)..<secondTabIndex])
+        let prefixLength = paragraphText.utf16.distance(from: paragraphText.utf16.startIndex, to: paragraphText.utf16.index(after: secondTabIndex))
+        guard prefixLength > 0, prefixLength <= range.length else { return }
+
+        let style = (paragraph.mutableCopy() as? NSMutableParagraphStyle) ?? NSMutableParagraphStyle()
+        style.textLists = []
+
+        let attributesLocation = min(range.location + prefixLength, max(range.location, attributed.length - 1))
+        var attributes = attributed.attributes(at: attributesLocation, effectiveRange: nil)
+        attributes[.paragraphStyle] = style
+
+        let displayMarker = displayListMarker(marker, textList: textList)
+        let replacement = NSAttributedString(string: "\(displayMarker) ", attributes: attributes)
+        attributed.replaceCharacters(in: NSRange(location: range.location, length: prefixLength), with: replacement)
+
+        let adjustedRange = NSRange(
+            location: range.location,
+            length: range.length - prefixLength + replacement.length
+        )
+        attributed.addAttribute(.paragraphStyle, value: style, range: adjustedRange)
+    }
+
+    private static func displayListMarker(_ marker: String, textList: NSTextList) -> String {
+        let trimmed = marker.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return marker }
+        guard isOrderedListMarker(trimmed, textList: textList),
+              !trimmed.hasSuffix("."),
+              !trimmed.hasSuffix(")") else {
+            return trimmed
+        }
+        return "\(trimmed)."
+    }
+
+    private static func isOrderedListMarker(_ marker: String, textList: NSTextList) -> Bool {
+        let markerFormat = String(describing: textList.markerFormat).lowercased()
+        if markerFormat.contains("decimal")
+            || markerFormat.contains("upper")
+            || markerFormat.contains("lower")
+            || markerFormat.contains("roman")
+            || markerFormat.contains("alpha") {
+            return true
+        }
+
+        return marker.range(of: #"^\d+$"#, options: .regularExpression) != nil
     }
 
     private static func measuredSize(for attributed: NSAttributedString, maxWidth: CGFloat) -> NSSize {

--- a/macshot/Services/ClipboardTextPinRenderer.swift
+++ b/macshot/Services/ClipboardTextPinRenderer.swift
@@ -4,7 +4,10 @@ enum ClipboardTextPinRenderer {
 
     private static let padding = NSEdgeInsets(top: 22, left: 24, bottom: 22, right: 24)
     private static let plainFont = NSFont.monospacedSystemFont(ofSize: 18, weight: .regular)
-    private static let maxPixelArea: CGFloat = 24_000_000
+    private static let maxPointArea: CGFloat = 24_000_000
+    private static let importedListBlockSpacing: CGFloat = 12
+    private static let importedTableBlockSpacing: CGFloat = 8
+    private static let maxImportedParagraphSpacing: CGFloat = 8
 
     static func attributedString(html data: Data) -> NSAttributedString? {
         attributedString(
@@ -43,6 +46,10 @@ enum ClipboardTextPinRenderer {
 
         let mutable = NSMutableAttributedString(attributedString: attributed)
         normalizeImportedListMarkers(in: mutable)
+        removeRedundantImportedBlankParagraphs(in: mutable)
+        restoreSpacingAfterImportedTables(in: mutable)
+        capImportedParagraphSpacing(in: mutable)
+        trimTrailingImportedLineBreaks(in: mutable)
 
         let documentAttributesDict = documentAttributes as? [NSAttributedString.DocumentAttributeKey: Any]
         guard let backgroundColor = documentAttributesDict?[.backgroundColor] as? NSColor,
@@ -69,6 +76,18 @@ enum ClipboardTextPinRenderer {
         )
     }
 
+    static func containsAttachments(_ attributed: NSAttributedString) -> Bool {
+        var found = false
+        let fullRange = NSRange(location: 0, length: attributed.length)
+        attributed.enumerateAttribute(.attachment, in: fullRange) { value, _, stop in
+            if value is NSTextAttachment {
+                found = true
+                stop.pointee = true
+            }
+        }
+        return found
+    }
+
     static func render(_ attributed: NSAttributedString, fallbackBackground: NSColor = .white) -> NSImage? {
         guard attributed.length > 0 else { return nil }
 
@@ -90,8 +109,8 @@ enum ClipboardTextPinRenderer {
             imageHeight = maxImageHeight
         }
 
-        if imageWidth * imageHeight > maxPixelArea {
-            let scale = sqrt(maxPixelArea / (imageWidth * imageHeight))
+        if imageWidth * imageHeight > maxPointArea {
+            let scale = sqrt(maxPointArea / (imageWidth * imageHeight))
             imageWidth = max(320, floor(imageWidth * scale))
             imageHeight = max(180, floor(imageHeight * scale))
         }
@@ -139,6 +158,158 @@ enum ClipboardTextPinRenderer {
         }
     }
 
+    private static func trimTrailingImportedLineBreaks(in attributed: NSMutableAttributedString) {
+        while attributed.length > 0 {
+            let lastRange = NSRange(location: attributed.length - 1, length: 1)
+            let lastCharacter = (attributed.string as NSString).substring(with: lastRange)
+            guard lastCharacter.rangeOfCharacter(from: .newlines) != nil else { break }
+            attributed.deleteCharacters(in: lastRange)
+        }
+    }
+
+    private static func removeRedundantImportedBlankParagraphs(in attributed: NSMutableAttributedString) {
+        let nsString = attributed.string as NSString
+        let fullRange = NSRange(location: 0, length: nsString.length)
+        var paragraphs: [(paragraph: NSRange, enclosing: NSRange)] = []
+
+        nsString.enumerateSubstrings(in: fullRange, options: [.byParagraphs, .substringNotRequired]) { _, paragraphRange, enclosingRange, _ in
+            paragraphs.append((paragraphRange, enclosingRange))
+        }
+
+        for index in paragraphs.indices.reversed() {
+            let current = paragraphs[index]
+            guard current.paragraph.length == 0,
+                  index > 0,
+                  index + 1 < paragraphs.count,
+                  paragraphs[index - 1].paragraph.length > 0,
+                  paragraphs[index + 1].paragraph.length > 0,
+                  hasParagraphSpacing(at: paragraphs[index - 1].paragraph.location, in: attributed),
+                  current.enclosing.location + current.enclosing.length <= attributed.length else {
+                continue
+            }
+            attributed.deleteCharacters(in: current.enclosing)
+        }
+    }
+
+    private static func hasParagraphSpacing(at location: Int, in attributed: NSAttributedString) -> Bool {
+        guard attributed.length > 0 else { return false }
+        let safeLocation = min(location, attributed.length - 1)
+        guard let style = attributed.attribute(.paragraphStyle, at: safeLocation, effectiveRange: nil) as? NSParagraphStyle else {
+            return false
+        }
+        return style.paragraphSpacing > 0 || style.paragraphSpacingBefore > 0
+    }
+
+    private static func capImportedParagraphSpacing(in attributed: NSMutableAttributedString) {
+        let fullRange = NSRange(location: 0, length: attributed.length)
+        attributed.enumerateAttribute(.paragraphStyle, in: fullRange) { value, range, _ in
+            guard let paragraph = (value as? NSParagraphStyle)?.mutableCopy() as? NSMutableParagraphStyle else { return }
+
+            var changed = false
+            if paragraph.paragraphSpacing > maxImportedParagraphSpacing {
+                paragraph.paragraphSpacing = maxImportedParagraphSpacing
+                changed = true
+            }
+            if paragraph.paragraphSpacingBefore > maxImportedParagraphSpacing {
+                paragraph.paragraphSpacingBefore = maxImportedParagraphSpacing
+                changed = true
+            }
+
+            if changed {
+                attributed.addAttribute(.paragraphStyle, value: paragraph, range: range)
+            }
+        }
+    }
+
+    private static func restoreSpacingAfterImportedTables(in attributed: NSMutableAttributedString) {
+        let nsString = attributed.string as NSString
+        let fullRange = NSRange(location: 0, length: nsString.length)
+        var paragraphs: [(paragraph: NSRange, enclosing: NSRange, isTable: Bool)] = []
+
+        nsString.enumerateSubstrings(in: fullRange, options: [.byParagraphs, .substringNotRequired]) { _, paragraphRange, enclosingRange, _ in
+            let isTable = paragraphRange.length > 0 && isTableParagraph(at: paragraphRange.location, in: attributed)
+            paragraphs.append((paragraphRange, enclosingRange, isTable))
+        }
+
+        for index in paragraphs.indices {
+            let current = paragraphs[index]
+            guard current.isTable,
+                  let next = nextNonEmptyParagraph(after: index, in: paragraphs),
+                  !next.isTable else {
+                continue
+            }
+
+            applyParagraphSpacing(
+                importedTableBlockSpacing,
+                at: current.enclosing,
+                in: attributed
+            )
+            applyParagraphSpacingBefore(
+                importedTableBlockSpacing,
+                at: next.enclosing,
+                in: attributed
+            )
+        }
+    }
+
+    private static func nextNonEmptyParagraph(
+        after index: Int,
+        in paragraphs: [(paragraph: NSRange, enclosing: NSRange, isTable: Bool)]
+    ) -> (paragraph: NSRange, enclosing: NSRange, isTable: Bool)? {
+        guard index + 1 < paragraphs.count else { return nil }
+        for nextIndex in (index + 1)..<paragraphs.count where paragraphs[nextIndex].paragraph.length > 0 {
+            return paragraphs[nextIndex]
+        }
+        return nil
+    }
+
+    private static func isTableParagraph(at location: Int, in attributed: NSAttributedString) -> Bool {
+        guard attributed.length > 0 else { return false }
+        let safeLocation = min(location, attributed.length - 1)
+        guard let style = attributed.attribute(.paragraphStyle, at: safeLocation, effectiveRange: nil) as? NSParagraphStyle else {
+            return false
+        }
+        return style.textBlocks.contains { $0 is NSTextTableBlock }
+    }
+
+    private static func applyParagraphSpacing(
+        _ spacing: CGFloat,
+        at range: NSRange,
+        in attributed: NSMutableAttributedString
+    ) {
+        guard range.location < attributed.length,
+              let paragraph = (attributed.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle)?
+                .mutableCopy() as? NSMutableParagraphStyle else {
+            return
+        }
+
+        paragraph.paragraphSpacing = max(paragraph.paragraphSpacing, spacing)
+        let safeRange = NSRange(
+            location: range.location,
+            length: min(range.length, attributed.length - range.location)
+        )
+        attributed.addAttribute(.paragraphStyle, value: paragraph, range: safeRange)
+    }
+
+    private static func applyParagraphSpacingBefore(
+        _ spacing: CGFloat,
+        at range: NSRange,
+        in attributed: NSMutableAttributedString
+    ) {
+        guard range.location < attributed.length,
+              let paragraph = (attributed.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle)?
+                .mutableCopy() as? NSMutableParagraphStyle else {
+            return
+        }
+
+        paragraph.paragraphSpacingBefore = max(paragraph.paragraphSpacingBefore, spacing)
+        let safeRange = NSRange(
+            location: range.location,
+            length: min(range.length, attributed.length - range.location)
+        )
+        attributed.addAttribute(.paragraphStyle, value: paragraph, range: safeRange)
+    }
+
     private static func normalizeImportedListMarkers(in attributed: NSMutableAttributedString) {
         let nsString = attributed.string as NSString
         let fullRange = NSRange(location: 0, length: nsString.length)
@@ -148,12 +319,34 @@ enum ClipboardTextPinRenderer {
             paragraphRanges.append(enclosingRange)
         }
 
-        for range in paragraphRanges.reversed() where range.location < attributed.length {
-            normalizeImportedListMarker(in: range, attributed: attributed)
+        let listParagraphs = paragraphRanges.map { isImportedListParagraph(at: $0, in: attributed) }
+        for index in paragraphRanges.indices.reversed() {
+            let range = paragraphRanges[index]
+            guard range.location < attributed.length else { continue }
+
+            let hasFollowingParagraph = index + 1 < paragraphRanges.count
+            let isEndOfListBlock = listParagraphs[index] && hasFollowingParagraph && !listParagraphs[index + 1]
+            normalizeImportedListMarker(
+                in: range,
+                attributed: attributed,
+                addsBlockEndSpacing: isEndOfListBlock
+            )
         }
     }
 
-    private static func normalizeImportedListMarker(in range: NSRange, attributed: NSMutableAttributedString) {
+    private static func isImportedListParagraph(at range: NSRange, in attributed: NSAttributedString) -> Bool {
+        guard range.location < attributed.length,
+              let paragraph = attributed.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle else {
+            return false
+        }
+        return !paragraph.textLists.isEmpty
+    }
+
+    private static func normalizeImportedListMarker(
+        in range: NSRange,
+        attributed: NSMutableAttributedString,
+        addsBlockEndSpacing: Bool
+    ) {
         guard let paragraph = attributed.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle,
               let textList = paragraph.textLists.last else {
             return
@@ -165,24 +358,34 @@ enum ClipboardTextPinRenderer {
             return
         }
 
-        let marker = String(paragraphText[paragraphText.index(after: paragraphText.startIndex)..<secondTabIndex])
-        let prefixLength = paragraphText.utf16.distance(from: paragraphText.utf16.startIndex, to: paragraphText.utf16.index(after: secondTabIndex))
-        guard prefixLength > 0, prefixLength <= range.length else { return }
+        let markerStart = paragraphText.index(after: paragraphText.startIndex)
+        let marker = String(paragraphText[markerStart..<secondTabIndex])
+        let markerStartOffset = markerStart.utf16Offset(in: paragraphText)
+        let markerEndOffset = secondTabIndex.utf16Offset(in: paragraphText)
+        let markerLocation = range.location + markerStartOffset
+        let markerLength = markerEndOffset - markerStartOffset
+        guard markerLength > 0, markerLocation + markerLength <= attributed.length else { return }
 
         let style = (paragraph.mutableCopy() as? NSMutableParagraphStyle) ?? NSMutableParagraphStyle()
         style.textLists = []
+        if addsBlockEndSpacing {
+            style.paragraphSpacing = max(style.paragraphSpacing, importedListBlockSpacing)
+        }
 
-        let attributesLocation = min(range.location + prefixLength, max(range.location, attributed.length - 1))
+        let attributesLocation = min(markerLocation, max(range.location, attributed.length - 1))
         var attributes = attributed.attributes(at: attributesLocation, effectiveRange: nil)
         attributes[.paragraphStyle] = style
 
         let displayMarker = displayListMarker(marker, textList: textList)
-        let replacement = NSAttributedString(string: "\(displayMarker) ", attributes: attributes)
-        attributed.replaceCharacters(in: NSRange(location: range.location, length: prefixLength), with: replacement)
+        let replacement = NSAttributedString(string: displayMarker, attributes: attributes)
+        attributed.replaceCharacters(
+            in: NSRange(location: markerLocation, length: markerLength),
+            with: replacement
+        )
 
         let adjustedRange = NSRange(
             location: range.location,
-            length: range.length - prefixLength + replacement.length
+            length: range.length - markerLength + replacement.length
         )
         attributed.addAttribute(.paragraphStyle, value: style, range: adjustedRange)
     }
@@ -224,8 +427,9 @@ enum ClipboardTextPinRenderer {
         var counts: [String: (color: NSColor, length: Int)] = [:]
 
         attributed.enumerateAttribute(.backgroundColor, in: fullRange) { value, range, _ in
-            guard let color = value as? NSColor, color.alphaComponent > 0.01 else { return }
-            let resolved = color.usingColorSpace(.sRGB) ?? color
+            guard let color = value as? NSColor,
+                  let resolved = color.usingColorSpace(.sRGB),
+                  resolved.alphaComponent > 0.01 else { return }
             let key = String(
                 format: "%.3f:%.3f:%.3f:%.3f",
                 resolved.redComponent,

--- a/macshot/Services/HotkeyManager.swift
+++ b/macshot/Services/HotkeyManager.swift
@@ -20,6 +20,7 @@ class HotkeyManager {
         case scrollCapture = 8
         case openFromClipboard = 9
         case captureLastArea = 10
+        case pinFromClipboard = 11
 
         var keyCodeKey: String {
             switch self {
@@ -33,6 +34,7 @@ class HotkeyManager {
             case .scrollCapture: return "hotkeyScrollCaptureKeyCode"
             case .openFromClipboard: return "hotkeyOpenClipboardKeyCode"
             case .captureLastArea: return "hotkeyCaptureLastAreaKeyCode"
+            case .pinFromClipboard: return "hotkeyPinClipboardKeyCode"
             }
         }
 
@@ -48,6 +50,7 @@ class HotkeyManager {
             case .scrollCapture: return "hotkeyScrollCaptureModifiers"
             case .openFromClipboard: return "hotkeyOpenClipboardModifiers"
             case .captureLastArea: return "hotkeyCaptureLastAreaModifiers"
+            case .pinFromClipboard: return "hotkeyPinClipboardModifiers"
             }
         }
 
@@ -67,6 +70,7 @@ class HotkeyManager {
             case .scrollCapture: return L("Scroll Capture")
             case .openFromClipboard: return L("Open from Clipboard")
             case .captureLastArea: return L("Capture Last Area")
+            case .pinFromClipboard: return L("Pin from Clipboard")
             }
         }
 
@@ -82,12 +86,13 @@ class HotkeyManager {
             case .scrollCapture: return 0
             case .openFromClipboard: return 0  // no default hotkey
             case .captureLastArea: return 0    // no default hotkey
+            case .pinFromClipboard: return 0    // no default hotkey
             }
         }
 
         var defaultModifiers: UInt32 {
             switch self {
-            case .recordScreen, .scrollCapture, .openFromClipboard, .captureLastArea: return 0
+            case .recordScreen, .scrollCapture, .openFromClipboard, .captureLastArea, .pinFromClipboard: return 0
             default: return UInt32(cmdKey | shiftKey)
             }
         }
@@ -126,7 +131,7 @@ class HotkeyManager {
     }
 
     /// Register all hotkeys with their callbacks.
-    func registerAll(captureArea: @escaping () -> Void, captureFullScreen: @escaping () -> Void, recordArea: @escaping () -> Void, recordScreen: @escaping () -> Void, historyOverlay: @escaping () -> Void, captureOCR: @escaping () -> Void, quickCapture: @escaping () -> Void, scrollCapture: @escaping () -> Void, openFromClipboard: @escaping () -> Void, captureLastArea: @escaping () -> Void) {
+    func registerAll(captureArea: @escaping () -> Void, captureFullScreen: @escaping () -> Void, recordArea: @escaping () -> Void, recordScreen: @escaping () -> Void, historyOverlay: @escaping () -> Void, captureOCR: @escaping () -> Void, quickCapture: @escaping () -> Void, scrollCapture: @escaping () -> Void, openFromClipboard: @escaping () -> Void, captureLastArea: @escaping () -> Void, pinFromClipboard: @escaping () -> Void) {
         unregisterAll()
         register(slot: .captureArea, callback: captureArea)
         register(slot: .captureFullScreen, callback: captureFullScreen)
@@ -138,6 +143,7 @@ class HotkeyManager {
         register(slot: .scrollCapture, callback: scrollCapture)
         register(slot: .openFromClipboard, callback: openFromClipboard)
         register(slot: .captureLastArea, callback: captureLastArea)
+        register(slot: .pinFromClipboard, callback: pinFromClipboard)
     }
 
     private func installEventHandler() {

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -29,6 +29,7 @@
 "Show History Panel" = "Show History Panel";
 "Open Image..." = "Open Image...";
 "Open from Clipboard" = "Open from Clipboard";
+"Pin from Clipboard" = "Pin from Clipboard";
 "Settings..." = "Settings...";
 "Check for Updates..." = "Check for Updates...";
 "Quit macshot" = "Quit macshot";
@@ -341,6 +342,8 @@
 /* Alerts */
 "No Image on Clipboard" = "No Image on Clipboard";
 "Copy an image to the clipboard first, then try again." = "Copy an image to the clipboard first, then try again.";
+"No Image or Text on Clipboard" = "No Image or Text on Clipboard";
+"Copy an image or text to the clipboard first, then try again." = "Copy an image or text to the clipboard first, then try again.";
 "OK" = "OK";
 "Accessibility Access Required" = "Accessibility Access Required";
 "macshot needs Accessibility permission to auto-scroll other apps. Please grant access in System Settings, then try again." = "macshot needs Accessibility permission to auto-scroll other apps. Please grant access in System Settings, then try again.";


### PR DESCRIPTION
## Summary
- Add a Pin from Clipboard menu item and configurable hotkey slot.
- Pin the first clipboard item as an image when real image data is available.
- Render text/HTML/RTF clipboard content as a pinned image, with normalization for imported lists, attachments, and block spacing.

## Test Plan
- git diff --check origin/main...HEAD
- swiftc smoke checks for HTML image fallback and imported text spacing
- xcodebuild -project macshot.xcodeproj -scheme macshot -configuration Debug -destination 'platform=macOS' -derivedDataPath /private/tmp/macshot-pin-clipboard-derivedData -clonedSourcePackagesDirPath /private/tmp/macshot-pin-clipboard-sourcePackages CODE_SIGNING_ALLOWED=NO -quiet build

## Demo
  Text clipboard:
<img width="2953" height="1165" alt="Screenshot 2026-05-25 at 02-40-44" src="https://github.com/user-attachments/assets/5563dd1c-5f36-4127-ad5c-d52b69810795" />
