### PR TITLE
Fix hidden overlay chrome intercepting new selection drags

### DIFF
--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -1258,30 +1258,23 @@ class OverlayView: NSView {
 
     private func shouldIgnoreInactiveChromeHit(_ view: NSView?) -> Bool {
         guard !isEditorMode, let view, view !== self else { return false }
-        for chromeView in [bottomStripView, rightStripView, toolOptionsRowView].compactMap({ $0 }) {
-            if view === chromeView || isDescendant(view, of: chromeView) {
-                return !showToolbars || hasHiddenAncestor(view, stoppingAt: self)
-            }
-        }
-        return false
-    }
 
-    private func isDescendant(_ view: NSView, of ancestor: NSView) -> Bool {
-        var current = view.superview
-        while let candidate = current {
-            if candidate === ancestor { return true }
-            if candidate === self { return false }
-            current = candidate.superview
-        }
-        return false
-    }
-
-    private func hasHiddenAncestor(_ view: NSView, stoppingAt stopView: NSView) -> Bool {
         var current: NSView? = view
-        while let candidate = current, candidate !== stopView {
-            if candidate.isHidden { return true }
+        var hasHiddenAncestor = false
+        while let candidate = current, candidate !== self {
+            hasHiddenAncestor = hasHiddenAncestor || candidate.isHidden
+            if isOverlayChromeRoot(candidate) {
+                return !showToolbars || hasHiddenAncestor
+            }
             current = candidate.superview
         }
+        return false
+    }
+
+    private func isOverlayChromeRoot(_ view: NSView) -> Bool {
+        if let bottomStripView, view === bottomStripView { return true }
+        if let rightStripView, view === rightStripView { return true }
+        if let toolOptionsRowView, view === toolOptionsRowView { return true }
         return false
     }
 

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -1249,7 +1249,40 @@ class OverlayView: NSView {
                 return row.hitTest(convert(point, to: row.superview))
             }
         }
-        return super.hitTest(point)
+        let result = super.hitTest(point)
+        if shouldIgnoreInactiveChromeHit(result) {
+            return self
+        }
+        return result
+    }
+
+    private func shouldIgnoreInactiveChromeHit(_ view: NSView?) -> Bool {
+        guard !isEditorMode, let view, view !== self else { return false }
+        for chromeView in [bottomStripView, rightStripView, toolOptionsRowView].compactMap({ $0 }) {
+            if view === chromeView || isDescendant(view, of: chromeView) {
+                return !showToolbars || hasHiddenAncestor(view, stoppingAt: self)
+            }
+        }
+        return false
+    }
+
+    private func isDescendant(_ view: NSView, of ancestor: NSView) -> Bool {
+        var current = view.superview
+        while let candidate = current {
+            if candidate === ancestor { return true }
+            if candidate === self { return false }
+            current = candidate.superview
+        }
+        return false
+    }
+
+    private func hasHiddenAncestor(_ view: NSView, stoppingAt stopView: NSView) -> Bool {
+        var current: NSView? = view
+        while let candidate = current, candidate !== stopView {
+            if candidate.isHidden { return true }
+            current = candidate.superview
+        }
+        return false
     }
 
     /// Returns true if the point is over any chrome element (toolbars, options row, popovers, labels).


### PR DESCRIPTION
## Summary

This fixes an intermittent issue where starting a new screenshot selection could fail when the drag began over the previous position of hidden overlay chrome, such as the tool options row.

The overlay reuses toolbar/options views between capture sessions. In some cases, `super.hitTest(_:)` could still resolve a mouse-down to a hidden or inactive chrome subview, preventing `OverlayView.mouseDown(with:)` from starting the selection.

This change keeps visible toolbar/options behavior unchanged, but ignores hidden or inactive overlay chrome hits and routes those mouse events back to `OverlayView`.

## Test Plan

- Built successfully with:
  `xcodebuild -project macshot.xcodeproj -scheme macshot -configuration Debug -derivedDataPath / private/tmp/macshot-derived-data CODE_SIGNING_ALLOWED=NO build`
- Manually tested repeated screenshot sessions through the previously affected narrow region; selection starts normally instead of being swallowed by the hidden options row.

## Demo
### Before
https://github.com/user-attachments/assets/9b9554fa-89a0-4a4e-9a57-e11361eb4367

### After
https://github.com/user-attachments/assets/3d499b4e-4ef9-4732-8c3c-09436e3c6e83





