### PR TITLE
Add macshot://edit?id= URL command to open a history entry in the editor

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -2021,6 +2021,31 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         DetachedEditorWindowController.open(image: image)
     }
 
+    /// Open a history entry in the editor by its id, restoring editable annotations when
+    /// available (falls back to the flattened image, like the history overlay does). Lets
+    /// external tools re-open a specific capture for editing — `macshot://edit?id=<id>` —
+    /// without flattening it, which `open?file=` cannot do.
+    private func openHistoryEntryInEditor(id: String) {
+        guard let entry = ScreenshotHistory.shared.entries.first(where: { $0.id == id }) else { return }
+
+        if entry.hasAnnotations,
+           let rawImage = ScreenshotHistory.shared.loadRawImage(for: entry),
+           let annotations = ScreenshotHistory.shared.loadAnnotations(for: entry) {
+            let editState = ScreenshotHistory.shared.loadEditState(for: entry)
+            DetachedEditorWindowController.open(
+                image: rawImage,
+                annotations: annotations,
+                historyEntryID: id,
+                editState: editState
+            )
+            return
+        }
+
+        // Fall back to the flattened image — beautify already baked in.
+        guard let image = ScreenshotHistory.shared.loadImage(for: entry) else { return }
+        DetachedEditorWindowController.open(image: image, historyEntryID: id, disableBeautify: true)
+    }
+
     // MARK: - Open Video
 
     @objc private func openVideoFromMenu() {
@@ -2092,6 +2117,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
                let path = components.queryItems?.first(where: { $0.name == "file" })?.value {
                 openImageFile(url: URL(fileURLWithPath: path))
+            }
+        case "edit":
+            if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+               let id = components.queryItems?.first(where: { $0.name == "id" })?.value {
+                openHistoryEntryInEditor(id: id)
             }
         default: break
         }

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -2785,6 +2785,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
             ("macshot://history",             L("Open the recent captures overlay")),
             ("macshot://settings",            L("Open this settings window")),
             ("macshot://open?file=/path.png", L("Open an image file in the editor")),
+            ("macshot://edit?id=<id>",        L("Open a history entry in the editor (keeps annotations editable)")),
         ]
 
         let title = NSTextField(labelWithString: L("Supported URL Scheme Commands"))


### PR DESCRIPTION
Adds `macshot://edit?id=<historyEntryID>` — open a specific history entry directly in the editor with its annotations still **editable**.

### Why
`macshot://open?file=` opens a flat image, so any annotations are baked into pixels and can no longer be moved or re-edited. There's currently no external way to reopen a capture with its editable annotation layer. This lets external tools (launchers, library/automation apps) hand a capture back to macshot for real re-editing rather than a flat round-trip.

### What it does
Mirrors the history overlay's "Open in Editor" path: loads the entry's raw image + annotations (+ editState) via `ScreenshotHistory` and calls `DetachedEditorWindowController.open(...)`, falling back to the flattened image when there's no editable layer — same behavior as `HistoryOverlayController.openInEditor`. The Settings URL-scheme help list documents the new command.

### Testing
Built and ran a local copy. Firing `macshot://edit?id=<id>`:
- reopens the entry in the editor with the annotation **editable** (movable),
- falls back to the flattened image for entries without an editable layer,
- no-ops for an unknown id.

No new build warnings; existing `open?file=` behavior is unchanged.

### Checklist
- [x] Builds without warnings (no new warnings from this change)
- [x] Tested manually (no unit tests)
- [x] Doesn't break existing behavior (adds a new command only)
- [x] Commit message describes what and why

AppKit only, no new dependencies, reuses existing APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
