### PR TITLE
Respect remember last tool setting

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -1043,6 +1043,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // so new OverlayView instances start clean.
         let rememberTool = UserDefaults.standard.object(forKey: "rememberLastTool") as? Bool ?? true
         if !rememberTool {
+            OverlayView.resetRememberedTool()
             UserDefaults.standard.removeObject(forKey: "effectsPreset")
             UserDefaults.standard.removeObject(forKey: "effectsBrightness")
             UserDefaults.standard.removeObject(forKey: "effectsContrast")

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -215,13 +215,22 @@ class OverlayView: NSView {
         }
         return .arrow
     }()
+    private static var shouldRememberLastTool: Bool {
+        UserDefaults.standard.object(forKey: "rememberLastTool") as? Bool ?? true
+    }
+    private static var initialTool: AnnotationTool {
+        shouldRememberLastTool ? lastUsedTool : .arrow
+    }
+    static func resetRememberedTool() {
+        lastUsedTool = .arrow
+        UserDefaults.standard.removeObject(forKey: "lastUsedTool")
+    }
     var currentTool: AnnotationTool = {
-        let remember = UserDefaults.standard.object(forKey: "rememberLastTool") as? Bool ?? true
-        return remember ? OverlayView.lastUsedTool : .arrow
+        OverlayView.initialTool
     }() {
         didSet {
             // Persist drawing tool choices; skip transient/mode tools
-            if currentTool != .select && currentTool != .loupe {
+            if OverlayView.shouldRememberLastTool && currentTool != .select && currentTool != .loupe {
                 OverlayView.lastUsedTool = currentTool
                 UserDefaults.standard.set(currentTool.rawValue, forKey: "lastUsedTool")
             }
@@ -8110,6 +8119,7 @@ class OverlayView: NSView {
         undoStack.removeAll()
         redoStack.removeAll()
         currentAnnotation = nil
+        currentTool = OverlayView.initialTool
         numberCounter = 0
         showToolbars = false
         teardownGlassChromePanels()

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -2274,7 +2274,11 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         UserDefaults.standard.set(sender.state == .on, forKey: "playCopySound")
     }
     @objc private func rememberToolChanged(_ sender: NSButton) {
-        UserDefaults.standard.set(sender.state == .on, forKey: "rememberLastTool")
+        let enabled = sender.state == .on
+        UserDefaults.standard.set(enabled, forKey: "rememberLastTool")
+        if !enabled {
+            OverlayView.resetRememberedTool()
+        }
     }
     @objc private func thumbnailChanged(_ sender: NSButton) {
         UserDefaults.standard.set(sender.state == .on, forKey: "showFloatingThumbnail")


### PR DESCRIPTION
## Summary
- only persist `lastUsedTool` when `Remember last selected tool` is enabled
- reset pooled overlay views to Arrow when remembering is disabled
- clear stale remembered tool data when disabling the setting or starting capture with it off

## Testing
- `xcodebuild -project macshot.xcodeproj -scheme macshot -configuration Debug -derivedDataPath ./build CODE_SIGNING_ALLOWED=NO build`
- Manually tested disabled remember-tool behavior locally (human QA by me)

Fixes https://github.com/sw33tLie/macshot/issues/252