### PR TITLE
Add customizable menu bar icon (default or SF Symbol)

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -599,21 +599,52 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         rebuildStatusBarMenu()
     }
 
+    // User-customizable menu bar icon (see Settings → General → Appearance).
+    // Mode is "default" (bundled StatusBarIcon asset) or "symbol" (a user-chosen SF Symbol).
+    static let statusBarIconModeKey = "statusBarIconMode"
+    static let statusBarIconSymbolNameKey = "statusBarIconSymbolName"
+
     private func applyNormalStatusBarIcon() {
         if let button = statusItem.button {
-            if let img = NSImage(named: "StatusBarIcon") {
-                img.isTemplate = true
-                img.size = NSSize(width: 22, height: 22)
-                button.image = img
-            } else {
-                button.title = "macshot"
-            }
+            applyPreferredIconImage(to: button)
             // Use custom click handler so we can dismiss modals before showing the menu
             button.target = self
             button.action = #selector(statusBarIconClicked(_:))
             button.sendAction(on: [.leftMouseDown, .rightMouseDown])
             (button.cell as? NSButtonCell)?.highlightsBy = .pushInCellMask
         }
+    }
+
+    /// Sets the button image/title from the user's icon preference. "symbol" mode renders
+    /// the chosen SF Symbol as a 22pt template image; anything else — including an empty or
+    /// invalid symbol name — falls back to the bundled icon so the item is never blank.
+    private func applyPreferredIconImage(to button: NSStatusBarButton) {
+        let mode = UserDefaults.standard.string(forKey: Self.statusBarIconModeKey) ?? "default"
+        let symbolName = UserDefaults.standard.string(forKey: Self.statusBarIconSymbolNameKey) ?? ""
+
+        if mode == "symbol", !symbolName.isEmpty,
+           let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: "macshot") {
+            symbol.isTemplate = true
+            symbol.size = NSSize(width: 22, height: 22)
+            button.image = symbol
+            button.title = ""
+        } else if let img = NSImage(named: "StatusBarIcon") {
+            img.isTemplate = true
+            img.size = NSSize(width: 22, height: 22)
+            button.image = img
+            button.title = ""
+        } else {
+            button.image = nil
+            button.title = "macshot"
+        }
+    }
+
+    /// Re-applies the menu bar icon to reflect the user's current preference. Invoked live
+    /// from Settings so changes take effect without a relaunch. No-op while recording — the
+    /// recording state owns the icon then and restores the preferred one when it ends.
+    func refreshStatusBarIcon() {
+        guard recordingEngine == nil, let button = statusItem.button else { return }
+        applyPreferredIconImage(to: button)
     }
 
     @objc private func statusBarIconClicked(_ sender: NSStatusBarButton) {

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -58,6 +58,14 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     private var thumbnailScaleLabel: NSTextField!
     private var launchAtLoginCheckbox: NSButton!
     private var hideMenuBarIconCheckbox: NSButton!
+    private var menuBarIconModePopup: NSPopUpButton!
+    private var menuBarIconPresetPopup: NSPopUpButton!
+    private var menuBarIconSymbolField: NSTextField!
+
+    /// Curated SF Symbol quick-picks for the menu bar icon. Free text is still allowed.
+    private static let menuBarIconPresetSymbols = [
+        "camera.viewfinder", "camera.fill", "crop", "scissors", "bolt.fill", "star.fill",
+    ]
     private var historySizeField: NSTextField!
     private var historySizeStepper: NSStepper!
     private var snapGuidesCheckbox: NSButton!
@@ -407,6 +415,44 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         hideNote.font = NSFont.systemFont(ofSize: 10)
         hideNote.textColor = .secondaryLabelColor
         stack.addArrangedSubview(indented(hideNote))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        // Menu bar icon: keep the bundled icon or pick any SF Symbol.
+        menuBarIconModePopup = NSPopUpButton()
+        menuBarIconModePopup.addItem(withTitle: L("Default"))
+        menuBarIconModePopup.addItem(withTitle: L("Custom symbol"))
+        menuBarIconModePopup.target = self
+        menuBarIconModePopup.action = #selector(menuBarIconModeChanged(_:))
+        stack.addArrangedSubview(labeledRow(L("Menu bar icon:"), controls: [menuBarIconModePopup]))
+        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
+
+        menuBarIconSymbolField = NSTextField()
+        menuBarIconSymbolField.placeholderString = "camera.viewfinder"
+        menuBarIconSymbolField.translatesAutoresizingMaskIntoConstraints = false
+        menuBarIconSymbolField.widthAnchor.constraint(equalToConstant: 180).isActive = true
+        menuBarIconSymbolField.target = self
+        menuBarIconSymbolField.action = #selector(menuBarIconSymbolChanged(_:))
+
+        // Pull-down quick-picker: index 0 is the "Presets" label, symbols follow.
+        menuBarIconPresetPopup = NSPopUpButton(frame: .zero, pullsDown: true)
+        menuBarIconPresetPopup.addItem(withTitle: L("Presets"))
+        for symbol in Self.menuBarIconPresetSymbols {
+            menuBarIconPresetPopup.addItem(withTitle: symbol)
+        }
+        menuBarIconPresetPopup.target = self
+        menuBarIconPresetPopup.action = #selector(menuBarIconPresetChanged(_:))
+
+        let iconSymbolRow = NSStackView(views: [menuBarIconSymbolField, menuBarIconPresetPopup])
+        iconSymbolRow.orientation = .horizontal
+        iconSymbolRow.spacing = 8
+        iconSymbolRow.alignment = .centerY
+        stack.addArrangedSubview(indented(iconSymbolRow))
+        stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
+
+        let iconNote = NSTextField(wrappingLabelWithString: L("Enter any SF Symbol name (e.g. camera.fill) or pick a preset. Browse names in Apple's SF Symbols app. Invalid names fall back to the default icon."))
+        iconNote.font = NSFont.systemFont(ofSize: 10)
+        iconNote.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(indented(iconNote))
         stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
 
         let urlSchemeCheckbox = NSButton(checkboxWithTitle: L("Enable macshot:// URL scheme"), target: self, action: #selector(urlSchemeChanged(_:)))
@@ -2124,6 +2170,11 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
 
         hideMenuBarIconCheckbox.state = UserDefaults.standard.bool(forKey: "hideMenuBarIcon") ? .on : .off
 
+        let iconMode = UserDefaults.standard.string(forKey: AppDelegate.statusBarIconModeKey) ?? "default"
+        menuBarIconModePopup.selectItem(at: iconMode == "symbol" ? 1 : 0)
+        menuBarIconSymbolField.stringValue = UserDefaults.standard.string(forKey: AppDelegate.statusBarIconSymbolNameKey) ?? ""
+        updateMenuBarIconControlsEnabled()
+
         let snapGuides = UserDefaults.standard.object(forKey: "snapGuidesEnabled") as? Bool ?? true
         snapGuidesCheckbox.state = snapGuides ? .on : .off
 
@@ -2711,6 +2762,35 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         let hidden = sender.state == .on
         UserDefaults.standard.set(hidden, forKey: "hideMenuBarIcon")
         (NSApp.delegate as? AppDelegate)?.setMenuBarIconVisible(!hidden)
+    }
+
+    @objc private func menuBarIconModeChanged(_ sender: NSPopUpButton) {
+        let mode = sender.indexOfSelectedItem == 1 ? "symbol" : "default"
+        UserDefaults.standard.set(mode, forKey: AppDelegate.statusBarIconModeKey)
+        updateMenuBarIconControlsEnabled()
+        (NSApp.delegate as? AppDelegate)?.refreshStatusBarIcon()
+    }
+
+    @objc private func menuBarIconPresetChanged(_ sender: NSPopUpButton) {
+        // Pull-down: index 0 is the "Presets" label; real symbols start at 1.
+        guard sender.indexOfSelectedItem >= 1,
+              let symbol = sender.titleOfSelectedItem, !symbol.isEmpty else { return }
+        menuBarIconSymbolField.stringValue = symbol
+        UserDefaults.standard.set(symbol, forKey: AppDelegate.statusBarIconSymbolNameKey)
+        (NSApp.delegate as? AppDelegate)?.refreshStatusBarIcon()
+    }
+
+    @objc private func menuBarIconSymbolChanged(_ sender: NSTextField) {
+        let name = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        UserDefaults.standard.set(name, forKey: AppDelegate.statusBarIconSymbolNameKey)
+        (NSApp.delegate as? AppDelegate)?.refreshStatusBarIcon()
+    }
+
+    /// Enables the symbol field + preset picker only in "Custom symbol" mode.
+    private func updateMenuBarIconControlsEnabled() {
+        let custom = menuBarIconModePopup.indexOfSelectedItem == 1
+        menuBarIconSymbolField.isEnabled = custom
+        menuBarIconPresetPopup.isEnabled = custom
     }
 
     @objc private func autoUpdateChanged(_ sender: NSButton) {


### PR DESCRIPTION
The menu bar icon was hardcoded to the bundled StatusBarIcon asset. Add a "Menu bar icon" setting under General → Appearance with two modes:

- Default: the existing bundled icon (unchanged default behavior)
- Custom symbol: any SF Symbol name, plus a preset quick-picker with a few options

applyNormalStatusBarIcon() now renders the preferred icon; an empty or invalid symbol name falls back to the default so the menu bar item is never blank. Settings apply the icon live via AppDelegate.refreshStatusBarIcon() (a no-op while recording, which owns the icon and restores the preferred one on stop).

Implements #232.