### PR TITLE
feat: add configurable translation target language

### DIFF
--- a/Tests/TranslationTargetLanguageTests.swift
+++ b/Tests/TranslationTargetLanguageTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+}
+
+private func expectEqual<T: Equatable>(
+    _ actual: @autoclosure () -> T,
+    _ expected: T,
+    _ message: String
+) throws {
+    let actualValue = actual()
+    guard actualValue == expected else {
+        throw TestFailure(
+            description: "\(message): expected \(String(describing: expected)), got \(String(describing: actualValue))"
+        )
+    }
+}
+
+@main
+private enum TranslationTargetLanguageTests {
+    private static let supportedCodes: Set<String> = ["en", "pt", "zh-CN", "zh-TW"]
+
+    static func main() {
+        do {
+            try testSystemLanguageResolution()
+            try testExplicitLanguageOverridesSystemLanguage()
+            try testClearingExplicitLanguageRestoresSystemResolution()
+            try testInvalidStoredLanguageIsIgnoredAndPreserved()
+            print("TranslationTargetLanguageTests: PASS")
+        } catch {
+            FileHandle.standardError.write(Data("TranslationTargetLanguageTests: FAIL - \(error)\n".utf8))
+            exit(1)
+        }
+    }
+
+    private static func testSystemLanguageResolution() throws {
+        try expectSystemLanguage("en-US", equals: "en")
+        try expectSystemLanguage("pt-BR", equals: "pt")
+        try expectSystemLanguage("en_US", equals: "en")
+
+        for language in ["zh-Hans-US", "zh-SG", "zh"] {
+            try expectSystemLanguage(language, equals: "zh-CN")
+        }
+
+        for language in ["zh-Hant-HK", "zh-HK", "zh-MO"] {
+            try expectSystemLanguage(language, equals: "zh-TW")
+        }
+
+        try expectEqual(
+            TranslationTargetLanguage.systemLanguage(
+                preferredLanguages: ["fr-FR", "pt-BR"],
+                supportedCodes: supportedCodes,
+                fallback: "en"
+            ),
+            "en",
+            "an unsupported first preferred language should use the fallback"
+        )
+        try expectEqual(
+            TranslationTargetLanguage.systemLanguage(
+                preferredLanguages: [],
+                supportedCodes: supportedCodes,
+                fallback: "en"
+            ),
+            "en",
+            "empty preferred languages should use the fallback"
+        )
+    }
+
+    private static func testExplicitLanguageOverridesSystemLanguage() throws {
+        try withIsolatedDefaults { defaults in
+            TranslationTargetLanguage.setExplicitLanguage(
+                "pt",
+                in: defaults,
+                supportedCodes: supportedCodes
+            )
+
+            try expectEqual(
+                TranslationTargetLanguage.resolvedLanguage(
+                    defaults: defaults,
+                    preferredLanguages: ["zh-Hans-US"],
+                    supportedCodes: supportedCodes,
+                    fallback: "en"
+                ),
+                "pt",
+                "a valid explicit language should override the system language"
+            )
+        }
+    }
+
+    private static func testClearingExplicitLanguageRestoresSystemResolution() throws {
+        try withIsolatedDefaults { defaults in
+            TranslationTargetLanguage.setExplicitLanguage(
+                "pt",
+                in: defaults,
+                supportedCodes: supportedCodes
+            )
+            TranslationTargetLanguage.setExplicitLanguage(
+                nil,
+                in: defaults,
+                supportedCodes: supportedCodes
+            )
+
+            try expectEqual(
+                TranslationTargetLanguage.resolvedLanguage(
+                    defaults: defaults,
+                    preferredLanguages: ["zh-SG"],
+                    supportedCodes: supportedCodes,
+                    fallback: "en"
+                ),
+                "zh-CN",
+                "clearing the explicit language should restore system resolution"
+            )
+            try expectEqual(
+                defaults.object(forKey: TranslationTargetLanguage.preferenceKey) == nil,
+                true,
+                "clearing the explicit language should remove the stored preference"
+            )
+        }
+    }
+
+    private static func testInvalidStoredLanguageIsIgnoredAndPreserved() throws {
+        try withIsolatedDefaults { defaults in
+            defaults.set("fr", forKey: TranslationTargetLanguage.preferenceKey)
+
+            try expectEqual(
+                TranslationTargetLanguage.explicitLanguage(
+                    in: defaults,
+                    supportedCodes: supportedCodes
+                ),
+                nil,
+                "an unsupported stored language should be ignored"
+            )
+            try expectEqual(
+                TranslationTargetLanguage.resolvedLanguage(
+                    defaults: defaults,
+                    preferredLanguages: ["pt-BR"],
+                    supportedCodes: supportedCodes,
+                    fallback: "en"
+                ),
+                "pt",
+                "an unsupported stored language should defer to system resolution"
+            )
+            try expectEqual(
+                defaults.string(forKey: TranslationTargetLanguage.preferenceKey),
+                "fr",
+                "an unsupported stored language should not be deleted"
+            )
+        }
+    }
+
+    private static func expectSystemLanguage(_ preferredLanguage: String, equals expected: String) throws {
+        try expectEqual(
+            TranslationTargetLanguage.systemLanguage(
+                preferredLanguages: [preferredLanguage],
+                supportedCodes: supportedCodes,
+                fallback: "en"
+            ),
+            expected,
+            "system language \(preferredLanguage)"
+        )
+    }
+
+    private static func withIsolatedDefaults(_ body: (UserDefaults) throws -> Void) throws {
+        let suiteName = "TranslationTargetLanguageTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw TestFailure(description: "could not create isolated UserDefaults")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        try body(defaults)
+    }
+}

--- a/Tests/TranslationTargetLanguageTests.swift
+++ b/Tests/TranslationTargetLanguageTests.swift
@@ -24,6 +24,7 @@ private enum TranslationTargetLanguageTests {
     static func main() {
         do {
             try testSystemLanguageResolution()
+            try testDefaultFallback()
             try testExplicitLanguageOverridesSystemLanguage()
             try testClearingExplicitLanguageRestoresSystemResolution()
             try testInvalidStoredLanguageIsIgnoredAndPreserved()
@@ -65,6 +66,29 @@ private enum TranslationTargetLanguageTests {
             "en",
             "empty preferred languages should use the fallback"
         )
+    }
+
+    private static func testDefaultFallback() throws {
+        try expectEqual(
+            TranslationTargetLanguage.systemLanguage(
+                preferredLanguages: ["fr-FR"],
+                supportedCodes: supportedCodes
+            ),
+            "en",
+            "system language should default to the English fallback"
+        )
+
+        try withIsolatedDefaults { defaults in
+            try expectEqual(
+                TranslationTargetLanguage.resolvedLanguage(
+                    defaults: defaults,
+                    preferredLanguages: ["fr-FR"],
+                    supportedCodes: supportedCodes
+                ),
+                "en",
+                "resolved language should default to the English fallback"
+            )
+        }
     }
 
     private static func testExplicitLanguageOverridesSystemLanguage() throws {

--- a/docs/qa-feature-stories/translation/target-language.md
+++ b/docs/qa-feature-stories/translation/target-language.md
@@ -1,0 +1,68 @@
+# QA 功能说明: 截图翻译目标语言
+
+## 功能标识
+
+- 功能域: `translation`
+- 功能点: `target-language`
+- 最近更新: `codex/translation-target-language-pr`
+
+## 背景
+
+截图 OCR 和原位翻译需要一个明确的目标语言。用户希望默认使用 macOS 系统语言，同时可在设置页固定选择某种目标语言。
+
+## 当前确认行为
+
+- 翻译调用通过 `TranslationService.translateBatch(texts:targetLang:completion:)` 进入 Google Translate 或 Apple Translation。
+- OCR 结果窗口和截图原位翻译都会传入目标语言代码。
+- 偏好使用 `UserDefaults` 键 `translateTargetLang` 保存。
+
+## 本次变更
+
+- 设置的 Capture → Translation 区域新增 `Target language:` popup。
+- popup 第一项是 `Follow System`；选择它会删除显式偏好。
+- 选择任一具体语言会保存对应语言代码，之后翻译使用该固定目标。
+- 未保存显式偏好时，系统读取第一项 macOS 首选语言。
+- `zh-Hans`、`zh-SG` 与 `zh` 解析为 `zh-CN`；`zh-Hant`、`zh-TW`、`zh-HK`、`zh-MO` 解析为 `zh-TW`。
+- 不在支持列表中的系统语言会回退到 `en`。
+- 设置窗口重开时会刷新 popup，反映 OCR 或截图翻译控件后来保存的显式语言。
+
+## 触发入口
+
+- 设置入口：Capture tab 的 Translation 区域。
+- 翻译入口：OCR 结果窗口的翻译操作、截图原位翻译，以及 `macshot://ocr-translate`。
+- 系统条件：macOS 15+ 可显示 Apple Translation Engine 与语言包入口；所有支持的 macOS 版本均可选择目标语言并使用 Google Provider。
+
+## 主流程
+
+1. 用户打开设置，在 Target language 中选择 `Follow System` 或具体语言。
+2. 选择具体语言时，应用将语言代码写入 `translateTargetLang`；选择 Follow System 时删除该键。
+3. 发起 OCR 或原位翻译时，应用先读取有效显式偏好；没有时解析 macOS 首选语言。
+4. 应用将解析得到的语言代码传给当前翻译 Provider，并显示对应译文。
+
+## 分支与异常流程
+
+- macOS 首选语言为空或不被支持：使用英语 `en`。
+- 已保存的语言代码不在支持列表：忽略该值，按系统语言解析；读取时不删除旧值。
+- Apple Translation 不可用或当前语言包不可用：用户仍可选择目标语言，应用按现有 Provider 逻辑使用 Google Translate 或显示既有错误。
+- OCR 未识别到文本或 Provider 请求失败：沿用既有错误提示，不创建翻译覆盖层。
+
+## 数据与接口影响
+
+- 本地数据：继续使用 `UserDefaults.translateTargetLang`；没有新增数据库、迁移或服务器配置。
+- 外部服务：Google Translate 的 `tl` 参数和 Apple Translation 的 target locale 接收解析后的目标语言代码。
+- 兼容性：原先已保存且在支持列表中的语言代码继续有效。
+
+## 前端/App 细节
+
+- 页面/组件：`SettingsWindowController.makeCaptureTabView()`、`OCRResultController`、`OverlayView`。
+- 用户可见状态：具体语言被选中时显示该语言；无有效显式偏好时显示 `Follow System`。
+- 本地状态：`translationTargetLanguagePopup` 在 `loadSettings()` 时刷新。
+- 权限：本次未改变 Screen Recording、网络或文件权限。
+
+## 测试关注点
+
+- 首选语言为 `zh-Hans`、`zh-Hant`、`zh-HK`、`zh-SG`、`pt-BR`、不支持语言时的解析结果。
+- 固定语言、切回 Follow System、无效旧偏好三种 `UserDefaults` 状态。
+- macOS 12–14：目标语言 popup 可见，Apple Engine 控件不可见。
+- macOS 15+：目标语言 popup、Apple Engine 和语言包入口均可见。
+- OCR 窗口或原位翻译修改语言后，再打开设置页时 selection 与显式偏好一致。

--- a/docs/reviews/pre-pr-codex-translation-target-language-pr.md
+++ b/docs/reviews/pre-pr-codex-translation-target-language-pr.md
@@ -1,0 +1,143 @@
+# Engineering Review — diff upstream/main...codex/translation-target-language-pr
+
+## 0. 概览
+
+| 项 | 值 |
+|---|---|
+| 评审对象 | diff-range |
+| 目标 | `8ce1a37...77b244a` |
+| 规模 | 49 files, +640/-9 |
+| 可合并 / 接入状态 | 基点 `upstream/main` 是当前分支祖先；无冲突 |
+| CI / 门禁 | 无仓库内 GitHub Actions 工作流；本地 Release/Debug 构建与独立语言解析测试通过 |
+| 评审门 | **PASS** (0 P1) |
+
+## 1. 变更性质
+
+- ✏️ 翻译目标默认行为：没有显式偏好时，从固定语言改为解析第一项 macOS 首选语言。
+- 🆕 设置能力：Capture 设置新增目标语言和 `Follow System` 选项。
+- 🆕 语言解析单元：新增 `TranslationTargetLanguage`，隔离 locale 归一化和偏好读写。
+- ✏️ 本地化：为 40 个 `Localizable.strings` 增加两条设置文案。
+
+## 2. 产品 / 体验影响
+
+| 功能 | 旧体验 | 新体验 | 回退风险 |
+|---|---|---|---|
+| 截图翻译目标语言 | 目标语言不能在设置中选择 | 默认跟随系统，用户可选择固定目标语言 | 系统语言不在列表中时回退英语 |
+
+```mermaid
+flowchart LR
+  A["打开 Capture 设置"] --> B["选择 Follow System 或目标语言"]
+  B --> C["截图并执行翻译"]
+  C --> D["显示所选目标语言的译文"]
+  B --> E["Follow System"]
+  E --> F["读取 macOS 首选语言"]
+```
+
+## 3. 功能详述
+
+- `TranslationTargetLanguage` 将 `Locale.preferredLanguages.first` 归一化；中文脚本和地区映射为 `zh-CN` 或 `zh-TW`，不支持的语言回退 `en`。
+- `translateTargetLang` 有效时是显式偏好；`Follow System` 删除该键，让后续读取继续跟随系统语言。
+- `SettingsWindowController` 在每次 `loadSettings()` 刷新 popup，避免 OCR/覆盖层改变显式语言后出现陈旧选择。
+- `OCRResultController` 和 `TranslationOverlay` 均调用 `TranslationService.translateBatch(texts:targetLang:)`，目标代码被转交给 Google 或 Apple Provider。
+
+关键链路回归检查：未触达登录、网络鉴权、支付、异步队列或持久化数据库；翻译调用链的输入参数由既有 UI 传递，默认值变化是产品预期行为。
+
+## 4. API / 路由
+
+N/A — 未新增或修改 HTTP/API 路由。Google Translate 非官方 endpoint 和 Apple Translation 框架调用均保持既有接口。
+
+## 5. 数据表 / 集合
+
+N/A — 无数据库、集合、schema 或迁移变更。唯一持久化数据为现有 `UserDefaults` 键 `translateTargetLang`。
+
+## 6. 链路图
+
+```mermaid
+sequenceDiagram
+  participant S as "SettingsWindowController"
+  participant T as "TranslationService"
+  participant P as "UserDefaults"
+  participant O as "OCR/Overlay caller"
+  participant R as "Translation provider"
+  S->>T: "explicitTargetLanguage = code or nil"
+  T->>P: "write or remove translateTargetLang"
+  O->>T: "targetLanguage / translateBatch"
+  T->>P: "read explicit preference"
+  T->>R: "translateBatch with resolved target"
+```
+
+## 7. 依赖的外部服务 / 第三方
+
+- Google Translate endpoint：既有依赖，目标语言参数继续通过 `tl` 传递。
+- Apple Translation：既有 macOS 15+ 框架依赖；仅在系统可用时显示 Engine 及语言包入口。
+- 无新增 SDK、服务或凭证。
+
+## 8. 新增依赖、库与内部模块/组件
+
+- 新外部库：无。
+- 新增内部模块：`macshot/Services/TranslationTargetLanguage.swift`，只依赖 Foundation。
+- 新增 UI 控件：`SettingsWindowController` 的目标语言 popup。
+
+## 9. 改动模块地图
+
+| 模块 | 作用 |
+|---|---|
+| `macshot/Services` | 解析系统 locale、存储显式偏好、将目标语言供翻译服务读取 |
+| `macshot/UI/Windows` | 设置页目标语言控件和刷新逻辑 |
+| `macshot/UI/Overlay`、`AppDelegate` | 更新默认目标语言语义说明 |
+| `macshot/*.lproj` | 设置文案本地化 |
+| `Tests` | 独立语言解析与偏好读写测试 |
+
+## 10. 架构合规
+
+| 检查项 | 结果 |
+|---|---|
+| AppKit UI 在控制器中构建 | ✅ 沿用 `SettingsWindowController` 的现有模式 |
+| 偏好持久化 | ✅ 复用既有 `UserDefaults` 键并集中校验 |
+| 文件同步 Xcode 组 | ✅ 新 Swift 文件位于 `macshot/` 下，无需手改 project 文件 |
+| macOS 12.3 兼容 | ✅ 目标语言 popup 不依赖 Apple Translation；Apple 专属 UI 保持可用性检查 |
+
+## 11. 后端可靠性四维度
+
+N/A — 这是单机 AppKit 应用中的本地偏好和翻译请求变更，不涉及服务副本、数据库状态机、消息队列或长任务调度。
+
+## 12. 安全专项
+
+- 偏好值只接受 `availableLanguages` 白名单中的代码；无效已有值被忽略且不在读取时改写。
+- 无新密钥、用户身份、授权边界、命令执行或不可信输入解释逻辑。
+- Google endpoint 仍为既有外部依赖；本次没有扩大其请求数据范围。
+
+## 13. 前端性能 / 兼容性
+
+- popup 构建遍历约 30 个语言项，仅在设置 UI 初始化时执行。
+- `loadSettings()` 只对一个 popup 做线性项匹配，开销可忽略。
+- macOS 12–14 可选目标语言并使用 Google Provider；macOS 15+ 保留 Apple Provider 与语言包入口。
+
+## 14. 测试覆盖
+
+- `Tests/TranslationTargetLanguageTests.swift` 覆盖 locale 分隔符、中文简繁映射、首选语言回退、显式偏好、清除偏好及无效旧值。
+- `swiftc macshot/Services/TranslationTargetLanguage.swift Tests/TranslationTargetLanguageTests.swift -o /tmp/macshot-translation-target-tests && /tmp/macshot-translation-target-tests`：通过。
+- Debug 和 Release `xcodebuild`：通过。
+- 40 个 `Localizable.strings` 中两条新增 key 均存在且 `plutil -lint` 通过。
+- 仍缺少 AppKit popup 交互的自动化 UI 测试，以及 provider 参数转交的端到端测试；当前由构建和调用链审阅覆盖。
+
+## 15. 可观测性
+
+N/A — 本次未新增异步服务、遥测事件或错误吞没路径；翻译 provider 的既有错误回调保持不变。
+
+## 16. 冲突状态
+
+无。`upstream/main` 是该分支的祖先，当前没有待解决合并冲突。
+
+## 17. 问题清单
+
+| # | 级别 | 位置 | 问题 | 本对象引入? | 建议修法 | 来源 |
+|---|---|---|---|---|---|---|
+| 1 | 提示 | `SettingsWindowController.swift` | 未提供自动化 AppKit popup 交互测试 | 是 | 后续如引入 UI test target，覆盖 macOS 12–14 与 15+ 可见性及 Follow System 切换 | Codex |
+| 2 | 提示 | `TranslationService.swift` | 未提供 provider 参数转交的集成测试 | 是 | 后续可通过注入 provider transport 进行测试 | Codex |
+
+## 18. 结论与建议
+
+- Gate：**PASS**。
+- P1/P2：无。
+- 建议：可以合并；保留两项自动化测试作为后续质量改进，不阻塞本 PR。

--- a/docs/superpowers/plans/2026-07-09-translation-target-language.md
+++ b/docs/superpowers/plans/2026-07-09-translation-target-language.md
@@ -1,0 +1,187 @@
+# Translation Target Language Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent translation target-language setting whose default follows the first macOS preferred language.
+
+**Architecture:** Put locale normalization and UserDefaults preference handling in a small Foundation-only helper so it can be tested independently of AppKit and the macOS Translation framework. `TranslationService` exposes resolved and explicit target-language APIs, while `SettingsWindowController` renders `Follow System` plus the shared language list.
+
+**Tech Stack:** Swift 5, Foundation, AppKit, UserDefaults, Xcode/macOS, a standalone Swift test executable.
+
+---
+
+### Task 1: Test and implement target-language resolution
+
+**Files:**
+- Create: `Tests/TranslationTargetLanguageTests.swift`
+- Create: `macshot/Services/TranslationTargetLanguage.swift`
+
+- [ ] **Step 1: Write the failing test runner**
+
+Create a Foundation-only executable test with an `@main` runner that checks:
+
+```swift
+expect(resolve(["en-US"]) == "en")
+expect(resolve(["pt-BR"]) == "pt")
+expect(resolve(["zh-Hans-US"]) == "zh-CN")
+expect(resolve(["zh-SG"]) == "zh-CN")
+expect(resolve(["zh"]) == "zh-CN")
+expect(resolve(["zh-Hant-HK"]) == "zh-TW")
+expect(resolve(["zh-HK"]) == "zh-TW")
+expect(resolve(["zh-MO"]) == "zh-TW")
+expect(resolve(["xx-YY"]) == "en")
+expect(resolve([]) == "en")
+```
+
+Use a temporary `UserDefaults` suite to verify explicit values override the system, clearing the explicit value restores system resolution, and invalid stored values are ignored without being removed.
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+swiftc Tests/TranslationTargetLanguageTests.swift -o /tmp/macshot-translation-target-tests
+```
+
+Expected: compilation fails because `TranslationTargetLanguage` does not exist.
+
+- [ ] **Step 3: Add the minimal Foundation helper**
+
+Create `TranslationTargetLanguage` with:
+
+```swift
+enum TranslationTargetLanguage {
+    static let preferenceKey = "translateTargetLang"
+
+    static func explicitLanguage(
+        in defaults: UserDefaults,
+        supportedCodes: Set<String>
+    ) -> String?
+
+    static func setExplicitLanguage(
+        _ code: String?,
+        in defaults: UserDefaults,
+        supportedCodes: Set<String>
+    )
+
+    static func resolvedLanguage(
+        defaults: UserDefaults,
+        preferredLanguages: [String],
+        supportedCodes: Set<String>,
+        fallback: String = "en"
+    ) -> String
+
+    static func systemLanguage(
+        preferredLanguages: [String],
+        supportedCodes: Set<String>,
+        fallback: String = "en"
+    ) -> String
+}
+```
+
+Normalize `_` to `-`, map Chinese scripts/regions explicitly, map all other locale variants to their lowercase base code, and use only the first preferred language before falling back.
+
+- [ ] **Step 4: Run the test to verify GREEN**
+
+Run:
+
+```bash
+swiftc macshot/Services/TranslationTargetLanguage.swift Tests/TranslationTargetLanguageTests.swift -o /tmp/macshot-translation-target-tests && /tmp/macshot-translation-target-tests
+```
+
+Expected: exit 0 and `TranslationTargetLanguageTests: PASS`.
+
+- [ ] **Step 5: Commit the resolver and tests**
+
+```bash
+git add macshot/Services/TranslationTargetLanguage.swift Tests/TranslationTargetLanguageTests.swift
+git commit -m "Add translation target language resolution"
+```
+
+### Task 2: Restore configurable translation behavior
+
+**Files:**
+- Modify: `macshot/Services/TranslationService.swift`
+- Modify: `macshot/AppDelegate.swift`
+- Modify: `macshot/UI/Overlay/OverlayView.swift`
+- Modify: `macshot/UI/Overlay/OverlayWindowController.swift`
+
+- [ ] **Step 1: Wire preference APIs into `TranslationService`**
+
+Add a supported-code set derived from `availableLanguages`, expose `explicitTargetLanguage: String?`, and implement `targetLanguage` as a resolved concrete code using `Locale.preferredLanguages`. Keep the existing setter behavior for screenshot/OCR language pickers by storing an explicit selection.
+
+- [ ] **Step 2: Make batch translation honor its argument**
+
+Change `translateBatch(texts:targetLang:completion:)` to pass `targetLang` to Apple or Google translation instead of replacing it with `zh-CN`.
+
+- [ ] **Step 3: Remove stale fixed-language comments**
+
+Update comments in the four files so they describe the configured/resolved target language.
+
+- [ ] **Step 4: Re-run resolver tests**
+
+Run the Task 1 GREEN command. Expected: PASS.
+
+- [ ] **Step 5: Commit service integration**
+
+```bash
+git add macshot/Services/TranslationService.swift macshot/AppDelegate.swift macshot/UI/Overlay/OverlayView.swift macshot/UI/Overlay/OverlayWindowController.swift
+git commit -m "Use configurable translation target language"
+```
+
+### Task 3: Add the target-language setting
+
+**Files:**
+- Modify: `macshot/UI/Windows/SettingsWindowController.swift`
+
+- [ ] **Step 1: Add the popup to the Translation section**
+
+Always render the Translation section. Add a popup whose first item is localized `Follow System` with an empty represented code, followed by `TranslationService.availableLanguages`. Select the explicit stored language when valid; otherwise select `Follow System`.
+
+- [ ] **Step 2: Preserve Apple-only controls**
+
+Show the engine selector, provider note, and language-pack link only when Apple Translation is available. The target popup remains visible on older macOS versions because Google Translate is still available.
+
+- [ ] **Step 3: Persist changes**
+
+Add `translationTargetLanguageChanged(_:)`. Set `TranslationService.explicitTargetLanguage` to the represented language code, or `nil` for `Follow System`.
+
+- [ ] **Step 4: Build the app**
+
+Run:
+
+```bash
+xcodebuild -scheme macshot -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 5: Commit the settings UI**
+
+```bash
+git add macshot/UI/Windows/SettingsWindowController.swift
+git commit -m "Add translation target language setting"
+```
+
+### Task 4: Final verification and publish
+
+**Files:**
+- Verify all files changed by Tasks 1-3.
+
+- [ ] **Step 1: Run tests and build from a clean state**
+
+Run the resolver test command, then `xcodebuild clean build` with signing disabled. Both must exit 0.
+
+- [ ] **Step 2: Inspect the final diff**
+
+Run `git diff upstream/main...HEAD --check` and inspect `git diff upstream/main...HEAD` for unrelated changes. Keep the existing untracked `MacShot.dmg` untouched.
+
+Inspect the settings implementation to confirm the popup selects `Follow System` when there is no valid explicit preference and that every language item carries its language code as `representedObject`.
+
+- [ ] **Step 3: Push directly to the fork**
+
+```bash
+git push origin main
+```
+
+Expected: `origin/main` advances without creating a pull request.

--- a/docs/superpowers/specs/2026-07-09-translation-target-language-design.md
+++ b/docs/superpowers/specs/2026-07-09-translation-target-language-design.md
@@ -1,0 +1,31 @@
+# Translation Target Language Setting
+
+## Goal
+
+Replace the hardcoded Simplified Chinese translation target with a user-configurable setting in the Capture settings tab. New installations follow the first macOS preferred language by default.
+
+## Behavior
+
+- The Translation section contains a Target language popup.
+- The first option is `Follow System`; the remaining options reuse `TranslationService.availableLanguages`.
+- With `Follow System` selected, translation resolves the first macOS preferred language each time it is needed.
+- Chinese script identifiers map to the existing service codes: Simplified Chinese to `zh-CN` and Traditional Chinese to `zh-TW`. Region-only identifiers map `zh-HK` and `zh-MO` to Traditional Chinese, while `zh-SG` and bare `zh` map to Simplified Chinese.
+- Other locale variants match their base language code, for example `en-US` to `en` and `pt-BR` to `pt`.
+- Unsupported or unavailable system languages fall back to English.
+- Selecting an explicit target persists its language code. Selecting `Follow System` removes the explicit preference so later macOS language changes take effect.
+- Existing explicit `translateTargetLang` values remain valid. Invalid stored values behave as `Follow System` without mutating defaults during a read.
+
+## Implementation
+
+- `TranslationService` owns preference parsing and system-language resolution.
+- `targetLanguage` returns a concrete supported language code for translation callers.
+- A separate optional preference API distinguishes an explicit selection from `Follow System` for the settings UI.
+- `translateBatch` honors its target-language argument again instead of replacing it with a constant.
+- `SettingsWindowController` builds the popup from the shared language list and writes changes through `TranslationService`.
+- The Translation section is shown on every supported macOS version. The engine and language-pack controls remain conditional on Apple Translation availability; the target-language popup is always available because Google Translate is the fallback engine.
+
+## Validation
+
+- Unit tests cover explicit preference persistence, clearing back to system mode, locale normalization, Chinese script mapping, unsupported-language fallback, and invalid stored values.
+- A full macOS build verifies the AppKit settings integration.
+- Manual inspection verifies the popup selection and represented language codes.

--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -1020,9 +1020,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         startCapture(fromMenu: fromMenu)
     }
 
-    /// Region-capture → OCR → translate → draw the translation in place over the
+    /// Region-capture -> OCR -> translate -> draw the translation in place over the
     /// original text on the screenshot (macshot://ocr-translate). `target` nil
-    /// uses the saved default language.
+    /// uses the fixed Simplified Chinese target.
     private func beginCaptureTranslate(target: String?, fromMenu: Bool) {
         guard canStartCapture else { return }
         pendingTranslateOverlayMode = true
@@ -2210,7 +2210,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         case "quick-capture":       quickCapture()
         case "ocr":                 captureOCR()
         case "ocr-translate":
-            // ?target=<lang code, e.g. zh-CN>; omitted → saved default language.
+            // ?target=<lang code, e.g. zh-CN>; omitted uses the fixed Simplified Chinese target.
             let target = URLComponents(url: url, resolvingAgainstBaseURL: false)?
                 .queryItems?.first(where: { $0.name == "target" })?.value?
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -1022,7 +1022,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     /// Region-capture -> OCR -> translate -> draw the translation in place over the
     /// original text on the screenshot (macshot://ocr-translate). `target` nil
-    /// uses the fixed Simplified Chinese target.
+    /// uses the configured target resolved by TranslationService.
     private func beginCaptureTranslate(target: String?, fromMenu: Bool) {
         guard canStartCapture else { return }
         pendingTranslateOverlayMode = true
@@ -2210,7 +2210,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         case "quick-capture":       quickCapture()
         case "ocr":                 captureOCR()
         case "ocr-translate":
-            // ?target=<lang code, e.g. zh-CN>; omitted uses the fixed Simplified Chinese target.
+            // ?target=<lang code, e.g. zh-CN>; omitted uses the configured target.
             let target = URLComponents(url: url, resolvingAgainstBaseURL: false)?
                 .queryItems?.first(where: { $0.name == "target" })?.value?
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/macshot/Services/TranslationService.swift
+++ b/macshot/Services/TranslationService.swift
@@ -11,6 +11,8 @@ enum TranslationProvider: String {
 
 enum TranslationService {
 
+    private static let fixedTargetLanguage = "zh-CN"
+
     // MARK: - Provider
 
     static var provider: TranslationProvider {
@@ -35,8 +37,8 @@ enum TranslationService {
     // MARK: - Target language
 
     static var targetLanguage: String {
-        get { UserDefaults.standard.string(forKey: "translateTargetLang") ?? "en" }
-        set { UserDefaults.standard.set(newValue, forKey: "translateTargetLang") }
+        get { fixedTargetLanguage }
+        set { UserDefaults.standard.set(fixedTargetLanguage, forKey: "translateTargetLang") }
     }
 
     static let availableLanguages: [(code: String, name: String)] = [
@@ -140,10 +142,11 @@ enum TranslationService {
     // MARK: - Translate a batch of strings (auto-detect source)
 
     /// Translates multiple strings using the selected provider.
+    /// The target language is intentionally pinned to Simplified Chinese.
     /// Calls completion on the main queue.
     static func translateBatch(
         texts: [String],
-        targetLang: String,
+        targetLang _: String,
         completion: @escaping (Result<[String], Error>) -> Void
     ) {
         guard !texts.isEmpty else {
@@ -152,9 +155,9 @@ enum TranslationService {
         }
 
         if #available(macOS 15.0, *), provider == .apple {
-            translateBatchApple(texts: texts, targetLang: targetLang, completion: completion)
+            translateBatchApple(texts: texts, targetLang: fixedTargetLanguage, completion: completion)
         } else {
-            translateBatchGoogle(texts: texts, targetLang: targetLang, completion: completion)
+            translateBatchGoogle(texts: texts, targetLang: fixedTargetLanguage, completion: completion)
         }
     }
 

--- a/macshot/Services/TranslationService.swift
+++ b/macshot/Services/TranslationService.swift
@@ -11,8 +11,6 @@ enum TranslationProvider: String {
 
 enum TranslationService {
 
-    private static let fixedTargetLanguage = "zh-CN"
-
     // MARK: - Provider
 
     static var provider: TranslationProvider {
@@ -36,9 +34,31 @@ enum TranslationService {
 
     // MARK: - Target language
 
+    static var explicitTargetLanguage: String? {
+        get {
+            TranslationTargetLanguage.explicitLanguage(
+                in: UserDefaults.standard,
+                supportedCodes: supportedLanguageCodes
+            )
+        }
+        set {
+            TranslationTargetLanguage.setExplicitLanguage(
+                newValue,
+                in: UserDefaults.standard,
+                supportedCodes: supportedLanguageCodes
+            )
+        }
+    }
+
     static var targetLanguage: String {
-        get { fixedTargetLanguage }
-        set { UserDefaults.standard.set(fixedTargetLanguage, forKey: "translateTargetLang") }
+        get {
+            TranslationTargetLanguage.resolvedLanguage(
+                defaults: UserDefaults.standard,
+                preferredLanguages: Locale.preferredLanguages,
+                supportedCodes: supportedLanguageCodes
+            )
+        }
+        set { explicitTargetLanguage = newValue }
     }
 
     static let availableLanguages: [(code: String, name: String)] = [
@@ -73,6 +93,8 @@ enum TranslationService {
         ("th", "Thai"),
         ("vi", "Vietnamese"),
     ]
+
+    private static let supportedLanguageCodes: Set<String> = Set(availableLanguages.map { $0.code })
 
     /// Check which languages are available for Apple Translation.
     /// Returns a dict of language code → installed status.
@@ -142,11 +164,10 @@ enum TranslationService {
     // MARK: - Translate a batch of strings (auto-detect source)
 
     /// Translates multiple strings using the selected provider.
-    /// The target language is intentionally pinned to Simplified Chinese.
     /// Calls completion on the main queue.
     static func translateBatch(
         texts: [String],
-        targetLang _: String,
+        targetLang: String,
         completion: @escaping (Result<[String], Error>) -> Void
     ) {
         guard !texts.isEmpty else {
@@ -155,9 +176,9 @@ enum TranslationService {
         }
 
         if #available(macOS 15.0, *), provider == .apple {
-            translateBatchApple(texts: texts, targetLang: fixedTargetLanguage, completion: completion)
+            translateBatchApple(texts: texts, targetLang: targetLang, completion: completion)
         } else {
-            translateBatchGoogle(texts: texts, targetLang: fixedTargetLanguage, completion: completion)
+            translateBatchGoogle(texts: texts, targetLang: targetLang, completion: completion)
         }
     }
 

--- a/macshot/Services/TranslationTargetLanguage.swift
+++ b/macshot/Services/TranslationTargetLanguage.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+enum TranslationTargetLanguage {
+    static let preferenceKey = "translateTargetLang"
+
+    static func explicitLanguage(
+        in defaults: UserDefaults,
+        supportedCodes: Set<String>
+    ) -> String? {
+        guard
+            let language = defaults.string(forKey: preferenceKey),
+            supportedCodes.contains(language)
+        else {
+            return nil
+        }
+
+        return language
+    }
+
+    static func setExplicitLanguage(
+        _ language: String?,
+        in defaults: UserDefaults,
+        supportedCodes: Set<String>
+    ) {
+        guard let language else {
+            defaults.removeObject(forKey: preferenceKey)
+            return
+        }
+
+        guard supportedCodes.contains(language) else { return }
+        defaults.set(language, forKey: preferenceKey)
+    }
+
+    static func resolvedLanguage(
+        defaults: UserDefaults,
+        preferredLanguages: [String],
+        supportedCodes: Set<String>,
+        fallback: String
+    ) -> String {
+        explicitLanguage(in: defaults, supportedCodes: supportedCodes)
+            ?? systemLanguage(
+                preferredLanguages: preferredLanguages,
+                supportedCodes: supportedCodes,
+                fallback: fallback
+            )
+    }
+
+    static func systemLanguage(
+        preferredLanguages: [String],
+        supportedCodes: Set<String>,
+        fallback: String
+    ) -> String {
+        guard let preferredLanguage = preferredLanguages.first else { return fallback }
+
+        let components = preferredLanguage
+            .replacingOccurrences(of: "_", with: "-")
+            .split(separator: "-")
+            .map { $0.lowercased() }
+        guard let baseCode = components.first else { return fallback }
+
+        let language: String
+        if baseCode == "zh" {
+            let subtags = Set(components.dropFirst())
+            if subtags.contains("hant") {
+                language = "zh-TW"
+            } else if subtags.contains("hans") {
+                language = "zh-CN"
+            } else if !subtags.isDisjoint(with: ["tw", "hk", "mo"]) {
+                language = "zh-TW"
+            } else {
+                language = "zh-CN"
+            }
+        } else {
+            language = baseCode
+        }
+
+        return supportedCodes.contains(language) ? language : fallback
+    }
+}

--- a/macshot/Services/TranslationTargetLanguage.swift
+++ b/macshot/Services/TranslationTargetLanguage.swift
@@ -35,7 +35,7 @@ enum TranslationTargetLanguage {
         defaults: UserDefaults,
         preferredLanguages: [String],
         supportedCodes: Set<String>,
-        fallback: String
+        fallback: String = "en"
     ) -> String {
         explicitLanguage(in: defaults, supportedCodes: supportedCodes)
             ?? systemLanguage(
@@ -48,7 +48,7 @@ enum TranslationTargetLanguage {
     static func systemLanguage(
         preferredLanguages: [String],
         supportedCodes: Set<String>,
-        fallback: String
+        fallback: String = "en"
     ) -> String {
         guard let preferredLanguage = preferredLanguages.first else { return fallback }
 

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -724,7 +724,7 @@ class OverlayView: NSView {
     var autoEnterRecordingMode: Bool = false  // set by "Record Screen" menu — enters recording mode after selection
     var autoOCRMode: Bool = false  // set by "Capture OCR & QR" menu — triggers OCR immediately after selection
     var autoTranslateOverlayMode: Bool = false  // set by macshot://ocr-translate — OCR + translate + overlay after selection
-    var autoTranslateOverlayLang: String?  // target language for autoTranslateOverlayMode (nil = saved default)
+    var autoTranslateOverlayLang: String?  // target language for autoTranslateOverlayMode (nil = fixed Simplified Chinese)
     var autoQuickSaveMode: Bool = false  // set by "Quick Capture" menu — quick-saves immediately after selection
     var autoScrollCaptureMode: Bool = false  // set by "Scroll Capture" menu — triggers scroll capture immediately after selection
     var autoConfirmMode: Bool = false  // set by "Add Capture" — auto-confirms selection (no toolbars, no save)

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -724,7 +724,7 @@ class OverlayView: NSView {
     var autoEnterRecordingMode: Bool = false  // set by "Record Screen" menu — enters recording mode after selection
     var autoOCRMode: Bool = false  // set by "Capture OCR & QR" menu — triggers OCR immediately after selection
     var autoTranslateOverlayMode: Bool = false  // set by macshot://ocr-translate — OCR + translate + overlay after selection
-    var autoTranslateOverlayLang: String?  // target language for autoTranslateOverlayMode (nil = fixed Simplified Chinese)
+    var autoTranslateOverlayLang: String?  // target language for autoTranslateOverlayMode (nil = configured target)
     var autoQuickSaveMode: Bool = false  // set by "Quick Capture" menu — quick-saves immediately after selection
     var autoScrollCaptureMode: Bool = false  // set by "Scroll Capture" menu — triggers scroll capture immediately after selection
     var autoConfirmMode: Bool = false  // set by "Add Capture" — auto-confirms selection (no toolbars, no save)

--- a/macshot/UI/Overlay/OverlayWindowController.swift
+++ b/macshot/UI/Overlay/OverlayWindowController.swift
@@ -303,7 +303,7 @@ class OverlayWindowController {
 
     /// Set flag so overlay runs OCR + translate + in-place overlay immediately
     /// after the user makes a selection (macshot://ocr-translate). `targetLang`
-    /// nil uses the saved default language.
+    /// nil uses the fixed Simplified Chinese target.
     func setAutoTranslateOverlayMode(targetLang: String?) {
         overlayView?.autoTranslateOverlayMode = true
         overlayView?.autoTranslateOverlayLang = targetLang

--- a/macshot/UI/Overlay/OverlayWindowController.swift
+++ b/macshot/UI/Overlay/OverlayWindowController.swift
@@ -303,7 +303,7 @@ class OverlayWindowController {
 
     /// Set flag so overlay runs OCR + translate + in-place overlay immediately
     /// after the user makes a selection (macshot://ocr-translate). `targetLang`
-    /// nil uses the fixed Simplified Chinese target.
+    /// nil uses the configured target resolved by TranslationService.
     func setAutoTranslateOverlayMode(targetLang: String?) {
         overlayView?.autoTranslateOverlayMode = true
         overlayView?.autoTranslateOverlayLang = targetLang

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -54,6 +54,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     private var savePathField: NSTextField!
     private var saveActionPopup: NSPopUpButton!
     private var ocrActionPopup: NSPopUpButton!
+    private var translationTargetLanguagePopup: NSPopUpButton!
     private var copySoundCheckbox: NSButton!
     // rememberSelectionCheckbox removed — selection is always saved for "Capture Last Area"
     private var rememberToolCheckbox: NSButton!
@@ -994,21 +995,14 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         stack.addArrangedSubview(sectionHeader(L("Translation")))
         stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
 
-        let translationTargetLanguagePopup = NSPopUpButton()
+        translationTargetLanguagePopup = NSPopUpButton()
         translationTargetLanguagePopup.addItem(withTitle: L("Follow System"))
         translationTargetLanguagePopup.lastItem?.representedObject = ""
         for language in TranslationService.availableLanguages {
             translationTargetLanguagePopup.addItem(withTitle: language.name)
             translationTargetLanguagePopup.lastItem?.representedObject = language.code
         }
-        if let explicitCode = TranslationService.explicitTargetLanguage,
-           let index = translationTargetLanguagePopup.itemArray.firstIndex(where: {
-               $0.representedObject as? String == explicitCode
-           }) {
-            translationTargetLanguagePopup.selectItem(at: index)
-        } else {
-            translationTargetLanguagePopup.selectItem(at: 0)
-        }
+        refreshTranslationTargetLanguageSelection()
         translationTargetLanguagePopup.target = self
         translationTargetLanguagePopup.action = #selector(translationTargetLanguageChanged(_:))
         stack.addArrangedSubview(labeledRow(L("Target language:"), controls: [translationTargetLanguagePopup]))
@@ -2403,6 +2397,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
             UserDefaults.standard.set(legacyAutoCopy ? 0 : 1, forKey: "ocrAction")
         }
         ocrActionPopup.selectItem(at: UserDefaults.standard.integer(forKey: "ocrAction"))
+        refreshTranslationTargetLanguageSelection()
         captureMenuOrder = CaptureMenuItemID.orderedItems()
         rebuildCaptureMenuOrderRows()
 
@@ -3131,6 +3126,18 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     @objc private func translationTargetLanguageChanged(_ sender: NSPopUpButton) {
         guard let code = sender.selectedItem?.representedObject as? String else { return }
         TranslationService.explicitTargetLanguage = code.isEmpty ? nil : code
+    }
+
+    private func refreshTranslationTargetLanguageSelection() {
+        guard let popup = translationTargetLanguagePopup else { return }
+        if let explicitCode = TranslationService.explicitTargetLanguage,
+           let index = popup.itemArray.firstIndex(where: {
+               $0.representedObject as? String == explicitCode
+           }) {
+            popup.selectItem(at: index)
+        } else {
+            popup.selectItem(at: 0)
+        }
     }
 
     @objc private func openTranslationSettings() {

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -991,9 +991,31 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
 
         // ── Translation ──────────────────────────────────────
+        stack.addArrangedSubview(sectionHeader(L("Translation")))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        let translationTargetLanguagePopup = NSPopUpButton()
+        translationTargetLanguagePopup.addItem(withTitle: L("Follow System"))
+        translationTargetLanguagePopup.lastItem?.representedObject = ""
+        for language in TranslationService.availableLanguages {
+            translationTargetLanguagePopup.addItem(withTitle: language.name)
+            translationTargetLanguagePopup.lastItem?.representedObject = language.code
+        }
+        if let explicitCode = TranslationService.explicitTargetLanguage,
+           let index = translationTargetLanguagePopup.itemArray.firstIndex(where: {
+               $0.representedObject as? String == explicitCode
+           }) {
+            translationTargetLanguagePopup.selectItem(at: index)
+        } else {
+            translationTargetLanguagePopup.selectItem(at: 0)
+        }
+        translationTargetLanguagePopup.target = self
+        translationTargetLanguagePopup.action = #selector(translationTargetLanguageChanged(_:))
+        stack.addArrangedSubview(labeledRow(L("Target language:"), controls: [translationTargetLanguagePopup]))
+        stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
+
         if TranslationService.appleTranslationAvailable {
-            stack.addArrangedSubview(sectionHeader(L("Translation")))
-            stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+            stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
 
             let translationProviderPopup = NSPopUpButton()
             translationProviderPopup.addItems(withTitles: [
@@ -3104,6 +3126,11 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
 
     @objc private func translationProviderChanged(_ sender: NSPopUpButton) {
         TranslationService.provider = sender.indexOfSelectedItem == 0 ? .apple : .google
+    }
+
+    @objc private func translationTargetLanguageChanged(_ sender: NSPopUpButton) {
+        guard let code = sender.selectedItem?.representedObject as? String else { return }
+        TranslationService.explicitTargetLanguage = code.isEmpty ? nil : code
     }
 
     @objc private func openTranslationSettings() {

--- a/macshot/ar.lproj/Localizable.strings
+++ b/macshot/ar.lproj/Localizable.strings
@@ -528,6 +528,8 @@
 "Stop Recording" = "إيقاف التسجيل";
 "Pause" = "إيقاف مؤقت";
 "Resume" = "استئناف";
+"Follow System" = "اتباع لغة النظام";
+"Target language:" = "اللغة المستهدفة:";
 "Engine:" = "المحرك:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (على الجهاز)";

--- a/macshot/bg.lproj/Localizable.strings
+++ b/macshot/bg.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "Stop Recording" = "Спиране на записа";
 "Pause" = "Пауза";
 "Resume" = "Продължаване";
+"Follow System" = "Използвай езика на системата";
+"Target language:" = "Целеви език:";
 "Engine:" = "Двигател:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (на устройството)";

--- a/macshot/bn.lproj/Localizable.strings
+++ b/macshot/bn.lproj/Localizable.strings
@@ -536,6 +536,8 @@
 "Stop Recording" = "রেকর্ডিং বন্ধ করুন";
 "Pause" = "বিরতি";
 "Resume" = "পুনরায় শুরু";
+"Follow System" = "সিস্টেমের ভাষা ব্যবহার করুন";
+"Target language:" = "লক্ষ্য ভাষা:";
 "Engine:" = "ইঞ্জিন:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (ডিভাইসে)";

--- a/macshot/ca.lproj/Localizable.strings
+++ b/macshot/ca.lproj/Localizable.strings
@@ -528,6 +528,8 @@
 "Stop Recording" = "Aturar gravacio";
 "Pause" = "Pausa";
 "Resume" = "Reprendre";
+"Follow System" = "Utilitza l'idioma del sistema";
+"Target language:" = "Idioma de destinació:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (al dispositiu)";

--- a/macshot/cs.lproj/Localizable.strings
+++ b/macshot/cs.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "Stop Recording" = "Zastavit nahrávání";
 "Pause" = "Pozastavit";
 "Resume" = "Pokračovat";
+"Follow System" = "Použít jazyk systému";
+"Target language:" = "Cílový jazyk:";
 "Engine:" = "Engine:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (na zařízení)";

--- a/macshot/da.lproj/Localizable.strings
+++ b/macshot/da.lproj/Localizable.strings
@@ -534,6 +534,8 @@
 "Stop Recording" = "Stop optagelse";
 "Pause" = "Pause";
 "Resume" = "Genoptag";
+"Follow System" = "F\U00F8lg systemsproget";
+"Target language:" = "M\U00E5lsprog:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (p\U00E5 enheden)";

--- a/macshot/de.lproj/Localizable.strings
+++ b/macshot/de.lproj/Localizable.strings
@@ -524,6 +524,8 @@
 "Stop Recording" = "Aufzeichnung beenden";
 "Pause" = "Pause";
 "Resume" = "Fortsetzen";
+"Follow System" = "Systemsprache verwenden";
+"Target language:" = "Zielsprache:";
 "Engine:" = "Engine:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (auf dem Gerät)";

--- a/macshot/el.lproj/Localizable.strings
+++ b/macshot/el.lproj/Localizable.strings
@@ -536,6 +536,8 @@
 "Stop Recording" = "Διακοπή εγγραφής";
 "Pause" = "Παύση";
 "Resume" = "Συνέχιση";
+"Follow System" = "Ακολούθηση γλώσσας συστήματος";
+"Target language:" = "Γλώσσα προορισμού:";
 "Engine:" = "Μηχανή:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (στη συσκευή)";

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -531,6 +531,8 @@
 "Stop Recording" = "Stop Recording";
 "Pause" = "Pause";
 "Resume" = "Resume";
+"Follow System" = "Follow System";
+"Target language:" = "Target language:";
 "Engine:" = "Engine:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (on-device)";

--- a/macshot/es.lproj/Localizable.strings
+++ b/macshot/es.lproj/Localizable.strings
@@ -523,6 +523,8 @@
 "Stop Recording" = "Detener grabacion";
 "Pause" = "Pausa";
 "Resume" = "Reanudar";
+"Follow System" = "Usar el idioma del sistema";
+"Target language:" = "Idioma de destino:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (en el dispositivo)";

--- a/macshot/fa.lproj/Localizable.strings
+++ b/macshot/fa.lproj/Localizable.strings
@@ -527,6 +527,8 @@
 "Stop Recording" = "توقف ضبط ویدیو";
 "Pause" = "مکث";
 "Resume" = "ادامه";
+"Follow System" = "پیروی از زبان سیستم";
+"Target language:" = "زبان مقصد:";
 "Engine:" = "موتور:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (روی دستگاه)";

--- a/macshot/fi.lproj/Localizable.strings
+++ b/macshot/fi.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "Stop Recording" = "Pys\U00E4yt\U00E4 nauhoitus";
 "Pause" = "Tauko";
 "Resume" = "Jatka";
+"Follow System" = "K\U00E4yt\U00E4 j\U00E4rjestelm\U00E4n kielt\U00E4";
+"Target language:" = "Kohdekieli:";
 "Engine:" = "Moottori:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (laitteessa)";

--- a/macshot/fil.lproj/Localizable.strings
+++ b/macshot/fil.lproj/Localizable.strings
@@ -534,6 +534,8 @@
 "Stop Recording" = "Ihinto ang Pag-record";
 "Pause" = "I-pause";
 "Resume" = "Ipagpatuloy";
+"Follow System" = "Gamitin ang wika ng sistema";
+"Target language:" = "Wikang patutunguhan:";
 "Engine:" = "Engine:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (sa device)";

--- a/macshot/fr.lproj/Localizable.strings
+++ b/macshot/fr.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "Stop Recording" = "Arrêter l'enregistrement";
 "Pause" = "Pause";
 "Resume" = "Reprendre";
+"Follow System" = "Utiliser la langue du système";
+"Target language:" = "Langue cible :";
 "Engine:" = "Moteur :";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (sur l'appareil)";

--- a/macshot/he.lproj/Localizable.strings
+++ b/macshot/he.lproj/Localizable.strings
@@ -527,6 +527,8 @@
 "Stop Recording" = "הפסק הקלטה";
 "Pause" = "השהה";
 "Resume" = "המשך";
+"Follow System" = "לפי שפת המערכת";
+"Target language:" = "שפת יעד:";
 "Engine:" = "מנוע:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (על המכשיר)";

--- a/macshot/hi.lproj/Localizable.strings
+++ b/macshot/hi.lproj/Localizable.strings
@@ -535,6 +535,8 @@
 "Stop Recording" = "रिकॉर्डिंग रोकें";
 "Pause" = "विराम";
 "Resume" = "फिर से शुरू करें";
+"Follow System" = "सिस्टम की भाषा का उपयोग करें";
+"Target language:" = "लक्षित भाषा:";
 "Engine:" = "इंजन:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (डिवाइस पर)";

--- a/macshot/hr.lproj/Localizable.strings
+++ b/macshot/hr.lproj/Localizable.strings
@@ -534,6 +534,8 @@
 "Stop Recording" = "Zaustavi snimanje";
 "Pause" = "Pauziraj";
 "Resume" = "Nastavi";
+"Follow System" = "Koristi jezik sustava";
+"Target language:" = "Ciljni jezik:";
 "Engine:" = "Pokretac:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (na uredaju)";

--- a/macshot/hu.lproj/Localizable.strings
+++ b/macshot/hu.lproj/Localizable.strings
@@ -535,6 +535,8 @@
 "Stop Recording" = "Felvétel leállítása";
 "Pause" = "Szünet";
 "Resume" = "Folytatás";
+"Follow System" = "Rendszernyelv használata";
+"Target language:" = "Célnyelv:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (eszközön)";

--- a/macshot/id.lproj/Localizable.strings
+++ b/macshot/id.lproj/Localizable.strings
@@ -534,6 +534,8 @@
 "Stop Recording" = "Hentikan Rekaman";
 "Pause" = "Jeda";
 "Resume" = "Lanjutkan";
+"Follow System" = "Gunakan bahasa sistem";
+"Target language:" = "Bahasa tujuan:";
 "Engine:" = "Mesin:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (di perangkat)";

--- a/macshot/it.lproj/Localizable.strings
+++ b/macshot/it.lproj/Localizable.strings
@@ -515,6 +515,8 @@
 "Stop Recording" = "Interrompi registrazione";
 "Pause" = "Pausa";
 "Resume" = "Riprendi";
+"Follow System" = "Usa la lingua di sistema";
+"Target language:" = "Lingua di destinazione:";
 "Engine:" = "Motore:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (sul dispositivo)";

--- a/macshot/ja.lproj/Localizable.strings
+++ b/macshot/ja.lproj/Localizable.strings
@@ -523,6 +523,8 @@
 "Stop Recording" = "録画を停止";
 "Pause" = "一時停止";
 "Resume" = "再開";
+"Follow System" = "システム設定に従う";
+"Target language:" = "翻訳先の言語:";
 "Engine:" = "エンジン:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (オンデバイス)";

--- a/macshot/ko.lproj/Localizable.strings
+++ b/macshot/ko.lproj/Localizable.strings
@@ -525,6 +525,8 @@
 "Stop Recording" = "녹화 중지";
 "Pause" = "일시정지";
 "Resume" = "재개";
+"Follow System" = "시스템 언어 사용";
+"Target language:" = "대상 언어:";
 "Engine:" = "엔진:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (기기 내)";

--- a/macshot/ms.lproj/Localizable.strings
+++ b/macshot/ms.lproj/Localizable.strings
@@ -536,6 +536,8 @@
 "Stop Recording" = "Hentikan Rakaman";
 "Pause" = "Jeda";
 "Resume" = "Sambung";
+"Follow System" = "Ikut bahasa sistem";
+"Target language:" = "Bahasa sasaran:";
 "Engine:" = "Enjin:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (pada peranti)";

--- a/macshot/nb.lproj/Localizable.strings
+++ b/macshot/nb.lproj/Localizable.strings
@@ -535,6 +535,8 @@
 "Stop Recording" = "Stopp opptak";
 "Pause" = "Pause";
 "Resume" = "Gjenoppta";
+"Follow System" = "F\U00F8lg systemspr\U00E5ket";
+"Target language:" = "M\U00E5lspr\U00E5k:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (p\U00E5 enheten)";

--- a/macshot/nl.lproj/Localizable.strings
+++ b/macshot/nl.lproj/Localizable.strings
@@ -523,6 +523,8 @@
 "Stop Recording" = "Opname stoppen";
 "Pause" = "Pauzeren";
 "Resume" = "Hervatten";
+"Follow System" = "Systeemtaal gebruiken";
+"Target language:" = "Doeltaal:";
 "Engine:" = "Engine:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (op het apparaat)";

--- a/macshot/pl.lproj/Localizable.strings
+++ b/macshot/pl.lproj/Localizable.strings
@@ -531,6 +531,8 @@
 "Stop Recording" = "Zatrzymaj nagrywanie";
 "Pause" = "Wstrzymaj";
 "Resume" = "Wznów";
+"Follow System" = "Użyj języka systemowego";
+"Target language:" = "Język docelowy:";
 "Engine:" = "Silnik:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (na urządzeniu)";

--- a/macshot/pt-BR.lproj/Localizable.strings
+++ b/macshot/pt-BR.lproj/Localizable.strings
@@ -524,6 +524,8 @@
 "Stop Recording" = "Parar gravação";
 "Pause" = "Pausar";
 "Resume" = "Retomar";
+"Follow System" = "Usar o idioma do sistema";
+"Target language:" = "Idioma de destino:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (no dispositivo)";

--- a/macshot/pt.lproj/Localizable.strings
+++ b/macshot/pt.lproj/Localizable.strings
@@ -524,6 +524,8 @@
 "Stop Recording" = "Parar gravacao";
 "Pause" = "Pausa";
 "Resume" = "Retomar";
+"Follow System" = "Usar o idioma do sistema";
+"Target language:" = "Idioma de destino:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (no dispositivo)";

--- a/macshot/ro.lproj/Localizable.strings
+++ b/macshot/ro.lproj/Localizable.strings
@@ -526,6 +526,8 @@
 "Stop Recording" = "Opreste inregistrarea";
 "Pause" = "Pauza";
 "Resume" = "Reia";
+"Follow System" = "Folosește limba sistemului";
+"Target language:" = "Limba țintă:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (pe dispozitiv)";

--- a/macshot/ru.lproj/Localizable.strings
+++ b/macshot/ru.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "Stop Recording" = "Остановить запись";
 "Pause" = "Пауза";
 "Resume" = "Продолжить";
+"Follow System" = "Использовать язык системы";
+"Target language:" = "Целевой язык:";
 "Engine:" = "Движок:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (на устройстве)";

--- a/macshot/sk.lproj/Localizable.strings
+++ b/macshot/sk.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "Stop Recording" = "Zastavit nahravanie";
 "Pause" = "Pozastavit";
 "Resume" = "Pokracovat";
+"Follow System" = "Použiť jazyk systému";
+"Target language:" = "Cieľový jazyk:";
 "Engine:" = "Engine:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (na zariadeni)";

--- a/macshot/sr.lproj/Localizable.strings
+++ b/macshot/sr.lproj/Localizable.strings
@@ -535,6 +535,8 @@
 "Stop Recording" = "Заустави снимање";
 "Pause" = "Паузирај";
 "Resume" = "Настави";
+"Follow System" = "Користи језик система";
+"Target language:" = "Циљни језик:";
 "Engine:" = "Мотор:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (на уређају)";

--- a/macshot/sv.lproj/Localizable.strings
+++ b/macshot/sv.lproj/Localizable.strings
@@ -534,6 +534,8 @@
 "Stop Recording" = "Stoppa inspelning";
 "Pause" = "Pausa";
 "Resume" = "\U00C5teruppta";
+"Follow System" = "F\U00F6lj systemspr\U00E5ket";
+"Target language:" = "M\U00E5lspr\U00E5k:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (p\U00E5 enheten)";

--- a/macshot/ta.lproj/Localizable.strings
+++ b/macshot/ta.lproj/Localizable.strings
@@ -536,6 +536,8 @@
 "Stop Recording" = "பதிவை நிறுத்து";
 "Pause" = "இடைநிறுத்தம்";
 "Resume" = "தொடரவும்";
+"Follow System" = "கணினி அமைப்பின் மொழியைப் பயன்படுத்து";
+"Target language:" = "இலக்கு மொழி:";
 "Engine:" = "இயந்திரம்:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (சாதனத்தில்)";

--- a/macshot/th.lproj/Localizable.strings
+++ b/macshot/th.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "Stop Recording" = "หยุดบันทึก";
 "Pause" = "หยุดชั่วคราว";
 "Resume" = "ดำเนินการต่อ";
+"Follow System" = "ใช้ภาษาของระบบ";
+"Target language:" = "ภาษาเป้าหมาย:";
 "Engine:" = "เครื่องมือ:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (บนอุปกรณ์)";

--- a/macshot/tr.lproj/Localizable.strings
+++ b/macshot/tr.lproj/Localizable.strings
@@ -528,6 +528,8 @@
 "Stop Recording" = "Kaydı Durdur";
 "Pause" = "Duraklat";
 "Resume" = "Devam Et";
+"Follow System" = "Sistem dilini kullan";
+"Target language:" = "Hedef dil:";
 "Engine:" = "Motor:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (cihaz üzerinde)";

--- a/macshot/uk.lproj/Localizable.strings
+++ b/macshot/uk.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "Stop Recording" = "Зупинити запис";
 "Pause" = "Пауза";
 "Resume" = "Продовжити";
+"Follow System" = "Використовувати мову системи";
+"Target language:" = "Цільова мова:";
 "Engine:" = "Рушій:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (на пристрої)";

--- a/macshot/vi.lproj/Localizable.strings
+++ b/macshot/vi.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "Stop Recording" = "Dừng quay";
 "Pause" = "Tạm dừng";
 "Resume" = "Tiếp tục";
+"Follow System" = "Dùng ngôn ngữ hệ thống";
+"Target language:" = "Ngôn ngữ đích:";
 "Engine:" = "Công cụ:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple (trên thiết bị)";

--- a/macshot/zh-Hans.lproj/Localizable.strings
+++ b/macshot/zh-Hans.lproj/Localizable.strings
@@ -524,6 +524,8 @@
 "Stop Recording" = "停止录制";
 "Pause" = "暂停";
 "Resume" = "继续";
+"Follow System" = "跟随系统";
+"Target language:" = "目标语言：";
 "Engine:" = "引擎:";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple（设备端）";

--- a/macshot/zh-Hant.lproj/Localizable.strings
+++ b/macshot/zh-Hant.lproj/Localizable.strings
@@ -535,6 +535,8 @@
 "Stop Recording" = "停止錄製";
 "Pause" = "暫停";
 "Resume" = "繼續";
+"Follow System" = "跟隨系統";
+"Target language:" = "目標語言：";
 "Engine:" = "引擎：";
 "Google Translate" = "Google Translate";
 "Apple (on-device)" = "Apple（裝置端）";


### PR DESCRIPTION
## 背景

截图翻译目标语言此前无法在设置中统一配置。本 PR 默认跟随 macOS 系统首选语言，同时允许用户固定选择目标语言。

## 主要改动

- 在 Capture 设置的 Translation 区域增加 Target language 与 Follow System。
- 新增 locale 解析和偏好管理：中文简繁映射、无效语言回退英语、显式选择持久化。
- OCR 结果窗口和截图原位翻译统一使用解析后的目标语言。
- 补齐 40 个本地化表的新增文案。

## Review 结论

- Gate: PASS
- P1/P2: 无；保留两项非阻断自动化测试缺口。
- 工程审阅报告：[pre-pr-codex-translation-target-language-pr.md](https://github.com/huangyunan822/macshot/blob/codex/translation-target-language-pr/docs/reviews/pre-pr-codex-translation-target-language-pr.md)
- QA 功能说明：[target-language.md](https://github.com/huangyunan822/macshot/blob/codex/translation-target-language-pr/docs/qa-feature-stories/translation/target-language.md)

## 验证

- 独立语言解析测试：通过。
- 40 个 Localizable.strings 的新增 key 与 plutil 格式校验：通过。
- Debug 与 Release xcodebuild：通过。

## 已知问题

- 暂无 AppKit popup 自动化 UI 测试；建议后续覆盖 macOS 12-14 与 15+ 的可见性和 Follow System 切换。
- 暂无 provider 参数转交的端到端测试。

## Reviewer 关注点

- TranslationTargetLanguage 的 locale 映射和 fallback 规则。
- SettingsWindowController 重开时对显式语言选择的刷新。