### PR TITLE
GIF export: fix SIGBUS crash on long recordings, use gifski when available, add 5-30 fps picker

### DIFF
--- a/macshot/Capture/GIFEncoder.swift
+++ b/macshot/Capture/GIFEncoder.swift
@@ -25,8 +25,8 @@ final class GIFEncoder {
     init(url: URL, fps: Int, sourceFPS: Int) {
         self.url = url
         self.sourceEstimatedFPS = max(sourceFPS, fps)
-        // Cap GIF at 15fps for reasonable file size
-        let gifFPS = min(fps, 15)
+        // Cap GIF at 30fps for reasonable file size
+        let gifFPS = min(fps, 30)
         self.targetFPS = gifFPS
         self.delayTime = 1.0 / Float(gifFPS)
 
@@ -70,32 +70,31 @@ final class GIFEncoder {
             return
         }
 
-        // Wrap the pixel buffer in a CGContext to get a CGImage reference,
-        // then copy into an owned context so the image survives after unlock.
-        // CGImageDestinationFinalize reads all frames later — each CGImage
-        // must own its pixel data independently.
+        // Copy pixel rows straight into an owned context (single memcpy per row)
+        // instead of wrapping the buffer in a CGContext and blend-drawing it —
+        // the draw path did an extra full-frame copy plus format conversion per
+        // frame. Source is 32BGRA which matches the context's bitmapInfo, so a
+        // raw byte copy is safe. The owned copy itself is still required:
+        // CGImageDestinationFinalize reads all frames after the pixel buffer
+        // has been recycled (alwaysCopiesSampleData=false).
         let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
         let bitmapInfo = CGImageAlphaInfo.noneSkipFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
-        guard let srcCtx = CGContext(
-            data: baseAddress,
-            width: width, height: height,
-            bitsPerComponent: 8, bytesPerRow: bytesPerRow,
-            space: colorSpace, bitmapInfo: bitmapInfo
-        ), let srcImage = srcCtx.makeImage() else {
-            CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
-            return
-        }
-
         guard let ownedCtx = CGContext(
             data: nil,
             width: width, height: height,
             bitsPerComponent: 8, bytesPerRow: width * 4,
             space: colorSpace, bitmapInfo: bitmapInfo
-        ) else {
+        ), let dstAddress = ownedCtx.data else {
             CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
             return
         }
-        ownedCtx.draw(srcImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        let dstBytesPerRow = ownedCtx.bytesPerRow
+        let copyBytes = min(width * 4, min(bytesPerRow, dstBytesPerRow))
+        for row in 0..<height {
+            memcpy(dstAddress + row * dstBytesPerRow,
+                   baseAddress + row * bytesPerRow,
+                   copyBytes)
+        }
         CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
 
         guard let cgImage = ownedCtx.makeImage() else { return }

--- a/macshot/Capture/GifskiExporter.swift
+++ b/macshot/Capture/GifskiExporter.swift
@@ -1,0 +1,200 @@
+import Foundation
+import AVFoundation
+import CoreVideo
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Streams video frames to the gifski encoder (github.com/ImageOptim/gifski).
+///
+/// Why: ImageIO's CGImageDestination GIF writer is single-threaded and keeps
+/// every frame in memory until finalize — a 1-minute Retina recording is ~900
+/// frames / tens of GB, which crashes (SIGBUS in ColorQuantization::hist3d)
+/// and takes minutes on one core. gifski is multi-threaded (uses all
+/// performance cores), streams frames from disk, produces smaller and
+/// better-looking GIFs.
+enum GifskiExporter {
+
+    /// Bundled binary first, then Homebrew locations.
+    static func locateBinary() -> URL? {
+        var candidates: [URL] = []
+        if let res = Bundle.main.resourceURL {
+            candidates.append(res.appendingPathComponent("gifski"))
+        }
+        candidates.append(URL(fileURLWithPath: "/opt/homebrew/bin/gifski"))
+        candidates.append(URL(fileURLWithPath: "/usr/local/bin/gifski"))
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0.path) }
+    }
+
+    enum ExportError: LocalizedError {
+        case noFrames
+        case frameWriteFailed
+        case gifskiFailed(Int32, String)
+
+        var errorDescription: String? {
+            switch self {
+            case .noFrames: return "No frames were read from the recording"
+            case .frameWriteFailed: return "Failed to write intermediate frames"
+            case .gifskiFailed(let code, let msg): return "gifski exited with code \(code): \(msg)"
+            }
+        }
+    }
+
+    /// Reads all frames from `readerOutput` (decimated to `fps`), writes them
+    /// as PNGs encoded in parallel, then runs gifski over the frame files.
+    /// Reports progress 0.0–1.0 (0–0.5 reading frames, 0.5–1.0 encoding).
+    static func export(
+        binary: URL,
+        reader: AVAssetReader,
+        readerOutput: AVAssetReaderOutput,
+        fps: Int,
+        sourceFPS: Int,
+        estimatedFrames: Int,
+        to destURL: URL,
+        progress: @escaping (Double) -> Void
+    ) throws {
+        let fm = FileManager.default
+        let workDir = fm.temporaryDirectory.appendingPathComponent("gifski-" + UUID().uuidString)
+        try fm.createDirectory(at: workDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: workDir) }
+
+        // --- Phase 1 (0-50%): read, decimate, encode PNGs in parallel ---
+        let gifFPS = max(1, min(fps, 50))
+        let effSourceFPS = max(sourceFPS, gifFPS)
+        let encodeQueue = DispatchQueue(label: "macshot.gifski.png", qos: .userInitiated, attributes: .concurrent)
+        let group = DispatchGroup()
+        // Bound in-flight owned frame copies so memory stays flat on long clips.
+        let inFlight = DispatchSemaphore(value: 12)
+        let writeFailed = LockedFlag()
+
+        var inputIndex = 0
+        var framePaths: [String] = []
+
+        reader.startReading()
+        while reader.status == .reading {
+            autoreleasepool {
+                guard let sampleBuffer = readerOutput.copyNextSampleBuffer(),
+                      let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+                inputIndex += 1
+                // Fractional decimation: keep a frame whenever the target
+                // timeline advances (exact for any fps pair, e.g. 60 -> 24).
+                let prevTargetIndex = (inputIndex - 1) * gifFPS / effSourceFPS
+                let targetIndex = inputIndex * gifFPS / effSourceFPS
+                guard targetIndex > prevTargetIndex else { return }
+                // Own the pixels before the reader recycles the buffer
+                // (alwaysCopiesSampleData = false).
+                guard let image = copyImage(from: pixelBuffer) else { return }
+                let path = workDir.appendingPathComponent(String(format: "frame_%06d.png", framePaths.count)).path
+                framePaths.append(path)
+                inFlight.wait()
+                encodeQueue.async(group: group) {
+                    defer { inFlight.signal() }
+                    if !writePNG(image, toPath: path) { writeFailed.set() }
+                }
+                if estimatedFrames > 0 {
+                    progress(min(0.5, Double(inputIndex) / Double(estimatedFrames) * 0.5))
+                }
+            }
+        }
+        group.wait()
+
+        guard !framePaths.isEmpty else { throw ExportError.noFrames }
+        guard !writeFailed.isSet else { throw ExportError.frameWriteFailed }
+
+        // --- Phase 2 (50-100%): gifski across all cores ---
+        progress(0.5)
+        let proc = Process()
+        proc.executableURL = binary
+        proc.arguments = ["--fps", String(gifFPS), "--quality", "90", "-o", destURL.path] + framePaths
+        let errPipe = Pipe()
+        proc.standardError = errPipe
+        proc.standardOutput = Pipe()
+
+        let stderrBox = LockedData()
+        let totalFrames = framePaths.count
+        errPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            stderrBox.append(data)
+            // gifski progress lines look like "123/900" (updated with \r)
+            if let text = String(data: data, encoding: .utf8),
+               let done = lastProgressCount(in: text), totalFrames > 0 {
+                progress(0.5 + 0.5 * min(1.0, Double(done) / Double(totalFrames)))
+            }
+        }
+
+        try proc.run()
+        proc.waitUntilExit()
+        errPipe.fileHandleForReading.readabilityHandler = nil
+
+        guard proc.terminationStatus == 0 else {
+            let msg = String(data: stderrBox.data, encoding: .utf8)?
+                .split(separator: "\n").suffix(3).joined(separator: " ") ?? ""
+            throw ExportError.gifskiFailed(proc.terminationStatus, msg)
+        }
+        progress(1.0)
+    }
+
+    // MARK: - Helpers
+
+    /// Copies a 32BGRA pixel buffer into an independently-owned CGImage.
+    private static func copyImage(from pixelBuffer: CVPixelBuffer) -> CGImage? {
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+        guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else { return nil }
+
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let bitmapInfo = CGImageAlphaInfo.noneSkipFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        guard let ctx = CGContext(
+            data: nil,
+            width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: width * 4,
+            space: colorSpace, bitmapInfo: bitmapInfo
+        ), let dst = ctx.data else { return nil }
+
+        let dstBytesPerRow = ctx.bytesPerRow
+        let copyBytes = min(width * 4, min(bytesPerRow, dstBytesPerRow))
+        for row in 0..<height {
+            memcpy(dst + row * dstBytesPerRow, baseAddress + row * bytesPerRow, copyBytes)
+        }
+        return ctx.makeImage()
+    }
+
+    private static func writePNG(_ image: CGImage, toPath path: String) -> Bool {
+        guard let dest = CGImageDestinationCreateWithURL(
+            URL(fileURLWithPath: path) as CFURL,
+            UTType.png.identifier as CFString, 1, nil
+        ) else { return false }
+        CGImageDestinationAddImage(dest, image, nil)
+        return CGImageDestinationFinalize(dest)
+    }
+
+    /// Extracts the last "N/M" pair from gifski's progress output.
+    private static func lastProgressCount(in text: String) -> Int? {
+        guard let regex = try? NSRegularExpression(pattern: "(\\d+)\\s*/\\s*\\d+") else { return nil }
+        let range = NSRange(text.startIndex..., in: text)
+        guard let match = regex.matches(in: text, range: range).last,
+              let r = Range(match.range(at: 1), in: text) else { return nil }
+        return Int(text[r])
+    }
+}
+
+// MARK: - Tiny thread-safe boxes (readabilityHandler runs on its own thread)
+
+private final class LockedFlag {
+    private let lock = NSLock()
+    private var value = false
+    var isSet: Bool { lock.lock(); defer { lock.unlock() }; return value }
+    func set() { lock.lock(); value = true; lock.unlock() }
+}
+
+private final class LockedData {
+    private let lock = NSLock()
+    private var storage = Data()
+    var data: Data { lock.lock(); defer { lock.unlock() }; return storage }
+    func append(_ d: Data) { lock.lock(); storage.append(d); lock.unlock() }
+}

--- a/macshot/UI/Editor/VideoEditorWindowController.swift
+++ b/macshot/UI/Editor/VideoEditorWindowController.swift
@@ -154,6 +154,13 @@ private final class VideoEditorView: NSView {
     private var exportQuality: VideoQuality = .high
     private var qualityBtnRect: NSRect = .zero
 
+    // GIF export frame rate (5-30 fps), persisted across sessions
+    private var gifExportFPS: Int = {
+        let stored = UserDefaults.standard.integer(forKey: "gifExportFPS")
+        return stored == 0 ? 15 : min(30, max(5, stored))
+    }()
+    private var gifFPSBtnRect: NSRect = .zero
+
     // Effects band (zoom + censor segments) lives in its own NSView, hosted
     // inside an NSScrollView so it can overflow vertically when many segments
     // stack onto separate rows. The parent editor observes mutations via the
@@ -924,6 +931,23 @@ private final class VideoEditorView: NSView {
                 }
             }
 
+            // GIF frame rate dropdown (only meaningful when exporting as GIF)
+            gifFPSBtnRect = .zero
+            if exportAsGIF && x < maxLeftX {
+                let fpsAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .medium),
+                    .foregroundColor: ToolbarLayout.iconColor.withAlphaComponent(gifExportFPS != 15 ? 0.7 : 0.4),
+                ]
+                let fpsStr = "  ·  \(gifExportFPS) fps ▼" as NSString
+                let fpsSize = fpsStr.size(withAttributes: fpsAttrs)
+                let fpsBtnW = fpsSize.width + 8
+                if x + fpsBtnW < maxLeftX {
+                    gifFPSBtnRect = NSRect(x: x, y: btnY, width: fpsBtnW, height: btnH)
+                    fpsStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - fpsSize.height) / 2), withAttributes: fpsAttrs)
+                    x += fpsBtnW
+                }
+            }
+
             // Estimated export size — show when trim, scale, quality, or format change would affect output
             let trimRatio = duration > 0 ? (trimEnd - trimStart) / duration : 1.0
             let scaleRatio = exportScale * exportScale  // pixels scale quadratically
@@ -1353,6 +1377,11 @@ private final class VideoEditorView: NSView {
             showQualityMenu(); return
         }
 
+        // GIF frame rate dropdown
+        if gifFPSBtnRect.contains(point) && exportAsGIF {
+            showGIFFPSMenu(); return
+        }
+
         // Buttons
         if playBtnRect.contains(point) { togglePlayPause(); return }
         if muteBtnRect.contains(point) { toggleMute(); return }
@@ -1707,6 +1736,26 @@ private final class VideoEditorView: NSView {
         menu.popUp(positioning: nil, at: pos, in: self)
     }
 
+    private func showGIFFPSMenu() {
+        let menu = NSMenu()
+        for fps in 5...30 {
+            let item = NSMenuItem(title: "\(fps) fps", action: #selector(gifFPSSelected(_:)), keyEquivalent: "")
+            item.target = self
+            item.tag = fps
+            item.state = (fps == gifExportFPS) ? .on : .off
+            menu.addItem(item)
+        }
+        let pos = NSPoint(x: gifFPSBtnRect.minX, y: gifFPSBtnRect.maxY)
+        menu.popUp(positioning: nil, at: pos, in: self)
+    }
+
+    @objc private func gifFPSSelected(_ sender: NSMenuItem) {
+        gifExportFPS = min(30, max(5, sender.tag))
+        UserDefaults.standard.set(gifExportFPS, forKey: "gifExportFPS")
+        savedURL = nil
+        needsDisplay = true
+    }
+
     @objc private func qualitySelected(_ sender: NSMenuItem) {
         if let raw = sender.representedObject as? String, let q = VideoQuality(rawValue: raw) {
             exportQuality = q
@@ -1722,8 +1771,10 @@ private final class VideoEditorView: NSView {
         let startTime = CMTime(seconds: trimStart, preferredTimescale: 600)
         let endTime = CMTime(seconds: trimEnd, preferredTimescale: 600)
         let timeRange = CMTimeRange(start: startTime, end: endTime)
-        // GIF capped at 15fps
-        let gifFPS = min(15, asset.tracks(withMediaType: .video).first.map { Int($0.nominalFrameRate.rounded()) } ?? 15)
+        // User-selected GIF frame rate (5-30), capped at the source frame rate
+        // so playback speed stays true to real time.
+        let sourceNominalFPS = asset.tracks(withMediaType: .video).first.map { Int($0.nominalFrameRate.rounded()) } ?? 30
+        let gifFPS = min(max(5, min(30, gifExportFPS)), max(5, sourceNominalFPS))
         let scale = exportScale
         let hasEffects = !zoomSegments.isEmpty || !censorSegments.isEmpty || !textSegments.isEmpty
 
@@ -1763,7 +1814,12 @@ private final class VideoEditorView: NSView {
             }
         }
 
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        // .userInitiated instead of .background: on Apple Silicon, background QoS
+        // is confined to efficiency cores and heavily throttled, making GIF
+        // conversion many times slower than the hardware allows. The MP4 export
+        // path already uses .userInitiated; UI stays responsive either way since
+        // the work is off the main thread.
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             do {
                 let reader = try AVAssetReader(asset: readerAsset)
                 guard let videoTrack = readerVideoTrackOpt else {
@@ -1807,38 +1863,58 @@ private final class VideoEditorView: NSView {
 
                 let tmpURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".gif")
                 let sourceFPS = Int(videoTrack.nominalFrameRate.rounded())
-                let encoder = GIFEncoder(url: tmpURL, fps: gifFPS, sourceFPS: max(sourceFPS, gifFPS))
-                reader.startReading()
-
                 let durationSec = CMTimeGetSeconds(readerTimeRange.duration)
                 let estimatedFrames = max(1, Int(durationSec * Double(sourceFPS)))
-                var framesRead = 0
-                var lastReportedPct = -1
 
-                while reader.status == .reading {
-                    autoreleasepool {
-                        if let sampleBuffer = readerOutput.copyNextSampleBuffer(),
-                           let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
-                            encoder.addFrame(pixelBuffer)
-                            framesRead += 1
-                        }
-                    }
-                    // Update progress on main thread (reading = 0–50%, finalize = 50–100%)
-                    let pct = min(50, framesRead * 50 / estimatedFrames)
-                    if pct != lastReportedPct {
-                        lastReportedPct = pct
+                if let gifskiBinary = GifskiExporter.locateBinary() {
+                    // Parallel all-core encoder; streams frames via disk instead
+                    // of holding every frame in memory (ImageIO keeps all frames
+                    // until finalize and crashes on long recordings).
+                    try GifskiExporter.export(
+                        binary: gifskiBinary,
+                        reader: reader,
+                        readerOutput: readerOutput,
+                        fps: gifFPS,
+                        sourceFPS: max(sourceFPS, gifFPS),
+                        estimatedFrames: estimatedFrames,
+                        to: tmpURL
+                    ) { fraction in
+                        let pct = Int(fraction * 100)
                         DispatchQueue.main.async {
                             self?.showStatus(String(format: L("Processing GIF…") + " %d%%", pct), persist: true)
                         }
                     }
-                }
+                } else {
+                    let encoder = GIFEncoder(url: tmpURL, fps: gifFPS, sourceFPS: max(sourceFPS, gifFPS))
+                    reader.startReading()
+                    var framesRead = 0
+                    var lastReportedPct = -1
 
-                DispatchQueue.main.async {
-                    self?.showStatus(L("Processing GIF…") + " 50%", persist: true)
-                }
-                encoder.finish()
-                DispatchQueue.main.async {
-                    self?.showStatus(L("Processing GIF…") + " 100%", persist: true)
+                    while reader.status == .reading {
+                        autoreleasepool {
+                            if let sampleBuffer = readerOutput.copyNextSampleBuffer(),
+                               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
+                                encoder.addFrame(pixelBuffer)
+                                framesRead += 1
+                            }
+                        }
+                        // Update progress on main thread (reading = 0–50%, finalize = 50–100%)
+                        let pct = min(50, framesRead * 50 / estimatedFrames)
+                        if pct != lastReportedPct {
+                            lastReportedPct = pct
+                            DispatchQueue.main.async {
+                                self?.showStatus(String(format: L("Processing GIF…") + " %d%%", pct), persist: true)
+                            }
+                        }
+                    }
+
+                    DispatchQueue.main.async {
+                        self?.showStatus(L("Processing GIF…") + " 50%", persist: true)
+                    }
+                    encoder.finish()
+                    DispatchQueue.main.async {
+                        self?.showStatus(L("Processing GIF…") + " 100%", persist: true)
+                    }
                 }
 
                 // Move to destination


### PR DESCRIPTION
Fixes #295

## What this changes

**1. QoS: `.background` -> `.userInitiated` for GIF conversion** (`VideoEditorWindowController.swift`)
On Apple Silicon, background QoS is confined to efficiency cores and CPU/IO-throttled, so GIF conversion ran many times slower than the hardware allows. The MP4 export path already uses `.userInitiated`; this makes GIF consistent. UI stays responsive - the work is off the main thread either way.

**2. `GIFEncoder.addFrame`: single row-wise `memcpy`** (`GIFEncoder.swift`)
Replaces the CGContext-wrap + `makeImage()` + blend-`draw` sequence (two full-frame copies with format conversion per frame) with one direct row copy. Source is 32BGRA and matches the destination bitmapInfo. The owned copy itself is still required (`alwaysCopiesSampleData = false`).

**3. New `GifskiExporter`** (`Capture/GifskiExporter.swift`)
When a gifski binary is available (`Contents/Resources/gifski`, `/opt/homebrew/bin`, `/usr/local/bin`), GIF export streams decimated frames to disk as PNGs (encoded concurrently, bounded in-flight so memory stays flat) and runs gifski over them. gifski is multi-threaded, streams frames, and produces smaller, better-looking GIFs. **Falls back to the existing `GIFEncoder` path when gifski is absent** - no behavior change for users without it.

This also works around the crash in #295: ImageIO's `CGImageDestination` retains every frame until `Finalize` (a 1-minute recording is ~900 frames, tens of GB) and then dies with SIGBUS inside `ColorQuantization::hist3d` during global-palette quantization. Same family as #110, #84, #41.

**4. GIF frame-rate picker (5-30 fps)** in the video editor next to the MP4/GIF toggle, persisted in `UserDefaults`, replacing the hard 15 fps cap. Frame decimation is fractional, so timing stays exact for any source/target pair (e.g. 60->24).

## Results (M5 Max, 1-minute 5K recording)

- Before: minutes on a single throttled core, then SIGBUS at finalize (~43 GB VM on a 36 GB machine).
- After: completes reliably; frame extraction ~1250% CPU, gifski phase takes seconds; memory no longer scales with recording length.

Vendoring vs. requiring a user-installed gifski (it's AGPL) is your call - the code treats it as optional either way. Happy to adjust.