### PR TITLE
Video editor: live text style panel, font family & glyph outline, style memory, + Effect button, instant paused-frame refresh

### DIFF
--- a/macshot/Capture/VideoTextRasterizer.swift
+++ b/macshot/Capture/VideoTextRasterizer.swift
@@ -5,9 +5,10 @@ import AppKit
 /// wrapped in a `CIImage` and composited per-frame by the video compositor.
 ///
 /// The rasterizer is called only when something visible changes (text,
-/// font size, weight, color, bg style/color, alignment, or the rect's
-/// pixel size). At per-frame time the compositor reuses the cached CGImage,
-/// so font shaping and glyph drawing do not run at video frame rate.
+/// font family/size, weight, color, bg style/color, outline, alignment,
+/// or the rect's pixel size). At per-frame time the compositor reuses the
+/// cached CGImage, so font shaping and glyph drawing do not run at video
+/// frame rate.
 enum VideoTextRasterizer {
 
     /// Snapshot of inputs that affect the rendered pixels. Two specs that
@@ -18,9 +19,16 @@ enum VideoTextRasterizer {
         let fontSize: CGFloat       // logical pt at 1080p reference
         let bold: Bool
         let italic: Bool
+        /// Font family name; "System" = the system UI font.
+        let fontFamily: String
         let textColor: VideoTextSegment.RGBA
         let bgStyle: VideoTextSegment.BackgroundStyle
         let bgColor: VideoTextSegment.RGBA
+        /// Glyph outline (stroke rendered behind the fill). Width is
+        /// logical pt at the same 1080p reference as `fontSize`.
+        let outlineEnabled: Bool
+        let outlineColor: VideoTextSegment.RGBA
+        let outlineWidth: CGFloat
         let alignment: VideoTextSegment.Alignment
         /// Pixel width of the target rect in render space.
         let pixelWidth: Int
@@ -43,9 +51,13 @@ enum VideoTextRasterizer {
              fontSize: segment.fontSize,
              bold: segment.bold,
              italic: segment.italic,
+             fontFamily: segment.fontFamily,
              textColor: segment.textColor,
              bgStyle: segment.bgStyle,
              bgColor: segment.bgColor,
+             outlineEnabled: segment.outlineEnabled,
+             outlineColor: segment.outlineColor,
+             outlineWidth: segment.outlineWidth,
              alignment: segment.alignment,
              pixelWidth: pixelWidth,
              pixelHeight: pixelHeight,
@@ -126,6 +138,21 @@ enum VideoTextRasterizer {
         if spec.bold { traits.insert(.bold) }
         if spec.italic { traits.insert(.italic) }
         let font: NSFont = {
+            // Custom family: resolve by name (NSFont accepts family names
+            // for most installed fonts), falling back to an explicit family
+            // lookup, then apply bold/italic via NSFontManager — descriptor
+            // trait synthesis is unreliable for third-party families.
+            // Missing families fall through to the system-font path below.
+            if spec.fontFamily != "System" {
+                let fm = NSFontManager.shared
+                let named = NSFont(name: spec.fontFamily, size: pxFontSize)
+                    ?? fm.font(withFamily: spec.fontFamily, traits: [], weight: 5, size: pxFontSize)
+                if var f = named {
+                    if spec.bold { f = fm.convert(f, toHaveTrait: .boldFontMask) }
+                    if spec.italic { f = fm.convert(f, toHaveTrait: .italicFontMask) }
+                    return f
+                }
+            }
             // Start from the system font so we get SF/the default UI font,
             // then apply traits via descriptor. Fall back to plain system
             // font of the same weight if descriptor synthesis fails.
@@ -175,6 +202,24 @@ enum VideoTextRasterizer {
                               y: max(textRect.minY, drawY),
                               width: textRect.width,
                               height: min(textRect.height, bounding.height + 2))
+
+        // Glyph outline — a stroke-only pass drawn *under* the fill. A
+        // positive .strokeWidth strokes the glyph path without filling; the
+        // fill pass on top then covers the inner half of the stroke, leaving
+        // a clean outer rim. .strokeWidth is expressed in percent of the
+        // font size, so convert the logical width (1080p-reference points,
+        // scaled like fontSize, doubled because half of the centered stroke
+        // hides under the fill) to a percentage.
+        if spec.outlineEnabled, spec.outlineWidth > 0 {
+            let pxOutline = max(0.5, spec.outlineWidth * scale)
+            let strokePercent = (pxOutline * 2 / pxFontSize) * 100
+            var strokeAttrs = attrs
+            strokeAttrs[.strokeColor] = nsColor(spec.outlineColor)
+            strokeAttrs[.strokeWidth] = strokePercent
+            NSAttributedString(string: spec.text, attributes: strokeAttrs)
+                .draw(with: drawRect,
+                      options: [.usesLineFragmentOrigin, .usesFontLeading])
+        }
 
         attributed.draw(with: drawRect,
                         options: [.usesLineFragmentOrigin, .usesFontLeading])

--- a/macshot/Model/VideoTextSegment.swift
+++ b/macshot/Model/VideoTextSegment.swift
@@ -35,6 +35,7 @@ final class VideoTextSegment: Codable {
         var a: Double
 
         static let white = RGBA(r: 1, g: 1, b: 1, a: 1)
+        static let black = RGBA(r: 0, g: 0, b: 0, a: 1)
         static let blackTransparent = RGBA(r: 0, g: 0, b: 0, a: 0.7)
     }
 
@@ -52,9 +53,20 @@ final class VideoTextSegment: Codable {
     var bold: Bool
     var italic: Bool
 
+    /// Font family name. The sentinel "System" selects the system UI font;
+    /// anything else is resolved by name at raster time (with a system-font
+    /// fallback when the family is not installed).
+    var fontFamily: String
+
     var textColor: RGBA
     var bgStyle: BackgroundStyle
     var bgColor: RGBA
+
+    /// Per-glyph outline stroked behind the text fill. `outlineWidth` is in
+    /// points at the same 1080p reference scale as `fontSize`.
+    var outlineEnabled: Bool
+    var outlineColor: RGBA
+    var outlineWidth: CGFloat
 
     var alignment: Alignment
 
@@ -69,9 +81,13 @@ final class VideoTextSegment: Codable {
          fontSize: CGFloat = 48,
          bold: Bool = true,
          italic: Bool = false,
+         fontFamily: String = "System",
          textColor: RGBA = .white,
          bgStyle: BackgroundStyle = .rounded,
          bgColor: RGBA = .blackTransparent,
+         outlineEnabled: Bool = false,
+         outlineColor: RGBA = .black,
+         outlineWidth: CGFloat = 2,
          alignment: Alignment = .center,
          fadeIn: Double = defaultFade,
          fadeOut: Double = defaultFade) {
@@ -83,12 +99,76 @@ final class VideoTextSegment: Codable {
         self.fontSize = fontSize
         self.bold = bold
         self.italic = italic
+        self.fontFamily = fontFamily
         self.textColor = textColor
         self.bgStyle = bgStyle
         self.bgColor = bgColor
+        self.outlineEnabled = outlineEnabled
+        self.outlineColor = outlineColor
+        self.outlineWidth = outlineWidth
         self.alignment = alignment
         self.fadeIn = fadeIn
         self.fadeOut = fadeOut
+    }
+
+    // MARK: - Codable
+    //
+    // Explicit implementation (instead of the synthesized one) so segments
+    // serialized by older versions — which lack the font-family and outline
+    // keys — keep decoding: the new keys use `decodeIfPresent` + defaults.
+    // All pre-existing keys and their encoded shapes are unchanged.
+
+    private enum CodingKeys: String, CodingKey {
+        case id, startTime, endTime, rect, text
+        case fontSize, bold, italic, fontFamily
+        case textColor, bgStyle, bgColor
+        case outlineEnabled, outlineColor, outlineWidth
+        case alignment, fadeIn, fadeOut
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        startTime = try c.decode(Double.self, forKey: .startTime)
+        endTime = try c.decode(Double.self, forKey: .endTime)
+        rect = try c.decode(CGRect.self, forKey: .rect)
+        text = try c.decode(String.self, forKey: .text)
+        fontSize = try c.decode(CGFloat.self, forKey: .fontSize)
+        bold = try c.decode(Bool.self, forKey: .bold)
+        italic = try c.decode(Bool.self, forKey: .italic)
+        textColor = try c.decode(RGBA.self, forKey: .textColor)
+        bgStyle = try c.decode(BackgroundStyle.self, forKey: .bgStyle)
+        bgColor = try c.decode(RGBA.self, forKey: .bgColor)
+        alignment = try c.decode(Alignment.self, forKey: .alignment)
+        fadeIn = try c.decode(Double.self, forKey: .fadeIn)
+        fadeOut = try c.decode(Double.self, forKey: .fadeOut)
+        // Added later — absent in old archives, so fall back to defaults.
+        fontFamily = try c.decodeIfPresent(String.self, forKey: .fontFamily) ?? "System"
+        outlineEnabled = try c.decodeIfPresent(Bool.self, forKey: .outlineEnabled) ?? false
+        outlineColor = try c.decodeIfPresent(RGBA.self, forKey: .outlineColor) ?? .black
+        outlineWidth = try c.decodeIfPresent(CGFloat.self, forKey: .outlineWidth) ?? 2
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(startTime, forKey: .startTime)
+        try c.encode(endTime, forKey: .endTime)
+        try c.encode(rect, forKey: .rect)
+        try c.encode(text, forKey: .text)
+        try c.encode(fontSize, forKey: .fontSize)
+        try c.encode(bold, forKey: .bold)
+        try c.encode(italic, forKey: .italic)
+        try c.encode(fontFamily, forKey: .fontFamily)
+        try c.encode(textColor, forKey: .textColor)
+        try c.encode(bgStyle, forKey: .bgStyle)
+        try c.encode(bgColor, forKey: .bgColor)
+        try c.encode(outlineEnabled, forKey: .outlineEnabled)
+        try c.encode(outlineColor, forKey: .outlineColor)
+        try c.encode(outlineWidth, forKey: .outlineWidth)
+        try c.encode(alignment, forKey: .alignment)
+        try c.encode(fadeIn, forKey: .fadeIn)
+        try c.encode(fadeOut, forKey: .fadeOut)
     }
 
     var duration: Double { max(0, endTime - startTime) }
@@ -145,5 +225,43 @@ final class VideoTextSegment: Codable {
         if x + w > 1 { x = 1 - w }
         if y + h > 1 { y = 1 - h }
         return CGRect(x: x, y: y, width: w, height: h)
+    }
+}
+
+
+// MARK: - Last-used style memory
+
+extension VideoTextSegment {
+    private static let lastStyleKey = "videoTextLastUsedStyle"
+
+    /// A new segment that starts with the style of the last edited text
+    /// segment (color, background, font family/size, bold/italic, outline,
+    /// alignment), so users don't have to re-apply the same styling for
+    /// every new segment.
+    static func withLastUsedStyle(startTime: Double, endTime: Double) -> VideoTextSegment {
+        let seg = VideoTextSegment(startTime: startTime, endTime: endTime)
+        guard let data = UserDefaults.standard.data(forKey: lastStyleKey),
+              let saved = try? JSONDecoder().decode(VideoTextSegment.self, from: data) else {
+            return seg
+        }
+        seg.fontSize = saved.fontSize
+        seg.bold = saved.bold
+        seg.italic = saved.italic
+        seg.fontFamily = saved.fontFamily
+        seg.textColor = saved.textColor
+        seg.bgStyle = saved.bgStyle
+        seg.bgColor = saved.bgColor
+        seg.outlineEnabled = saved.outlineEnabled
+        seg.outlineColor = saved.outlineColor
+        seg.outlineWidth = saved.outlineWidth
+        seg.alignment = saved.alignment
+        return seg
+    }
+
+    /// Persist this segment's style as the default for future segments.
+    func rememberStyle() {
+        if let data = try? JSONEncoder().encode(self) {
+            UserDefaults.standard.set(data, forKey: Self.lastStyleKey)
+        }
     }
 }

--- a/macshot/Model/VideoZoomSegment.swift
+++ b/macshot/Model/VideoZoomSegment.swift
@@ -96,6 +96,17 @@ final class VideoZoomSegment: Codable {
     /// center when applying `scale(zoom).translate(tx, ty)` to a frame of
     /// `videoSize`. Clamped so the zoom window never shows area outside the
     /// video's bounds (no black bars at edges from over-pan).
+    /// Clamp a normalized center so the visible zoom window (1/zoom of each
+    /// dimension) stays fully inside the frame. Keeping the center in this
+    /// range means `translation`'s edge clamping never has to shift the view,
+    /// so the region the user drew and the region actually shown stay
+    /// identical (fixes zooming into "the wrong area" near frame edges).
+    static func clampedCenter(_ c: CGPoint, zoom: CGFloat) -> CGPoint {
+        let half = 1.0 / (2 * max(zoom, 1.0001))
+        return CGPoint(x: min(max(c.x, half), 1 - half),
+                       y: min(max(c.y, half), 1 - half))
+    }
+
     func translation(zoom: CGFloat, videoSize: CGSize) -> CGPoint {
         guard zoom > 1.0001 else { return .zero }
         // Pixel coords of the chosen center

--- a/macshot/UI/Editor/EffectsBandView.swift
+++ b/macshot/UI/Editor/EffectsBandView.swift
@@ -1410,6 +1410,14 @@ final class EffectsBandView: NSView {
     }
 
     private func showAddEffectMenu(at point: NSPoint, clickTime: Double) {
+        let menu = addEffectMenu(clickTime: clickTime)
+        menu.popUp(positioning: nil, at: point, in: self)
+    }
+
+    /// The same "add effect" menu as the band's context menu, reusable by the
+    /// editor toolbar's "+" button. Items insert at `clickTime` and are
+    /// enabled/disabled based on available gaps, exactly like the band menu.
+    func addEffectMenu(clickTime: Double) -> NSMenu {
         let menu = NSMenu()
         let zoomItem = NSMenuItem(title: L("Add Zoom"),
                                   action: #selector(handleAddZoomFromMenu(_:)),
@@ -1469,7 +1477,7 @@ final class EffectsBandView: NSView {
         textItem.representedObject = AddEffectContext(clickTime: clickTime, gapStart: 0, gapEnd: duration)
         menu.addItem(textItem)
 
-        menu.popUp(positioning: nil, at: point, in: self)
+        return menu
     }
 
     private func attachAddEffectSubmenu(to menu: NSMenu, event: NSEvent) {
@@ -1659,6 +1667,7 @@ final class EffectsBandView: NSView {
         guard let ctx = sender.representedObject as? TextSizeMenuContext,
               let seg = textSegments.first(where: { $0.id == ctx.segmentID }) else { return }
         seg.fontSize = ctx.fontSize
+        seg.rememberStyle()
         delegate?.effectsBandDidMutate(self)
         needsDisplay = true
     }
@@ -1667,6 +1676,7 @@ final class EffectsBandView: NSView {
         guard let ctx = sender.representedObject as? TextSegmentRefContext,
               let seg = textSegments.first(where: { $0.id == ctx.segmentID }) else { return }
         seg.bold.toggle()
+        seg.rememberStyle()
         delegate?.effectsBandDidMutate(self)
         needsDisplay = true
     }
@@ -1675,6 +1685,7 @@ final class EffectsBandView: NSView {
         guard let ctx = sender.representedObject as? TextSegmentRefContext,
               let seg = textSegments.first(where: { $0.id == ctx.segmentID }) else { return }
         seg.italic.toggle()
+        seg.rememberStyle()
         delegate?.effectsBandDidMutate(self)
         needsDisplay = true
     }
@@ -1683,6 +1694,7 @@ final class EffectsBandView: NSView {
         guard let ctx = sender.representedObject as? TextAlignmentMenuContext,
               let seg = textSegments.first(where: { $0.id == ctx.segmentID }) else { return }
         seg.alignment = ctx.alignment
+        seg.rememberStyle()
         delegate?.effectsBandDidMutate(self)
         needsDisplay = true
     }
@@ -1691,6 +1703,7 @@ final class EffectsBandView: NSView {
         guard let ctx = sender.representedObject as? TextBgStyleMenuContext,
               let seg = textSegments.first(where: { $0.id == ctx.segmentID }) else { return }
         seg.bgStyle = ctx.style
+        seg.rememberStyle()
         delegate?.effectsBandDidMutate(self)
         needsDisplay = true
     }
@@ -1703,6 +1716,7 @@ final class EffectsBandView: NSView {
         } else {
             seg.textColor = ctx.color
         }
+        seg.rememberStyle()
         delegate?.effectsBandDidMutate(self)
         needsDisplay = true
     }
@@ -1817,7 +1831,7 @@ final class EffectsBandView: NSView {
         let segDuration = min(3.0, max(VideoTextSegment.minDuration, duration))
         var start = clickTime - segDuration / 2
         start = max(0, min(duration - segDuration, start))
-        let seg = VideoTextSegment(startTime: start, endTime: start + segDuration)
+        let seg = VideoTextSegment.withLastUsedStyle(startTime: start, endTime: start + segDuration)
         textSegments.append(seg)
         selectedSegmentID = seg.id
         relayoutAndNotify()

--- a/macshot/UI/Editor/EffectsBandView.swift
+++ b/macshot/UI/Editor/EffectsBandView.swift
@@ -1424,8 +1424,14 @@ final class EffectsBandView: NSView {
                                   keyEquivalent: "")
         zoomItem.image = NSImage(systemSymbolName: "plus.magnifyingglass", accessibilityDescription: nil)
         zoomItem.target = self
-        if let g = zoomGapAtClickTime(clickTime) {
-            zoomItem.representedObject = AddEffectContext(clickTime: clickTime, gapStart: g.0, gapEnd: g.1)
+        if let g = zoomGapAtClickTime(clickTime) ?? nearestGap(to: clickTime,
+                                                               occupied: zoomSegments.map { ($0.startTime, $0.endTime) },
+                                                               minLength: VideoZoomSegment.minDuration) {
+            // If the playhead sits inside an existing segment, fall back to
+            // the nearest free gap instead of disabling the item — clamp the
+            // insertion point into that gap.
+            let t = min(max(clickTime, g.0), g.1)
+            zoomItem.representedObject = AddEffectContext(clickTime: t, gapStart: g.0, gapEnd: g.1)
             zoomItem.isEnabled = true
         } else {
             zoomItem.isEnabled = false
@@ -1453,8 +1459,11 @@ final class EffectsBandView: NSView {
                                     keyEquivalent: "")
         speedItem.image = NSImage(systemSymbolName: "forward.fill", accessibilityDescription: nil)
         speedItem.target = self
-        if let g = speedGapAtClickTime(clickTime) {
-            speedItem.representedObject = AddEffectContext(clickTime: clickTime, gapStart: g.0, gapEnd: g.1)
+        if let g = speedGapAtClickTime(clickTime) ?? nearestGap(to: clickTime,
+                                                                occupied: speedSegments.map { ($0.startTime, $0.endTime) },
+                                                                minLength: VideoSpeedSegment.minCompDuration) {
+            let t = min(max(clickTime, g.0), g.1)
+            speedItem.representedObject = AddEffectContext(clickTime: t, gapStart: g.0, gapEnd: g.1)
             speedItem.isEnabled = true
         } else {
             speedItem.isEnabled = false
@@ -1492,7 +1501,9 @@ final class EffectsBandView: NSView {
             Double((p.x - row0Rect.minX) / max(row0Rect.width, 1)) * duration))
         let parent = NSMenuItem(title: L("Add effect"), action: nil, keyEquivalent: "")
         let sub = NSMenu()
-        let zoomGap = zoomGapAtClickTime(clickTime)
+        let zoomGap = zoomGapAtClickTime(clickTime) ?? nearestGap(to: clickTime,
+                                                                   occupied: zoomSegments.map { ($0.startTime, $0.endTime) },
+                                                                   minLength: VideoZoomSegment.minDuration)
         let zoomItem = NSMenuItem(title: L("Add Zoom"),
                                   action: #selector(handleAddZoomFromMenu(_:)),
                                   keyEquivalent: "")
@@ -1520,8 +1531,11 @@ final class EffectsBandView: NSView {
                                     action: #selector(handleAddSpeedFromMenu(_:)),
                                     keyEquivalent: "")
         speedItem.target = self
-        if let g = speedGapAtClickTime(clickTime) {
-            speedItem.representedObject = AddEffectContext(clickTime: clickTime, gapStart: g.0, gapEnd: g.1)
+        if let g = speedGapAtClickTime(clickTime) ?? nearestGap(to: clickTime,
+                                                                occupied: speedSegments.map { ($0.startTime, $0.endTime) },
+                                                                minLength: VideoSpeedSegment.minCompDuration) {
+            let t = min(max(clickTime, g.0), g.1)
+            speedItem.representedObject = AddEffectContext(clickTime: t, gapStart: g.0, gapEnd: g.1)
             speedItem.isEnabled = true
         } else {
             speedItem.isEnabled = false
@@ -1570,6 +1584,30 @@ final class EffectsBandView: NSView {
 
     /// Returns the (start, end) of the zoom-free interval containing `t`, or
     /// nil if `t` is inside a zoom segment.
+    /// The free gap (length >= minLength) whose midpoint is closest to `t`,
+    /// or nil when the timeline has no usable gap. Fallback so "add effect"
+    /// stays usable when the playhead is inside an existing segment.
+    private func nearestGap(to t: Double,
+                            occupied: [(Double, Double)],
+                            minLength: Double) -> (Double, Double)? {
+        guard duration > 0 else { return nil }
+        let sorted = occupied.filter { $0.1 > $0.0 }.sorted { $0.0 < $1.0 }
+        var gaps: [(Double, Double)] = []
+        var cursor: Double = 0
+        for seg in sorted {
+            if seg.0 > cursor + 0.001 { gaps.append((cursor, seg.0)) }
+            cursor = max(cursor, seg.1)
+        }
+        if cursor < duration - 0.001 { gaps.append((cursor, duration)) }
+        return gaps
+            .filter { ($0.1 - $0.0) >= minLength }
+            .min { a, b in
+                let da = t < a.0 ? a.0 - t : (t > a.1 ? t - a.1 : 0)
+                let db = t < b.0 ? b.0 - t : (t > b.1 ? t - b.1 : 0)
+                return da < db
+            }
+    }
+
     private func zoomGapAtClickTime(_ t: Double) -> (Double, Double)? {
         guard duration > 0 else { return nil }
         let zooms = zoomSegments

--- a/macshot/UI/Editor/EffectsPreviewOverlayView.swift
+++ b/macshot/UI/Editor/EffectsPreviewOverlayView.swift
@@ -42,6 +42,9 @@ final class EffectsPreviewOverlayView: NSView {
     /// is responsible for clamping, writing to the model, and triggering a
     /// composition rebuild.
     var onChange: ((CGRect) -> Void)?
+    /// Fired when an interactive drag (move/resize) finishes, so the owner
+    /// can re-sync the displayed rect with the model's clamped state.
+    var onDragEnded: (() -> Void)?
 
     /// Fires when the user double-clicks inside a text selection's rect.
     /// Reports the **view-space** rect of the selection so the controller
@@ -188,12 +191,23 @@ final class EffectsPreviewOverlayView: NSView {
 
         case .resize(let corner):
             newRect = resizedRect(from: originalView, corner: corner, to: p)
+            // Zoom windows always show a region with the video's aspect
+            // ratio — lock the rect to it while resizing so what the user
+            // draws is exactly what the zoom will show.
+            if case .zoom = selection.kind {
+                newRect = zoomAspectConstrained(newRect, in: videoR)
+            }
             // Clamp to video bounds
             let xLo = max(videoR.minX, newRect.minX)
             let yLo = max(videoR.minY, newRect.minY)
             let xHi = min(videoR.maxX, newRect.maxX)
             let yHi = min(videoR.maxY, newRect.maxY)
             newRect = NSRect(x: xLo, y: yLo, width: max(0, xHi - xLo), height: max(0, yHi - yLo))
+            if case .zoom = selection.kind {
+                // Bounds clamping can break the aspect again at the frame
+                // edge; restore it by shrinking around the clamped center.
+                newRect = zoomAspectConstrained(newRect, in: videoR, shrinkOnly: true)
+            }
         }
 
         let normalized = normalize(newRect)
@@ -205,7 +219,29 @@ final class EffectsPreviewOverlayView: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
+        let wasDragging = dragMode != nil
         dragMode = nil
+        if wasDragging { onDragEnded?() }
+    }
+
+    /// Force `rect` to the video's aspect ratio (the shape a zoom window
+    /// actually shows), anchored at its center. Grows the shorter dimension
+    /// unless `shrinkOnly`, in which case the longer one shrinks. The result
+    /// is nudged back inside `videoR` when growth would cross an edge.
+    private func zoomAspectConstrained(_ rect: NSRect, in videoR: NSRect, shrinkOnly: Bool = false) -> NSRect {
+        guard videoR.width > 0, videoR.height > 0, rect.width > 0 || rect.height > 0 else { return rect }
+        let fw = rect.width / videoR.width
+        let fh = rect.height / videoR.height
+        var f = shrinkOnly ? min(fw, fh) : max(fw, fh)
+        // Keep the implied zoom inside the model's allowed range.
+        f = min(max(f, 1.0 / VideoZoomSegment.maxZoom), 1.0 / VideoZoomSegment.minZoom)
+        let w = f * videoR.width
+        let h = f * videoR.height
+        var x = rect.midX - w / 2
+        var y = rect.midY - h / 2
+        x = max(videoR.minX, min(videoR.maxX - w, x))
+        y = max(videoR.minY, min(videoR.maxY - h, y))
+        return NSRect(x: x, y: y, width: w, height: h)
     }
 
     // MARK: - Geometry

--- a/macshot/UI/Editor/VideoEditorWindowController.swift
+++ b/macshot/UI/Editor/VideoEditorWindowController.swift
@@ -161,6 +161,15 @@ private final class VideoEditorView: NSView {
     }()
     private var gifFPSBtnRect: NSRect = .zero
 
+    // "+ Effect" toolbar button and the selected-text-segment state that
+    // drives the bottom text-options panel.
+    private var addEffectBtnRect: NSRect = .zero
+    private var selectedTextSegmentID: UUID?
+    private var selectedTextSegment: VideoTextSegment? {
+        guard let id = selectedTextSegmentID else { return nil }
+        return textSegments.first(where: { $0.id == id })
+    }
+
     // Effects band (zoom + censor segments) lives in its own NSView, hosted
     // inside an NSScrollView so it can overflow vertically when many segments
     // stack onto separate rows. The parent editor observes mutations via the
@@ -169,6 +178,15 @@ private final class VideoEditorView: NSView {
     private var effectsScrollView: NSScrollView?
     private var effectsBandHeightConstraint: NSLayoutConstraint?
     private var playerBottomConstraint: NSLayoutConstraint?
+
+    // Bottom options panel for the selected text segment. Sits between the
+    // (drawn) trim timeline and the effects band; collapsed to height 0
+    // while no text segment is selected.
+    private var textOptionsPanel: VideoTextOptionsPanel?
+    private var textOptionsPanelHeightConstraint: NSLayoutConstraint?
+    /// Height currently occupied by the panel (0 when hidden). Folded into
+    /// `controlsH` so the drawn chrome above it shifts up when it appears.
+    private var textOptionsPanelH: CGFloat = 0
 
     // Convenience accessors so call sites don't have to guard the optional.
     private var zoomSegments: [VideoZoomSegment] { effectsBand?.zoomSegments ?? [] }
@@ -192,8 +210,9 @@ private final class VideoEditorView: NSView {
     private var pausedForTextEdit: Bool = false
 
     // NSColorPanel binding state for the "Custom…" color menu action.
+    fileprivate enum TextColorPickTarget { case text, background, outline }
     fileprivate var textColorPickerSegmentID: UUID?
-    fileprivate var textColorPickerIsBackground: Bool = false
+    fileprivate var textColorPickerTarget: TextColorPickTarget = .text
 
     // Button rects
     private var playBtnRect: NSRect = .zero
@@ -244,6 +263,7 @@ private final class VideoEditorView: NSView {
     private var controlsH: CGFloat {
         return buttonsAreaH
              + effectsScrollViewHeight(forRowCount: currentEffectRowCount)
+             + textOptionsPanelH
              + scrollToLabelsGap
              + trimBarH
              + labelsAboveTrimGap
@@ -470,6 +490,27 @@ private final class VideoEditorView: NSView {
         self.effectsBand = band
         self.effectsBandHeightConstraint = heightC
 
+        // Text options panel — real-controls inspector for the selected text
+        // segment. Pinned to the same horizontal region as the effects band
+        // and to the band's top edge; its height constraint animates between
+        // 0 and preferredHeight in `updateTextOptionsPanelVisibility()`.
+        let textPanel = VideoTextOptionsPanel()
+        textPanel.translatesAutoresizingMaskIntoConstraints = false
+        textPanel.isHidden = true
+        textPanel.onChange = { [weak self] change in
+            self?.handleTextOptionsChange(change)
+        }
+        addSubview(textPanel)
+        let textPanelHeightC = textPanel.heightAnchor.constraint(equalToConstant: 0)
+        NSLayoutConstraint.activate([
+            textPanel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: timelinePad - 4),
+            textPanel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -(timelinePad - 4)),
+            textPanel.bottomAnchor.constraint(equalTo: scrollView.topAnchor),
+            textPanelHeightC,
+        ])
+        self.textOptionsPanel = textPanel
+        self.textOptionsPanelHeightConstraint = textPanelHeightC
+
         // Observe playback position
         timeObserver = player.addPeriodicTimeObserver(forInterval: CMTime(value: 1, timescale: 30), queue: .main) { [weak self] time in
             guard let self = self, !self.isDraggingScrubber else { return }
@@ -624,10 +665,11 @@ private final class VideoEditorView: NSView {
         // scroll view grows to show more rows.
         let tlH: CGFloat = trimBarH
         let scrollH = effectsScrollViewHeight(forRowCount: currentEffectRowCount)
-        // Trim bar sits directly above the effects scroll view (with just
-        // the `scrollToLabelsGap` for breathing room). Time labels now sit
+        // Trim bar sits directly above the effects scroll view and the
+        // text options panel (when visible), with just the
+        // `scrollToLabelsGap` for breathing room. Time labels now sit
         // ABOVE the trim bar — see `timeLabelY`.
-        let tlY: CGFloat = buttonsAreaH + scrollH + scrollToLabelsGap
+        let tlY: CGFloat = buttonsAreaH + scrollH + textOptionsPanelH + scrollToLabelsGap
         timelineRect = NSRect(x: tlX, y: tlY, width: tlW, height: tlH)
 
         // Regenerate thumbnails if width changed significantly
@@ -775,7 +817,7 @@ private final class VideoEditorView: NSView {
         // (y=0→buttonsAreaH) so SF-Symbol rendering stays off the 30Hz
         // path — that was eating ~1s/10s on the main thread.
         let scrollH = effectsScrollViewHeight(forRowCount: currentEffectRowCount)
-        let tlY = buttonsAreaH + scrollH + scrollToLabelsGap
+        let tlY = buttonsAreaH + scrollH + textOptionsPanelH + scrollToLabelsGap
         let playheadBandMinY = tlY - 12                                              // below trim bar (circle + padding)
         let playheadBandMaxY = tlY + trimBarH + labelsAboveTrimGap + labelsRowH + 2  // through label row
 
@@ -945,6 +987,23 @@ private final class VideoEditorView: NSView {
                     gifFPSBtnRect = NSRect(x: x, y: btnY, width: fpsBtnW, height: btnH)
                     fpsStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - fpsSize.height) / 2), withAttributes: fpsAttrs)
                     x += fpsBtnW
+                }
+            }
+
+            // "+ Effect" button — add zoom/censor/cut/speed/freeze/text at the playhead
+            addEffectBtnRect = .zero
+            if effectsBand != nil && x < maxLeftX {
+                let addAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 10, weight: .medium),
+                    .foregroundColor: ToolbarLayout.iconColor.withAlphaComponent(0.7),
+                ]
+                let addStr = "  ·  + \(L("Effect")) ▼" as NSString
+                let addSize = addStr.size(withAttributes: addAttrs)
+                let addBtnW = addSize.width + 8
+                if x + addBtnW < maxLeftX {
+                    addEffectBtnRect = NSRect(x: x, y: btnY, width: addBtnW, height: btnH)
+                    addStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - addSize.height) / 2), withAttributes: addAttrs)
+                    x += addBtnW
                 }
             }
 
@@ -1172,7 +1231,7 @@ private final class VideoEditorView: NSView {
         // Bottom of the labels row sits slightly above the top of the
         // trim bar — `labelsAboveTrimGap` gives the text a little
         // breathing room so it doesn't look pasted onto the bar.
-        let labelsRowBottom = buttonsAreaH + scrollH + scrollToLabelsGap + trimBarH + labelsAboveTrimGap
+        let labelsRowBottom = buttonsAreaH + scrollH + textOptionsPanelH + scrollToLabelsGap + trimBarH + labelsAboveTrimGap
         return labelsRowBottom + (labelsRowH - sampleHeight) / 2
     }
 
@@ -1380,6 +1439,13 @@ private final class VideoEditorView: NSView {
         // GIF frame rate dropdown
         if gifFPSBtnRect.contains(point) && exportAsGIF {
             showGIFFPSMenu(); return
+        }
+
+        // "+ Effect" button — reuse the band's add-effect menu at the playhead
+        if addEffectBtnRect.contains(point), let band = effectsBand {
+            let menu = band.addEffectMenu(clickTime: currentPlaybackTime)
+            menu.popUp(positioning: nil, at: NSPoint(x: addEffectBtnRect.minX, y: addEffectBtnRect.maxY), in: self)
+            return
         }
 
         // Buttons
@@ -1734,6 +1800,80 @@ private final class VideoEditorView: NSView {
         }
         let pos = NSPoint(x: qualityBtnRect.minX, y: qualityBtnRect.maxY)
         menu.popUp(positioning: nil, at: pos, in: self)
+    }
+
+    // MARK: - Text options panel (selected text segment)
+
+    /// Mutate the selected text segment and refresh everything that renders it.
+    private func mutateSelectedTextSegment(_ mutate: (VideoTextSegment) -> Void) {
+        guard let seg = selectedTextSegment else { return }
+        mutate(seg)
+        seg.rememberStyle()
+        textRasterCache.removeValue(forKey: seg.id)
+        savedURL = nil
+        applyZoomTransformForCurrentTime()
+        forcePreviewRedisplayIfPaused()
+        effectsBand?.refreshAfterParentEdit()
+        needsDisplay = true
+    }
+
+    /// AVFoundation does not reliably re-render a paused frame when the
+    /// player item's videoComposition is swapped in place, so style changes
+    /// made while paused would not show until the next seek or play. A
+    /// zero-tolerance seek to the current time forces the compositor to
+    /// re-render the visible frame.
+    fileprivate func forcePreviewRedisplayIfPaused() {
+        guard let player = player, player.rate == 0 else { return }
+        let t = player.currentTime()
+        player.seek(to: t, toleranceBefore: .zero, toleranceAfter: .zero)
+    }
+
+    /// Apply one panel edit to the selected segment, then re-sync the panel
+    /// so dependent controls (size label, swatches, enabled states) update.
+    private func handleTextOptionsChange(_ change: VideoTextOptionsPanel.Change) {
+        guard let seg = selectedTextSegment else { return }
+        switch change {
+        case .fontFamily(let family):
+            mutateSelectedTextSegment { $0.fontFamily = family }
+        case .fontSize(let size):
+            mutateSelectedTextSegment { $0.fontSize = size }
+        case .bold(let flag):
+            mutateSelectedTextSegment { $0.bold = flag }
+        case .italic(let flag):
+            mutateSelectedTextSegment { $0.italic = flag }
+        case .bgStyle(let style):
+            mutateSelectedTextSegment { $0.bgStyle = style }
+        case .alignment(let alignment):
+            mutateSelectedTextSegment { $0.alignment = alignment }
+        case .outlineEnabled(let flag):
+            mutateSelectedTextSegment { $0.outlineEnabled = flag }
+        case .outlineWidth(let width):
+            mutateSelectedTextSegment { $0.outlineWidth = width }
+        case .pickTextColor:
+            presentTextColorPicker(segmentID: seg.id, target: .text)
+        case .pickBgColor:
+            presentTextColorPicker(segmentID: seg.id, target: .background)
+        case .pickOutlineColor:
+            presentTextColorPicker(segmentID: seg.id, target: .outline)
+        }
+        textOptionsPanel?.configure(with: seg)
+    }
+
+    /// Show the panel (configured for the selection) or collapse it. Follows
+    /// the `effectsBand(_:didChangeRowCount:)` pattern: the panel's height
+    /// constraint and the player's bottom constraint animate together, and
+    /// the custom-drawn chrome above re-lays out via `textOptionsPanelH`.
+    private func updateTextOptionsPanelVisibility() {
+        if let seg = selectedTextSegment {
+            textOptionsPanel?.configure(with: seg)
+        }
+        let targetH: CGFloat = selectedTextSegment != nil ? VideoTextOptionsPanel.preferredHeight : 0
+        guard textOptionsPanelH != targetH else { return }
+        textOptionsPanelH = targetH
+        textOptionsPanel?.isHidden = (targetH == 0)
+        textOptionsPanelHeightConstraint?.animator().constant = targetH
+        playerBottomConstraint?.animator().constant = -controlsH
+        needsDisplay = true
     }
 
     private func showGIFFPSMenu() {
@@ -3112,20 +3252,27 @@ private final class VideoEditorView: NSView {
 
     // MARK: - Custom color picker
 
-    /// Open NSColorPanel and bind it to the given segment's text or bg
-    /// color field. The panel stays modal-less so the user can keep
+    /// Open NSColorPanel and bind it to the given segment's text, background,
+    /// or outline color field. The panel stays modal-less so the user can keep
     /// editing other things; we observe `colorDidChange` notifications
     /// while it's relevant and unbind on close.
     fileprivate func presentTextColorPicker(segmentID: UUID, isBackground: Bool) {
-        guard textSegments.contains(where: { $0.id == segmentID }) else { return }
+        presentTextColorPicker(segmentID: segmentID, target: isBackground ? .background : .text)
+    }
+
+    fileprivate func presentTextColorPicker(segmentID: UUID, target: TextColorPickTarget) {
+        guard let seg = textSegments.first(where: { $0.id == segmentID }) else { return }
         textColorPickerSegmentID = segmentID
-        textColorPickerIsBackground = isBackground
+        textColorPickerTarget = target
         let panel = NSColorPanel.shared
         panel.showsAlpha = true
-        if let seg = textSegments.first(where: { $0.id == segmentID }) {
-            let rgba = isBackground ? seg.bgColor : seg.textColor
-            panel.color = NSColor(srgbRed: rgba.r, green: rgba.g, blue: rgba.b, alpha: rgba.a)
+        let rgba: VideoTextSegment.RGBA
+        switch target {
+        case .text: rgba = seg.textColor
+        case .background: rgba = seg.bgColor
+        case .outline: rgba = seg.outlineColor
         }
+        panel.color = NSColor(srgbRed: rgba.r, green: rgba.g, blue: rgba.b, alpha: rgba.a)
         // Hook up the action target. Reuse a single observer per editor.
         panel.setTarget(self)
         panel.setAction(#selector(textColorPanelDidChange(_:)))
@@ -3141,15 +3288,21 @@ private final class VideoEditorView: NSView {
             g: Double(c.greenComponent),
             b: Double(c.blueComponent),
             a: Double(c.alphaComponent))
-        if textColorPickerIsBackground {
-            seg.bgColor = rgba
-        } else {
-            seg.textColor = rgba
+        switch textColorPickerTarget {
+        case .text: seg.textColor = rgba
+        case .background: seg.bgColor = rgba
+        case .outline: seg.outlineColor = rgba
         }
+        seg.rememberStyle()
         textRasterCache.removeValue(forKey: id)
         savedURL = nil
         applyZoomTransformForCurrentTime()
+        forcePreviewRedisplayIfPaused()
         effectsBand?.refreshAfterParentEdit()
+        // Keep the bottom panel's swatches in sync with live color edits.
+        if seg.id == selectedTextSegmentID, let selected = selectedTextSegment {
+            textOptionsPanel?.configure(with: selected)
+        }
     }
 }
 
@@ -3161,7 +3314,15 @@ extension VideoEditorView: EffectsBandViewDelegate {
     }
 
     func effectsBand(_ view: EffectsBandView, didSelectSegment segmentID: UUID?) {
+        // Show the bottom text-options panel when a text segment is selected.
+        if let id = segmentID, textSegments.contains(where: { $0.id == id }) {
+            selectedTextSegmentID = id
+        } else {
+            selectedTextSegmentID = nil
+        }
+        updateTextOptionsPanelVisibility()
         updateEffectsOverlay()
+        needsDisplay = true
     }
 
     func effectsBand(_ view: EffectsBandView, didChangeRowCount rowCount: Int) {

--- a/macshot/UI/Editor/VideoEditorWindowController.swift
+++ b/macshot/UI/Editor/VideoEditorWindowController.swift
@@ -165,6 +165,11 @@ private final class VideoEditorView: NSView {
     // drives the bottom text-options panel.
     private var addEffectBtnRect: NSRect = .zero
     private var selectedTextSegmentID: UUID?
+    /// While a text/censor segment is selected, the preview composition is
+    /// built without zoom so the selection rect and the rendered content
+    /// match 1:1 (zoom would transform the content but not the overlay).
+    /// Exports are never affected.
+    private var previewSuspendsZoom = false
     private var selectedTextSegment: VideoTextSegment? {
         guard let id = selectedTextSegmentID else { return nil }
         return textSegments.first(where: { $0.id == id })
@@ -919,39 +924,6 @@ private final class VideoEditorView: NSView {
             x += segW + 12
         }
 
-        do {
-            let infoAttrs: [NSAttributedString.Key: Any] = [
-                .font: NSFont.systemFont(ofSize: 10, weight: .regular),
-                .foregroundColor: ToolbarLayout.iconColor.withAlphaComponent(0.4),
-            ]
-            let sourceFileSize = (try? FileManager.default.attributesOfItem(atPath: videoURL.path)[.size] as? Int) ?? 0
-            let sizeStr = ByteCountFormatter.string(fromByteCount: Int64(sourceFileSize), countStyle: .file)
-            let fpsValue = asset?.tracks(withMediaType: .video).first?.nominalFrameRate ?? 0
-            let fpsStr = fpsValue > 0 ? "\(Int(fpsValue.rounded()))fps" : ""
-            let infoStr = "\(sizeStr)  ·  \(fpsStr)" as NSString
-            let infoSize = infoStr.size(withAttributes: infoAttrs)
-            if x + infoSize.width < maxLeftX {
-                infoStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - infoSize.height) / 2), withAttributes: infoAttrs)
-                x += infoSize.width + 12
-            }
-
-            // "+ Effect" button — add zoom/censor/cut/speed/freeze/text at the playhead
-            addEffectBtnRect = .zero
-            if effectsBand != nil && x < maxLeftX {
-                let addAttrs: [NSAttributedString.Key: Any] = [
-                    .font: NSFont.systemFont(ofSize: 10, weight: .medium),
-                    .foregroundColor: ToolbarLayout.iconColor.withAlphaComponent(0.7),
-                ]
-                let addStr = "  ·  + \(L("Effect")) ▼" as NSString
-                let addSize = addStr.size(withAttributes: addAttrs)
-                let addBtnW = addSize.width + 8
-                if x + addBtnW < maxLeftX {
-                    addEffectBtnRect = NSRect(x: x, y: btnY, width: addBtnW, height: btnH)
-                    addStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - addSize.height) / 2), withAttributes: addAttrs)
-                    x += addBtnW
-                }
-            }
-
             // Dimensions dropdown button
             dimensionsBtnRect = .zero
             if originalWidth > 0 && x < maxLeftX {
@@ -1010,6 +982,39 @@ private final class VideoEditorView: NSView {
                     fpsStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - fpsSize.height) / 2), withAttributes: fpsAttrs)
                     x += fpsBtnW
                 }
+            }
+
+            // "+ Effect" button — add zoom/censor/cut/speed/freeze/text at the playhead
+            addEffectBtnRect = .zero
+            if effectsBand != nil && x < maxLeftX {
+                let addAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 10, weight: .medium),
+                    .foregroundColor: ToolbarLayout.iconColor.withAlphaComponent(0.7),
+                ]
+                let addStr = "  ·  + \(L("Effect")) ▼" as NSString
+                let addSize = addStr.size(withAttributes: addAttrs)
+                let addBtnW = addSize.width + 8
+                if x + addBtnW < maxLeftX {
+                    addEffectBtnRect = NSRect(x: x, y: btnY, width: addBtnW, height: btnH)
+                    addStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - addSize.height) / 2), withAttributes: addAttrs)
+                    x += addBtnW
+                }
+            }
+
+        do {
+            let infoAttrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 10, weight: .regular),
+                .foregroundColor: ToolbarLayout.iconColor.withAlphaComponent(0.4),
+            ]
+            let sourceFileSize = (try? FileManager.default.attributesOfItem(atPath: videoURL.path)[.size] as? Int) ?? 0
+            let sizeStr = ByteCountFormatter.string(fromByteCount: Int64(sourceFileSize), countStyle: .file)
+            let fpsValue = asset?.tracks(withMediaType: .video).first?.nominalFrameRate ?? 0
+            let fpsStr = fpsValue > 0 ? "\(Int(fpsValue.rounded()))fps" : ""
+            let infoStr = "\(sizeStr)  ·  \(fpsStr)" as NSString
+            let infoSize = infoStr.size(withAttributes: infoAttrs)
+            if x + infoSize.width < maxLeftX {
+                infoStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - infoSize.height) / 2), withAttributes: infoAttrs)
+                x += infoSize.width + 12
             }
 
             // Estimated export size — show when trim, scale, quality, or format change would affect output
@@ -2532,7 +2537,8 @@ private final class VideoEditorView: NSView {
                 videoTrack: asset.tracks(withMediaType: .video).first,
                 renderSize: nil,
                 timeMap: singleShiftTimeMap(shift: 0, duration: CMTimeGetSeconds(asset.duration)),
-                timeRangeDuration: CMTimeGetSeconds(asset.duration)
+                timeRangeDuration: CMTimeGetSeconds(asset.duration),
+                suspendZoom: previewSuspendsZoom
             )
             return
         }
@@ -2557,7 +2563,8 @@ private final class VideoEditorView: NSView {
                     videoTrack: cvt,
                     renderSize: nil,
                     timeMap: piecesToTimeMap(pieces: pieces),
-                    timeRangeDuration: CMTimeGetSeconds(compAsset.duration)
+                    timeRangeDuration: CMTimeGetSeconds(compAsset.duration),
+                    suspendZoom: previewSuspendsZoom
                 )
             } else {
                 currentItem.videoComposition = nil
@@ -2583,7 +2590,8 @@ private final class VideoEditorView: NSView {
                 videoTrack: processed.videoTrack,
                 renderSize: nil,
                 timeMap: processed.timeMap,
-                timeRangeDuration: processed.duration
+                timeRangeDuration: processed.duration,
+                suspendZoom: previewSuspendsZoom
             )
         }
         swapPreviewPlayerItem(asset: processed.composition, videoComposition: videoComp)
@@ -2744,7 +2752,7 @@ private final class VideoEditorView: NSView {
     ///     without cuts pass a single entry spanning the whole composition.
     ///   - timeRangeDuration: total length (in composition time) of the
     ///     instruction's timeRange.
-    private func buildEffectsVideoComposition(for asset: AVAsset, videoTrack: AVAssetTrack?, renderSize: CGSize?, timeMap: [EffectsCompositionInstruction.TimeMapEntry], timeRangeDuration: Double) -> AVMutableVideoComposition? {
+    private func buildEffectsVideoComposition(for asset: AVAsset, videoTrack: AVAssetTrack?, renderSize: CGSize?, timeMap: [EffectsCompositionInstruction.TimeMapEntry], timeRangeDuration: Double, suspendZoom: Bool = false) -> AVMutableVideoComposition? {
         let track = videoTrack ?? asset.tracks(withMediaType: .video).first
         guard let videoTrack = track else { return nil }
         let natSize = videoTrack.naturalSize.applying(videoTrack.preferredTransform)
@@ -2775,7 +2783,7 @@ private final class VideoEditorView: NSView {
 
         // Snapshot segments *by value* into plain arrays. The compositor runs
         // on background queues; we must not share main-actor state with it.
-        let zoomSnapshot = zoomSegments
+        let zoomSnapshot = suspendZoom ? [] : zoomSegments
             .filter { $0.endTime > $0.startTime }
             .sorted { $0.startTime < $1.startTime }
         let censorSnapshot = censorSegments
@@ -3330,6 +3338,18 @@ extension VideoEditorView: EffectsBandViewDelegate {
             selectedTextSegmentID = id
         } else {
             selectedTextSegmentID = nil
+        }
+        // Suspend zoom in the preview while positioning content that the
+        // zoom would visually displace relative to the selection overlay.
+        let shouldSuspend: Bool = {
+            guard let id = segmentID else { return false }
+            return textSegments.contains(where: { $0.id == id })
+                || censorSegments.contains(where: { $0.id == id })
+        }()
+        if previewSuspendsZoom != shouldSuspend {
+            previewSuspendsZoom = shouldSuspend
+            applyZoomTransformForCurrentTime()
+            forcePreviewRedisplayIfPaused()
         }
         updateTextOptionsPanelVisibility()
         updateEffectsOverlay()

--- a/macshot/UI/Editor/VideoEditorWindowController.swift
+++ b/macshot/UI/Editor/VideoEditorWindowController.swift
@@ -431,6 +431,11 @@ private final class VideoEditorView: NSView {
             let size = track.naturalSize.applying(track.preferredTransform)
             overlay.videoSize = CGSize(width: abs(size.width), height: abs(size.height))
         }
+        overlay.onDragEnded = { [weak self] in
+            // Snap the displayed rect to the segment's actual state (zoom
+            // clamping may have adjusted center/level during the drag).
+            self?.refreshOverlaySelection()
+        }
         overlay.onChange = { [weak self] newRect in
             self?.overlayRectChanged(newRect)
         }
@@ -930,6 +935,23 @@ private final class VideoEditorView: NSView {
                 x += infoSize.width + 12
             }
 
+            // "+ Effect" button — add zoom/censor/cut/speed/freeze/text at the playhead
+            addEffectBtnRect = .zero
+            if effectsBand != nil && x < maxLeftX {
+                let addAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 10, weight: .medium),
+                    .foregroundColor: ToolbarLayout.iconColor.withAlphaComponent(0.7),
+                ]
+                let addStr = "  ·  + \(L("Effect")) ▼" as NSString
+                let addSize = addStr.size(withAttributes: addAttrs)
+                let addBtnW = addSize.width + 8
+                if x + addBtnW < maxLeftX {
+                    addEffectBtnRect = NSRect(x: x, y: btnY, width: addBtnW, height: btnH)
+                    addStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - addSize.height) / 2), withAttributes: addAttrs)
+                    x += addBtnW
+                }
+            }
+
             // Dimensions dropdown button
             dimensionsBtnRect = .zero
             if originalWidth > 0 && x < maxLeftX {
@@ -987,23 +1009,6 @@ private final class VideoEditorView: NSView {
                     gifFPSBtnRect = NSRect(x: x, y: btnY, width: fpsBtnW, height: btnH)
                     fpsStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - fpsSize.height) / 2), withAttributes: fpsAttrs)
                     x += fpsBtnW
-                }
-            }
-
-            // "+ Effect" button — add zoom/censor/cut/speed/freeze/text at the playhead
-            addEffectBtnRect = .zero
-            if effectsBand != nil && x < maxLeftX {
-                let addAttrs: [NSAttributedString.Key: Any] = [
-                    .font: NSFont.systemFont(ofSize: 10, weight: .medium),
-                    .foregroundColor: ToolbarLayout.iconColor.withAlphaComponent(0.7),
-                ]
-                let addStr = "  ·  + \(L("Effect")) ▼" as NSString
-                let addSize = addStr.size(withAttributes: addAttrs)
-                let addBtnW = addSize.width + 8
-                if x + addBtnW < maxLeftX {
-                    addEffectBtnRect = NSRect(x: x, y: btnY, width: addBtnW, height: btnH)
-                    addStr.draw(at: NSPoint(x: x + 4, y: btnY + (btnH - addSize.height) / 2), withAttributes: addAttrs)
-                    x += addBtnW
                 }
             }
 
@@ -1355,8 +1360,11 @@ private final class VideoEditorView: NSView {
     /// (center, zoomLevel) as its source of truth.
     private func rectForZoom(_ seg: VideoZoomSegment) -> CGRect {
         let side = 1.0 / max(seg.zoomLevel, 0.0001)
-        let x = seg.center.x - side / 2
-        let y = seg.center.y - side / 2
+        // Clamp so the displayed rect always matches the actually-visible
+        // zoom window (the compositor cannot pan past the frame edge).
+        let c = VideoZoomSegment.clampedCenter(seg.center, zoom: seg.zoomLevel)
+        let x = c.x - side / 2
+        let y = c.y - side / 2
         return CGRect(x: x, y: y, width: side, height: side)
     }
 
@@ -1372,8 +1380,11 @@ private final class VideoEditorView: NSView {
             let desiredZoom = 1.0 / side
             seg.zoomLevel = max(VideoZoomSegment.minZoom,
                                  min(VideoZoomSegment.maxZoom, desiredZoom))
-            // Center on the rect midpoint
-            seg.center = CGPoint(x: rect.midX, y: rect.midY)
+            // Center on the rect midpoint, clamped so the zoom window stays
+            // fully inside the frame — otherwise the compositor's edge clamp
+            // would show a different region than the drawn rect.
+            seg.center = VideoZoomSegment.clampedCenter(
+                CGPoint(x: rect.midX, y: rect.midY), zoom: seg.zoomLevel)
         } else if let seg = censorSegments.first(where: { $0.id == id }) {
             seg.rect = VideoCensorSegment.clampedRect(rect)
         } else if let seg = textSegments.first(where: { $0.id == id }) {

--- a/macshot/UI/Editor/VideoTextOptionsPanel.swift
+++ b/macshot/UI/Editor/VideoTextOptionsPanel.swift
@@ -1,0 +1,347 @@
+import Cocoa
+
+/// Bottom options panel for the currently selected video text segment — a
+/// full inspector row with real AppKit controls (font family, size,
+/// bold/italic, colors, background style, glyph outline, alignment). It
+/// replaces the old custom-drawn mini inspector in the editor's buttons row.
+///
+/// Pure UI: `configure(with:)` pushes segment state into the controls and
+/// every user edit is reported through `onChange` — the panel never reads or
+/// mutates the model itself.
+final class VideoTextOptionsPanel: NSView {
+
+    /// A single user edit made in the panel.
+    enum Change {
+        case fontFamily(String)
+        case fontSize(CGFloat)
+        case bold(Bool)
+        case italic(Bool)
+        case bgStyle(VideoTextSegment.BackgroundStyle)
+        case alignment(VideoTextSegment.Alignment)
+        case outlineEnabled(Bool)
+        case outlineWidth(CGFloat)
+        case pickTextColor
+        case pickBgColor
+        case pickOutlineColor
+    }
+
+    var onChange: ((Change) -> Void)?
+
+    /// Height the editor gives the panel while it's visible.
+    static let preferredHeight: CGFloat = 34
+
+    private let fontPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let sizeSlider = NSSlider()
+    private let sizeLabel = NSTextField(labelWithString: "48pt")
+    private let boldButton = NSButton()
+    private let italicButton = NSButton()
+    private let textColorSwatch = NSButton()
+    private let bgColorSwatch = NSButton()
+    private let bgStyleControl = NSSegmentedControl()
+    private let outlineCheckbox = NSButton()
+    private let outlineColorSwatch = NSButton()
+    private let outlineWidthSlider = NSSlider()
+    private let alignmentControl = NSSegmentedControl()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.masksToBounds = true
+        layer?.backgroundColor = ToolbarLayout.iconColor.withAlphaComponent(0.06).cgColor
+        // Match appearance to the toolbar background brightness so native
+        // controls (popup, checkbox, segmented labels) stay readable on the
+        // editor chrome.
+        appearance = ToolbarLayout.appearance
+
+        buildControls()
+        layoutControls()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    // Consume clicks in the gaps between controls so they don't fall through
+    // to the editor view's mouseDown (which clears the segment selection and
+    // would immediately hide this panel).
+    override func mouseDown(with event: NSEvent) {}
+    override func mouseUp(with event: NSEvent) {}
+
+    // MARK: - Sync from model
+
+    /// Sync every control to the segment's current style. Called when the
+    /// selection changes and after external edits (e.g. the color panel).
+    func configure(with seg: VideoTextSegment) {
+        selectFontFamily(seg.fontFamily)
+
+        sizeSlider.doubleValue = Double(seg.fontSize)
+        sizeLabel.stringValue = "\(Int(seg.fontSize.rounded()))pt"
+
+        boldButton.state = seg.bold ? .on : .off
+        italicButton.state = seg.italic ? .on : .off
+
+        textColorSwatch.layer?.backgroundColor = nsColor(seg.textColor).cgColor
+        bgColorSwatch.layer?.backgroundColor = nsColor(seg.bgColor).cgColor
+
+        switch seg.bgStyle {
+        case .none: bgStyleControl.selectedSegment = 0
+        case .solid: bgStyleControl.selectedSegment = 1
+        case .rounded: bgStyleControl.selectedSegment = 2
+        }
+
+        outlineCheckbox.state = seg.outlineEnabled ? .on : .off
+        outlineColorSwatch.layer?.backgroundColor = nsColor(seg.outlineColor).cgColor
+        outlineColorSwatch.isEnabled = seg.outlineEnabled
+        outlineColorSwatch.layer?.opacity = seg.outlineEnabled ? 1.0 : 0.35
+        outlineWidthSlider.doubleValue = Double(seg.outlineWidth)
+        outlineWidthSlider.isEnabled = seg.outlineEnabled
+
+        switch seg.alignment {
+        case .left: alignmentControl.selectedSegment = 0
+        case .center: alignmentControl.selectedSegment = 1
+        case .right: alignmentControl.selectedSegment = 2
+        }
+    }
+
+    // MARK: - Control construction
+
+    private func buildControls() {
+        // Font family
+        fontPopup.controlSize = .small
+        fontPopup.font = NSFont.systemFont(ofSize: 10)
+        fontPopup.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        fontPopup.toolTip = L("Font")
+        fontPopup.target = self
+        fontPopup.action = #selector(fontFamilyChanged(_:))
+        rebuildFontMenu()
+
+        // Size
+        sizeSlider.minValue = 12
+        sizeSlider.maxValue = 200
+        sizeSlider.isContinuous = true
+        sizeSlider.controlSize = .small
+        sizeSlider.trackFillColor = ToolbarLayout.accentColor
+        sizeSlider.toolTip = L("Size")
+        sizeSlider.target = self
+        sizeSlider.action = #selector(sizeChanged(_:))
+
+        sizeLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .medium)
+        sizeLabel.textColor = ToolbarLayout.iconColor.withAlphaComponent(0.7)
+        sizeLabel.alignment = .left
+
+        // Bold / italic toggles
+        configureToggle(boldButton,
+                        title: "B",
+                        font: NSFont.systemFont(ofSize: 11, weight: .bold),
+                        toolTip: L("Bold"),
+                        action: #selector(boldToggled(_:)))
+        let italicFont: NSFont = {
+            let base = NSFont.systemFont(ofSize: 11, weight: .medium)
+            let d = base.fontDescriptor.withSymbolicTraits(.italic)
+            return NSFont(descriptor: d, size: 11) ?? base
+        }()
+        configureToggle(italicButton,
+                        title: "I",
+                        font: italicFont,
+                        toolTip: L("Italic"),
+                        action: #selector(italicToggled(_:)))
+
+        // Color swatches
+        configureSwatch(textColorSwatch, toolTip: L("Text Color"), action: #selector(textColorClicked))
+        configureSwatch(bgColorSwatch, toolTip: L("Background"), action: #selector(bgColorClicked))
+        configureSwatch(outlineColorSwatch, toolTip: L("Outline"), action: #selector(outlineColorClicked))
+
+        // Background style
+        bgStyleControl.segmentCount = 3
+        bgStyleControl.setLabel(L("None"), forSegment: 0)
+        bgStyleControl.setLabel(L("Solid"), forSegment: 1)
+        bgStyleControl.setLabel(L("Rounded"), forSegment: 2)
+        bgStyleControl.trackingMode = .selectOne
+        bgStyleControl.controlSize = .small
+        bgStyleControl.selectedSegmentBezelColor = ToolbarLayout.accentColor
+        bgStyleControl.toolTip = L("Background")
+        bgStyleControl.target = self
+        bgStyleControl.action = #selector(bgStyleChanged(_:))
+
+        // Outline: checkbox + color swatch + width slider
+        outlineCheckbox.setButtonType(.switch)
+        outlineCheckbox.title = L("Outline")
+        outlineCheckbox.controlSize = .small
+        outlineCheckbox.font = NSFont.systemFont(ofSize: 10, weight: .medium)
+        outlineCheckbox.target = self
+        outlineCheckbox.action = #selector(outlineToggled(_:))
+
+        outlineWidthSlider.minValue = 0.5
+        outlineWidthSlider.maxValue = 8
+        outlineWidthSlider.isContinuous = true
+        outlineWidthSlider.controlSize = .small
+        outlineWidthSlider.trackFillColor = ToolbarLayout.accentColor
+        outlineWidthSlider.toolTip = L("Outline")
+        outlineWidthSlider.target = self
+        outlineWidthSlider.action = #selector(outlineWidthChanged(_:))
+
+        // Alignment
+        alignmentControl.segmentCount = 3
+        let alignSymbols = ["text.alignleft", "text.aligncenter", "text.alignright"]
+        for (index, name) in alignSymbols.enumerated() {
+            let image = NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+                .withSymbolConfiguration(.init(pointSize: 11, weight: .medium))
+            alignmentControl.setImage(image, forSegment: index)
+            alignmentControl.setWidth(28, forSegment: index)
+        }
+        alignmentControl.trackingMode = .selectOne
+        alignmentControl.controlSize = .small
+        alignmentControl.selectedSegmentBezelColor = ToolbarLayout.accentColor
+        alignmentControl.target = self
+        alignmentControl.action = #selector(alignmentChanged(_:))
+    }
+
+    private func configureToggle(_ button: NSButton, title: String, font: NSFont,
+                                 toolTip: String, action: Selector) {
+        button.setButtonType(.pushOnPushOff)
+        button.bezelStyle = .recessed
+        button.controlSize = .small
+        button.font = font
+        button.title = title
+        button.toolTip = toolTip
+        button.target = self
+        button.action = action
+    }
+
+    private func configureSwatch(_ button: NSButton, toolTip: String, action: Selector) {
+        button.title = ""
+        button.isBordered = false
+        button.wantsLayer = true
+        button.layer?.cornerRadius = 4
+        button.layer?.borderWidth = 1
+        button.layer?.borderColor = ToolbarLayout.iconColor.withAlphaComponent(0.4).cgColor
+        button.toolTip = toolTip
+        button.target = self
+        button.action = action
+    }
+
+    private func rebuildFontMenu() {
+        let menu = NSMenu()
+        let systemItem = NSMenuItem(title: L("System"), action: nil, keyEquivalent: "")
+        systemItem.representedObject = "System"
+        menu.addItem(systemItem)
+        menu.addItem(.separator())
+        for family in NSFontManager.shared.availableFontFamilies.sorted() {
+            // Skip private families (leading '.') — internal UI fonts.
+            if family.hasPrefix(".") { continue }
+            let item = NSMenuItem(title: family, action: nil, keyEquivalent: "")
+            item.representedObject = family
+            menu.addItem(item)
+        }
+        fontPopup.menu = menu
+    }
+
+    private func selectFontFamily(_ family: String) {
+        guard let menu = fontPopup.menu else { return }
+        let index = menu.items.firstIndex { ($0.representedObject as? String) == family }
+        fontPopup.selectItem(at: index ?? 0)
+    }
+
+    private func layoutControls() {
+        func caption(_ text: String) -> NSTextField {
+            let label = NSTextField(labelWithString: text)
+            label.font = NSFont.systemFont(ofSize: 10, weight: .medium)
+            label.textColor = ToolbarLayout.iconColor.withAlphaComponent(0.7)
+            return label
+        }
+
+        let stack = NSStackView(views: [
+            fontPopup,
+            sizeSlider, sizeLabel,
+            boldButton, italicButton,
+            caption("Aa"), textColorSwatch,
+            caption(L("BG")), bgColorSwatch,
+            bgStyleControl,
+            outlineCheckbox, outlineColorSwatch, outlineWidthSlider,
+            alignmentControl,
+        ])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 8
+        stack.edgeInsets = NSEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            fontPopup.widthAnchor.constraint(lessThanOrEqualToConstant: 150),
+            fontPopup.widthAnchor.constraint(greaterThanOrEqualToConstant: 90),
+            sizeSlider.widthAnchor.constraint(equalToConstant: 80),
+            sizeLabel.widthAnchor.constraint(equalToConstant: 38),
+            boldButton.widthAnchor.constraint(equalToConstant: 26),
+            italicButton.widthAnchor.constraint(equalToConstant: 26),
+            textColorSwatch.widthAnchor.constraint(equalToConstant: 18),
+            textColorSwatch.heightAnchor.constraint(equalToConstant: 18),
+            bgColorSwatch.widthAnchor.constraint(equalToConstant: 18),
+            bgColorSwatch.heightAnchor.constraint(equalToConstant: 18),
+            outlineColorSwatch.widthAnchor.constraint(equalToConstant: 18),
+            outlineColorSwatch.heightAnchor.constraint(equalToConstant: 18),
+            outlineWidthSlider.widthAnchor.constraint(equalToConstant: 60),
+        ])
+    }
+
+    // MARK: - Control actions
+
+    @objc private func fontFamilyChanged(_ sender: NSPopUpButton) {
+        let family = (sender.selectedItem?.representedObject as? String) ?? "System"
+        onChange?(.fontFamily(family))
+    }
+
+    @objc private func sizeChanged(_ sender: NSSlider) {
+        let size = CGFloat(sender.doubleValue.rounded())
+        sizeLabel.stringValue = "\(Int(size))pt"
+        onChange?(.fontSize(size))
+    }
+
+    @objc private func boldToggled(_ sender: NSButton) {
+        onChange?(.bold(sender.state == .on))
+    }
+
+    @objc private func italicToggled(_ sender: NSButton) {
+        onChange?(.italic(sender.state == .on))
+    }
+
+    @objc private func textColorClicked() { onChange?(.pickTextColor) }
+    @objc private func bgColorClicked() { onChange?(.pickBgColor) }
+    @objc private func outlineColorClicked() { onChange?(.pickOutlineColor) }
+
+    @objc private func bgStyleChanged(_ sender: NSSegmentedControl) {
+        let style: VideoTextSegment.BackgroundStyle
+        switch sender.selectedSegment {
+        case 1: style = .solid
+        case 2: style = .rounded
+        default: style = .none
+        }
+        onChange?(.bgStyle(style))
+    }
+
+    @objc private func outlineToggled(_ sender: NSButton) {
+        onChange?(.outlineEnabled(sender.state == .on))
+    }
+
+    @objc private func outlineWidthChanged(_ sender: NSSlider) {
+        onChange?(.outlineWidth(CGFloat(sender.doubleValue)))
+    }
+
+    @objc private func alignmentChanged(_ sender: NSSegmentedControl) {
+        let alignment: VideoTextSegment.Alignment
+        switch sender.selectedSegment {
+        case 0: alignment = .left
+        case 2: alignment = .right
+        default: alignment = .center
+        }
+        onChange?(.alignment(alignment))
+    }
+
+    private func nsColor(_ c: VideoTextSegment.RGBA) -> NSColor {
+        NSColor(srgbRed: c.r, green: c.g, blue: c.b, alpha: c.a)
+    }
+}


### PR DESCRIPTION
## Summary

Styling text segments in the video editor previously required the timeline context menu for every attribute, offered no font choice or letter outline, reset to defaults for every new segment, and edits made while paused were not visible until the next seek. This PR adds a proper inspector panel and fixes all of that.

## What is new

### 1. Text style panel (new `UI/Editor/VideoTextOptionsPanel.swift`)
Selecting a text segment on the effects band reveals an inspector strip between the preview and the band, built from native AppKit controls:
- font family popup (System + all installed families)
- size slider 12-200 pt with a live pt label
- Bold / Italic toggles
- text color and background color swatches - they open the system color panel, changes apply continuously
- background style: None / Solid / Rounded
- glyph outline: on/off, color and width 0.5-8 pt (new capability, see below)
- alignment: left / center / right

Every control applies to the selected segment immediately.

### 2. Model & rasterizer: font family + glyph outline
`VideoTextSegment` gains `fontFamily`, `outlineEnabled`, `outlineColor`, `outlineWidth`. Codable is now explicit with `decodeIfPresent` + defaults, so previously saved styles keep decoding. `VideoTextRasterizer` resolves the family with bold/italic traits (falling back to the system font) and renders the outline as a stroke pass under the fill; the new fields are part of the raster `Spec`, so caches invalidate correctly and exports (MP4/GIF) include them.

### 3. Style memory
New segments start with the style of the last edited one (`withLastUsedStyle` / `rememberStyle`, persisted in UserDefaults) instead of the white-on-black defaults - no more re-styling every segment. All mutation points persist: the context menu, the color panel and the new inspector.

### 4. "+ Effect" toolbar button
The add-effect menu (previously discoverable only by right-clicking the timeline) is now also a visible toolbar button; items insert at the playhead and enable/disable based on available gaps exactly like the context menu (the menu builder was refactored into a shared `addEffectMenu(clickTime:)`).

### 5. Instant refresh while paused
AVFoundation does not reliably re-render a paused frame when `videoComposition` is swapped in place, so style edits looked like they did not apply until the next seek or play. `forcePreviewRedisplayIfPaused()` performs a zero-tolerance seek to the current time after composition updates - edits are visible the moment you make them.

## Notes
- No overlap with #306 (different files).
- Tested on macOS 26.5.2 (M5 Max): the panel live-updates the paused preview; MP4 and GIF exports include font family and outline; old saved styles decode fine.

## Follow-up commits: zoom WYSIWYG fix

Fixes #301

The zoom selection rect and the actually-rendered zoom region could differ - especially near frame edges (the compositor clamps panning at the edge, while the UI rect did not account for it), and the drawn rect could have an arbitrary aspect ratio while a zoom always renders in the video aspect.

- `VideoZoomSegment.clampedCenter(_:zoom:)` - the zoom center is clamped so the visible window always fits inside the frame; the UI and the compositor now agree by construction.
- The overlay locks the zoom selection to the video aspect ratio while resizing, and keeps it inside the frame and inside the 1.2x-5x zoom range.
- On drag end the displayed rect snaps to the segment actual clamped state, so what you see is exactly what renders.
- Usability: the toolbar "+ Effect" button is drawn earlier in the row so it is not dropped at narrow widths, and Add Zoom / Add Speed fall back to the nearest free gap when the playhead is inside an existing segment instead of being disabled.