### PR TITLE
feat: add Baidu Translate and configurable target language

### DIFF
--- a/macshot/Services/BaiduTranslationClient.swift
+++ b/macshot/Services/BaiduTranslationClient.swift
@@ -1,0 +1,370 @@
+import CryptoKit
+import Foundation
+
+/// Baidu General Text Translation API adapter.
+///
+/// Baidu accepts newline-separated text as one batch and returns one
+/// `trans_result` entry per source line. Keeping that behavior here avoids
+/// coupling provider-specific language codes and rate limits to UI callers.
+enum BaiduTranslationClient {
+    struct IndexedText {
+        let index: Int
+        let text: String
+    }
+
+    private final class BatchState: @unchecked Sendable {
+        nonisolated(unsafe) var output: [String]
+
+        nonisolated init(texts: [String], translatedIndexes: Set<Int>) {
+            output = texts
+            for index in translatedIndexes {
+                output[index] = ""
+            }
+        }
+
+        nonisolated func append(_ translation: String, at index: Int) {
+            if output[index].isEmpty {
+                output[index] = translation
+            } else {
+                output[index] += " \(translation)"
+            }
+        }
+    }
+
+    final class RequestThrottle: @unchecked Sendable {
+        nonisolated let interval: TimeInterval
+        nonisolated private let lock = NSLock()
+        nonisolated(unsafe) private var nextStart: TimeInterval = 0
+
+        nonisolated init(interval: TimeInterval) {
+            self.interval = interval
+        }
+
+        nonisolated func reserveDelay(now: TimeInterval) -> TimeInterval {
+            lock.lock()
+            defer { lock.unlock() }
+
+            let start = max(now, nextStart)
+            nextStart = start + interval
+            return start - now
+        }
+
+        nonisolated func schedule(_ work: @escaping @Sendable () -> Void) {
+            let delay = reserveDelay(now: ProcessInfo.processInfo.systemUptime)
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(
+                deadline: .now() + delay,
+                execute: work
+            )
+        }
+    }
+
+    enum ClientError: LocalizedError {
+        case notConfigured
+        case invalidResponse
+        case resultCountMismatch(expected: Int, actual: Int)
+        case httpError(Int)
+        case apiError(code: String, message: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notConfigured:
+                return "Configure Baidu Translate APP ID and Secret Key in Settings."
+            case .invalidResponse:
+                return "Could not parse the Baidu Translate response."
+            case .resultCountMismatch(let expected, let actual):
+                return "Baidu Translate returned \(actual) result(s) for \(expected) source text(s)."
+            case .httpError(let status):
+                return "Baidu Translate returned HTTP \(status)."
+            case .apiError(let code, let message):
+                return "Baidu Translate error \(code): \(message)"
+            }
+        }
+    }
+
+    nonisolated private static let endpoint = URL(
+        string: "https://fanyi-api.baidu.com/api/trans/vip/translate"
+    )!
+    nonisolated private static let maxChunkUTF8Bytes = 5_500
+    nonisolated private static let requestThrottle = RequestThrottle(interval: 1.05)
+
+    nonisolated private static let languageCodes: [String: String] = [
+        "zh-CN": "zh",
+        "zh-TW": "cht",
+        "ja": "jp",
+        "ko": "kor",
+        "fr": "fra",
+        "es": "spa",
+        "ar": "ara",
+        "sv": "swe",
+        "da": "dan",
+        "fi": "fin",
+        "nb": "nor",
+        "uk": "ukr",
+        "ro": "rom",
+        "bg": "bul",
+        "hr": "hrv",
+        "vi": "vie",
+    ]
+
+    nonisolated static func languageCode(for code: String) -> String {
+        languageCodes[code] ?? code
+    }
+
+    nonisolated static func signature(
+        appID: String,
+        query: String,
+        salt: String,
+        secret: String
+    ) -> String {
+        let source = Data("\(appID)\(query)\(salt)\(secret)".utf8)
+        return Insecure.MD5.hash(data: source)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    nonisolated static func indexedNonEmptyTexts(_ texts: [String]) -> [IndexedText] {
+        texts.enumerated().compactMap { index, text in
+            let normalized = text
+                .components(separatedBy: .newlines)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            return normalized.isEmpty ? nil : IndexedText(index: index, text: normalized)
+        }
+    }
+
+    nonisolated static func preparedTexts(
+        _ texts: [String],
+        maxUTF8Bytes: Int
+    ) -> [IndexedText] {
+        indexedNonEmptyTexts(texts).flatMap { item in
+            splitText(item.text, maxUTF8Bytes: maxUTF8Bytes).map {
+                IndexedText(index: item.index, text: $0)
+            }
+        }
+    }
+
+    private nonisolated static func splitText(
+        _ text: String,
+        maxUTF8Bytes: Int
+    ) -> [String] {
+        guard !text.isEmpty, maxUTF8Bytes > 0 else { return [] }
+
+        var parts: [String] = []
+        var current = ""
+        var currentBytes = 0
+
+        for character in text {
+            let characterBytes = String(character).lengthOfBytes(using: .utf8)
+            if !current.isEmpty && currentBytes + characterBytes > maxUTF8Bytes {
+                parts.append(current)
+                current = ""
+                currentBytes = 0
+            }
+            current.append(character)
+            currentBytes += characterBytes
+        }
+
+        if !current.isEmpty {
+            parts.append(current)
+        }
+        return parts
+    }
+
+    nonisolated static func configurationError(
+        appID: String,
+        secret: String
+    ) -> ClientError? {
+        let cleanAppID = appID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanSecret = secret.trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleanAppID.isEmpty || cleanSecret.isEmpty ? .notConfigured : nil
+    }
+
+    nonisolated static func makeChunks(
+        from texts: [IndexedText],
+        maxUTF8Bytes: Int
+    ) -> [[IndexedText]] {
+        guard !texts.isEmpty else { return [] }
+
+        var chunks: [[IndexedText]] = []
+        var current: [IndexedText] = []
+        var currentBytes = 0
+
+        for item in texts {
+            let itemBytes = item.text.lengthOfBytes(using: .utf8)
+            let separatorBytes = current.isEmpty ? 0 : 1
+            if !current.isEmpty && currentBytes + separatorBytes + itemBytes > maxUTF8Bytes {
+                chunks.append(current)
+                current = []
+                currentBytes = 0
+            }
+            current.append(item)
+            currentBytes += (current.count == 1 ? 0 : 1) + itemBytes
+        }
+
+        if !current.isEmpty {
+            chunks.append(current)
+        }
+        return chunks
+    }
+
+    nonisolated static func decodeTranslations(
+        data: Data,
+        expectedCount: Int
+    ) throws -> [String] {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ClientError.invalidResponse
+        }
+
+        if let rawCode = object["error_code"] {
+            let code = String(describing: rawCode)
+            let message = object["error_msg"] as? String ?? "Unknown error"
+            throw ClientError.apiError(code: code, message: message)
+        }
+
+        guard let rawResults = object["trans_result"] as? [[String: Any]] else {
+            throw ClientError.invalidResponse
+        }
+        guard rawResults.count == expectedCount else {
+            throw ClientError.resultCountMismatch(
+                expected: expectedCount,
+                actual: rawResults.count
+            )
+        }
+
+        return try rawResults.map { item in
+            guard let translated = item["dst"] as? String else {
+                throw ClientError.invalidResponse
+            }
+            return translated
+        }
+    }
+
+    nonisolated static func translateBatch(
+        texts: [String],
+        targetLang: String,
+        appID: String,
+        secret: String,
+        completion: @escaping (Result<[String], Error>) -> Void
+    ) {
+        let cleanAppID = appID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanSecret = secret.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let error = configurationError(appID: cleanAppID, secret: cleanSecret) {
+            completeOnMain(.failure(error), completion: completion)
+            return
+        }
+
+        let indexed = preparedTexts(texts, maxUTF8Bytes: maxChunkUTF8Bytes)
+        guard !indexed.isEmpty else {
+            completeOnMain(.success(texts), completion: completion)
+            return
+        }
+
+        let chunks = makeChunks(from: indexed, maxUTF8Bytes: maxChunkUTF8Bytes)
+        let state = BatchState(
+            texts: texts,
+            translatedIndexes: Set(indexed.map(\.index))
+        )
+
+        func processChunk(at chunkIndex: Int) {
+            guard chunkIndex < chunks.count else {
+                completeOnMain(.success(state.output), completion: completion)
+                return
+            }
+
+            let chunk = chunks[chunkIndex]
+            request(
+                chunk: chunk,
+                targetLang: targetLang,
+                appID: cleanAppID,
+                secret: cleanSecret
+            ) { result in
+                switch result {
+                case .failure(let error):
+                    completeOnMain(.failure(error), completion: completion)
+
+                case .success(let translations):
+                    for (item, translated) in zip(chunk, translations) {
+                        state.append(translated, at: item.index)
+                    }
+                    processChunk(at: chunkIndex + 1)
+                }
+            }
+        }
+
+        processChunk(at: 0)
+    }
+
+    private nonisolated static func request(
+        chunk: [IndexedText],
+        targetLang: String,
+        appID: String,
+        secret: String,
+        completion: @escaping (Result<[String], Error>) -> Void
+    ) {
+        let query = chunk.map(\.text).joined(separator: "\n")
+        let salt = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        let sign = signature(appID: appID, query: query, salt: salt, secret: secret)
+
+        var form = URLComponents()
+        form.queryItems = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "from", value: "auto"),
+            URLQueryItem(name: "to", value: languageCode(for: targetLang)),
+            URLQueryItem(name: "appid", value: appID),
+            URLQueryItem(name: "salt", value: salt),
+            URLQueryItem(name: "sign", value: sign),
+        ]
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue(
+            "application/x-www-form-urlencoded; charset=utf-8",
+            forHTTPHeaderField: "Content-Type"
+        )
+        request.timeoutInterval = 15
+        request.httpBody = form.percentEncodedQuery?.data(using: .utf8)
+        let preparedRequest = request
+
+        requestThrottle.schedule {
+            URLSession.shared.dataTask(with: preparedRequest) { data, response, error in
+                if let error {
+                    completion(.failure(error))
+                    return
+                }
+                if let http = response as? HTTPURLResponse,
+                   !(200...299).contains(http.statusCode) {
+                    completion(.failure(ClientError.httpError(http.statusCode)))
+                    return
+                }
+                guard let data else {
+                    completion(.failure(ClientError.invalidResponse))
+                    return
+                }
+
+                do {
+                    let translations = try decodeTranslations(
+                        data: data,
+                        expectedCount: chunk.count
+                    )
+                    completion(.success(translations))
+                } catch {
+                    completion(.failure(error))
+                }
+            }.resume()
+        }
+    }
+
+    private nonisolated static func completeOnMain<T>(
+        _ result: Result<T, Error>,
+        completion: @escaping (Result<T, Error>) -> Void
+    ) {
+        if Thread.isMainThread {
+            completion(result)
+        } else {
+            DispatchQueue.main.async {
+                completion(result)
+            }
+        }
+    }
+}

--- a/macshot/Services/TranslationProvider.swift
+++ b/macshot/Services/TranslationProvider.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum TranslationProvider: String {
+    case apple
+    case google
+    case baidu
+}

--- a/macshot/Services/TranslationService.swift
+++ b/macshot/Services/TranslationService.swift
@@ -4,11 +4,6 @@ import Combine
 import SwiftUI
 @preconcurrency import Translation
 
-enum TranslationProvider: String {
-    case apple = "apple"
-    case google = "google"
-}
-
 enum TranslationService {
 
     // MARK: - Provider
@@ -37,6 +32,16 @@ enum TranslationService {
     static var targetLanguage: String {
         get { UserDefaults.standard.string(forKey: "translateTargetLang") ?? "en" }
         set { UserDefaults.standard.set(newValue, forKey: "translateTargetLang") }
+    }
+
+    static var baiduAppID: String {
+        get { UserDefaults.standard.string(forKey: "baiduTranslateAppID") ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: "baiduTranslateAppID") }
+    }
+
+    static var baiduSecretKey: String {
+        get { UserDefaults.standard.string(forKey: "baiduTranslateSecretKey") ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: "baiduTranslateSecretKey") }
     }
 
     static let availableLanguages: [(code: String, name: String)] = [
@@ -151,10 +156,23 @@ enum TranslationService {
             return
         }
 
-        if #available(macOS 15.0, *), provider == .apple {
-            translateBatchApple(texts: texts, targetLang: targetLang, completion: completion)
-        } else {
+        switch provider {
+        case .apple:
+            if #available(macOS 15.0, *) {
+                translateBatchApple(texts: texts, targetLang: targetLang, completion: completion)
+            } else {
+                translateBatchGoogle(texts: texts, targetLang: targetLang, completion: completion)
+            }
+        case .google:
             translateBatchGoogle(texts: texts, targetLang: targetLang, completion: completion)
+        case .baidu:
+            BaiduTranslationClient.translateBatch(
+                texts: texts,
+                targetLang: targetLang,
+                appID: baiduAppID,
+                secret: baiduSecretKey,
+                completion: completion
+            )
         }
     }
 

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -138,6 +138,11 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     private var scrollMaxHeightStepper: NSStepper!
     private var scrollFrozenDetectionCheckbox: NSButton!
     private var languagePopup: NSPopUpButton!
+    private var translationProviderPopup: NSPopUpButton!
+    private var translationTargetPopup: NSPopUpButton!
+    private var baiduAppIDField: NSTextField!
+    private var baiduSecretKeyField: NSSecureTextField!
+    private var baiduSettingsViews: [NSView] = []
 
     var onHotkeyChanged: (() -> Void)?
 
@@ -991,35 +996,96 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
 
         // ── Translation ──────────────────────────────────────
+        stack.addArrangedSubview(sectionHeader(L("Translation")))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        translationProviderPopup = NSPopUpButton()
+        func addTranslationProvider(_ provider: TranslationProvider, title: String) {
+            translationProviderPopup.addItem(withTitle: title)
+            translationProviderPopup.lastItem?.representedObject = provider.rawValue
+        }
         if TranslationService.appleTranslationAvailable {
-            stack.addArrangedSubview(sectionHeader(L("Translation")))
-            stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+            addTranslationProvider(.apple, title: L("Apple (on-device)"))
+        }
+        addTranslationProvider(.google, title: L("Google Translate"))
+        addTranslationProvider(.baidu, title: L("Baidu Translate"))
+        selectTranslationProvider()
+        translationProviderPopup.target = self
+        translationProviderPopup.action = #selector(translationProviderChanged(_:))
+        stack.addArrangedSubview(labeledRow(L("Engine:"), controls: [translationProviderPopup]))
+        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
 
-            let translationProviderPopup = NSPopUpButton()
-            translationProviderPopup.addItems(withTitles: [
-                L("Apple (on-device)"),
-                L("Google Translate"),
-            ])
-            translationProviderPopup.selectItem(at: TranslationService.provider == .apple ? 0 : 1)
-            translationProviderPopup.target = self
-            translationProviderPopup.action = #selector(translationProviderChanged(_:))
-            stack.addArrangedSubview(labeledRow(L("Engine:"), controls: [translationProviderPopup]))
-            stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
+        translationTargetPopup = NSPopUpButton()
+        for language in TranslationService.availableLanguages {
+            translationTargetPopup.addItem(withTitle: language.name)
+            translationTargetPopup.lastItem?.representedObject = language.code
+        }
+        selectTranslationTarget()
+        translationTargetPopup.target = self
+        translationTargetPopup.action = #selector(translationTargetChanged(_:))
+        translationTargetPopup.widthAnchor.constraint(equalToConstant: 180).isActive = true
+        stack.addArrangedSubview(labeledRow(L("Translate to:"), controls: [translationTargetPopup]))
+        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
 
-            let providerNote = NSTextField(wrappingLabelWithString: L("Apple translation is faster and works offline. Google Translate supports more languages."))
-            providerNote.font = NSFont.systemFont(ofSize: 10)
-            providerNote.textColor = .secondaryLabelColor
-            stack.addArrangedSubview(indented(providerNote))
-            stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
+        let providerNote = NSTextField(wrappingLabelWithString: L("Apple translation is faster and works offline. Google Translate supports more languages."))
+        providerNote.font = NSFont.systemFont(ofSize: 10)
+        providerNote.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(indented(providerNote))
+        stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
 
-            let downloadLink = NSButton(title: L("Download language packs in System Settings…"), target: self, action: #selector(openTranslationSettings))
+        if TranslationService.appleTranslationAvailable {
+            let downloadLink = NSButton(
+                title: L("Download language packs in System Settings…"),
+                target: self,
+                action: #selector(openTranslationSettings)
+            )
             downloadLink.bezelStyle = .inline
             downloadLink.isBordered = false
             downloadLink.contentTintColor = .linkColor
             downloadLink.font = NSFont.systemFont(ofSize: 10)
             stack.addArrangedSubview(indented(downloadLink))
-            stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
+            stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
         }
+
+        baiduAppIDField = NSTextField()
+        baiduAppIDField.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        baiduAppIDField.stringValue = TranslationService.baiduAppID
+        baiduAppIDField.delegate = self
+        baiduAppIDField.widthAnchor.constraint(equalToConstant: 240).isActive = true
+        let baiduAppIDRow = labeledRow(L("APP ID:"), controls: [baiduAppIDField])
+        stack.addArrangedSubview(baiduAppIDRow)
+
+        baiduSecretKeyField = NSSecureTextField()
+        baiduSecretKeyField.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        baiduSecretKeyField.stringValue = TranslationService.baiduSecretKey
+        baiduSecretKeyField.delegate = self
+        baiduSecretKeyField.widthAnchor.constraint(equalToConstant: 240).isActive = true
+        let baiduSecretRow = labeledRow(L("Secret Key:"), controls: [baiduSecretKeyField])
+        stack.addArrangedSubview(baiduSecretRow)
+
+        let baiduNote = NSTextField(wrappingLabelWithString: L("Baidu APP ID and Secret Key are stored in this Mac's app preferences."))
+        baiduNote.font = NSFont.systemFont(ofSize: 10)
+        baiduNote.textColor = .secondaryLabelColor
+        let baiduNoteRow = indented(baiduNote)
+        stack.addArrangedSubview(baiduNoteRow)
+
+        let baiduConsoleLink = NSButton(
+            title: L("Open Baidu Translate console…"),
+            target: self,
+            action: #selector(openBaiduTranslationConsole)
+        )
+        baiduConsoleLink.bezelStyle = .inline
+        baiduConsoleLink.isBordered = false
+        baiduConsoleLink.contentTintColor = .linkColor
+        baiduConsoleLink.font = NSFont.systemFont(ofSize: 10)
+        let baiduConsoleRow = indented(baiduConsoleLink)
+        stack.addArrangedSubview(baiduConsoleRow)
+        stack.setCustomSpacing(20, after: stack.arrangedSubviews.last!)
+
+        baiduSettingsViews = [
+            baiduAppIDRow, baiduSecretRow, baiduNoteRow, baiduConsoleRow,
+        ]
+        updateBaiduSettingsVisibility()
 
         // ── Menu Bar Order ──────────────────────────────────
         stack.addArrangedSubview(sectionHeader(L("Menu Bar Order")))
@@ -2473,6 +2539,12 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         downscaleRetinaCheckbox.state = ImageEncoder.downscaleRetina ? .on : .off
         updateQualityVisibility()
 
+        selectTranslationProvider()
+        selectTranslationTarget()
+        baiduAppIDField.stringValue = TranslationService.baiduAppID
+        baiduSecretKeyField.stringValue = TranslationService.baiduSecretKey
+        updateBaiduSettingsVisibility()
+
         #if !OFFLINE
         imgbbKeyField.stringValue = UserDefaults.standard.string(forKey: "imgbbAPIKey") ?? ""
         #endif
@@ -3103,11 +3175,59 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     }
 
     @objc private func translationProviderChanged(_ sender: NSPopUpButton) {
-        TranslationService.provider = sender.indexOfSelectedItem == 0 ? .apple : .google
+        guard let rawValue = sender.selectedItem?.representedObject as? String,
+              let provider = TranslationProvider(rawValue: rawValue) else { return }
+        TranslationService.provider = provider
+        updateBaiduSettingsVisibility()
+    }
+
+    @objc private func translationTargetChanged(_ sender: NSPopUpButton) {
+        guard let code = sender.selectedItem?.representedObject as? String else { return }
+        TranslationService.targetLanguage = code
+    }
+
+    private func selectTranslationProvider() {
+        guard translationProviderPopup != nil else { return }
+        let rawValue = TranslationService.provider.rawValue
+        if let item = translationProviderPopup.itemArray.first(where: {
+            $0.representedObject as? String == rawValue
+        }) {
+            translationProviderPopup.select(item)
+        } else if let google = translationProviderPopup.itemArray.first(where: {
+            $0.representedObject as? String == TranslationProvider.google.rawValue
+        }) {
+            translationProviderPopup.select(google)
+            TranslationService.provider = .google
+        }
+    }
+
+    private func selectTranslationTarget() {
+        guard translationTargetPopup != nil else { return }
+        let code = TranslationService.targetLanguage
+        if let item = translationTargetPopup.itemArray.first(where: {
+            $0.representedObject as? String == code
+        }) {
+            translationTargetPopup.select(item)
+        }
+    }
+
+    private func updateBaiduSettingsVisibility() {
+        guard translationProviderPopup != nil else { return }
+        let isBaidu = translationProviderPopup.selectedItem?.representedObject as? String
+            == TranslationProvider.baidu.rawValue
+        for view in baiduSettingsViews {
+            view.isHidden = !isBaidu
+        }
     }
 
     @objc private func openTranslationSettings() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.Localization.Settings.extension?Translation") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    @objc private func openBaiduTranslationConsole() {
+        if let url = URL(string: "https://fanyi-api.baidu.com/") {
             NSWorkspace.shared.open(url)
         }
     }
@@ -3141,6 +3261,10 @@ extension SettingsWindowController: NSTextFieldDelegate {
             updateRecordingFilenamePreview()
         } else if field === menuBarIconSymbolField {
             applyMenuBarIconSymbol(field.stringValue)
+        } else if field === baiduAppIDField {
+            TranslationService.baiduAppID = field.stringValue
+        } else if field === baiduSecretKeyField {
+            TranslationService.baiduSecretKey = field.stringValue
         }
     }
 

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -1054,6 +1054,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         baiduAppIDField.widthAnchor.constraint(equalToConstant: 240).isActive = true
         let baiduAppIDRow = labeledRow(L("APP ID:"), controls: [baiduAppIDField])
         stack.addArrangedSubview(baiduAppIDRow)
+        stack.setCustomSpacing(6, after: baiduAppIDRow)
 
         baiduSecretKeyField = NSSecureTextField()
         baiduSecretKeyField.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -670,3 +670,9 @@
 
 /* Measure tool: clamp toggle (#212) */
 "Limit to selection" = "Limit to selection";
+
+/* Baidu translation */
+"Baidu Translate" = "Baidu Translate";
+"APP ID:" = "APP ID:";
+"Open Baidu Translate console…" = "Open Baidu Translate console…";
+"Baidu APP ID and Secret Key are stored in this Mac's app preferences." = "Baidu APP ID and Secret Key are stored in this Mac's app preferences.";

--- a/macshot/zh-Hans.lproj/Localizable.strings
+++ b/macshot/zh-Hans.lproj/Localizable.strings
@@ -668,3 +668,9 @@
 
 /* URL scheme: edit (PR #272) */
 "Open a history entry in the editor (keeps annotations editable)" = "在编辑器中打开历史记录（保持标注可编辑）";
+
+/* Baidu translation */
+"Baidu Translate" = "百度翻译";
+"APP ID:" = "APP ID:";
+"Open Baidu Translate console…" = "打开百度翻译控制台…";
+"Baidu APP ID and Secret Key are stored in this Mac's app preferences." = "百度 APP ID 和密钥会存储在这台 Mac 的应用偏好设置中。";

--- a/macshot/zh-Hant.lproj/Localizable.strings
+++ b/macshot/zh-Hant.lproj/Localizable.strings
@@ -668,3 +668,9 @@
 
 /* URL scheme: edit (PR #272) */
 "Open a history entry in the editor (keeps annotations editable)" = "在編輯器中開啟歷史記錄項目（標註仍可編輯）";
+
+/* Baidu translation */
+"Baidu Translate" = "百度翻譯";
+"APP ID:" = "APP ID:";
+"Open Baidu Translate console…" = "開啟百度翻譯控制台…";
+"Baidu APP ID and Secret Key are stored in this Mac's app preferences." = "百度 APP ID 和密鑰會儲存在這部 Mac 的 App 偏好設定中。";

--- a/scripts/tests/BaiduTranslationClientTests.swift
+++ b/scripts/tests/BaiduTranslationClientTests.swift
@@ -121,6 +121,21 @@ struct BaiduTranslationClientTests {
         expect(chunks.map { $0.map(\.index) } == [[0, 1], [2]],
                "chunks at source item boundaries")
 
+        do {
+            let settingsSource = try String(
+                contentsOfFile: "macshot/UI/Windows/SettingsWindowController.swift",
+                encoding: .utf8
+            )
+            expect(
+                settingsSource.contains(
+                    "stack.setCustomSpacing(6, after: baiduAppIDRow)"
+                ),
+                "separates the Baidu APP ID and Secret Key rows"
+            )
+        } catch {
+            fail("reads settings source for Baidu row spacing: \(error)")
+        }
+
         if failures == 0 {
             print("BaiduTranslationClientTests: all checks passed")
         } else {

--- a/scripts/tests/BaiduTranslationClientTests.swift
+++ b/scripts/tests/BaiduTranslationClientTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+@main
+struct BaiduTranslationClientTests {
+    private static var failures = 0
+
+    static func main() {
+        expect(TranslationProvider(rawValue: "baidu") == .baidu,
+               "declares Baidu as a translation provider")
+        expect(SettingsPortability.looksSecret("baiduTranslateSecretKey"),
+               "excludes the Baidu secret from settings export")
+        expect(SettingsPortability.isPortable("baiduTranslateAppID"),
+               "allows the non-secret Baidu APP ID in settings export")
+
+        expect(BaiduTranslationClient.languageCode(for: "zh-CN") == "zh",
+               "maps Simplified Chinese")
+        expect(BaiduTranslationClient.languageCode(for: "zh-TW") == "cht",
+               "maps Traditional Chinese")
+        expect(BaiduTranslationClient.languageCode(for: "ja") == "jp",
+               "maps Japanese")
+        expect(BaiduTranslationClient.languageCode(for: "en") == "en",
+               "passes through Baidu-compatible codes")
+
+        let signature = BaiduTranslationClient.signature(
+            appID: "2015063000000001",
+            query: "apple",
+            salt: "65478",
+            secret: "1234567890"
+        )
+        expect(signature == "a1a7461d92e5194c5cae3182b5b24de1",
+               "matches Baidu's documented signature")
+
+        let successJSON = Data("""
+        {
+          "from": "en",
+          "to": "zh",
+          "trans_result": [
+            {"src": "apple", "dst": "苹果"},
+            {"src": "banana", "dst": "香蕉"}
+          ]
+        }
+        """.utf8)
+        do {
+            let translations = try BaiduTranslationClient.decodeTranslations(
+                data: successJSON,
+                expectedCount: 2
+            )
+            expect(translations == ["苹果", "香蕉"],
+                   "decodes ordered translation results")
+        } catch {
+            fail("decodes ordered translation results: \(error)")
+        }
+
+        let apiErrorJSON = Data("""
+        {"error_code": "54001", "error_msg": "Invalid Sign"}
+        """.utf8)
+        expectThrows("surfaces Baidu API errors") {
+            _ = try BaiduTranslationClient.decodeTranslations(
+                data: apiErrorJSON,
+                expectedCount: 1
+            )
+        }
+
+        expectThrows("rejects mismatched result counts") {
+            _ = try BaiduTranslationClient.decodeTranslations(
+                data: successJSON,
+                expectedCount: 1
+            )
+        }
+
+        let indexed = BaiduTranslationClient.indexedNonEmptyTexts([
+            " hello ", "", " \n ", "world",
+        ])
+        expect(indexed.map(\.index) == [0, 3],
+               "preserves indexes for non-empty text")
+        expect(indexed.map(\.text) == ["hello", "world"],
+               "trims non-empty source text")
+
+        let multiline = BaiduTranslationClient.indexedNonEmptyTexts([
+            "first line\nsecond line",
+        ])
+        expect(multiline.map(\.text) == ["first line second line"],
+               "normalizes embedded newlines before batching")
+
+        let split = BaiduTranslationClient.preparedTexts(
+            ["abcdefghijk"],
+            maxUTF8Bytes: 5
+        )
+        expect(split.map(\.index) == [0, 0, 0],
+               "keeps the source index when splitting long text")
+        expect(split.allSatisfy { $0.text.lengthOfBytes(using: .utf8) <= 5 },
+               "splits a long source text at UTF-8-safe boundaries")
+
+        let throttle = BaiduTranslationClient.RequestThrottle(interval: 1.05)
+        let firstDelay = throttle.reserveDelay(now: 100)
+        let secondDelay = throttle.reserveDelay(now: 100)
+        expect(firstDelay == 0 && abs(secondDelay - 1.05) < 0.000_1,
+               "reserves globally spaced request start times")
+
+        expect(
+            BaiduTranslationClient.configurationError(appID: "", secret: "secret") != nil,
+            "requires a Baidu APP ID"
+        )
+        expect(
+            BaiduTranslationClient.configurationError(appID: "appid", secret: " ") != nil,
+            "requires a Baidu Secret Key"
+        )
+        expect(
+            BaiduTranslationClient.configurationError(appID: "appid", secret: "secret") == nil,
+            "accepts complete Baidu credentials"
+        )
+
+        let chunks = BaiduTranslationClient.makeChunks(
+            from: [
+                .init(index: 0, text: "1234"),
+                .init(index: 1, text: "5678"),
+                .init(index: 2, text: "90"),
+            ],
+            maxUTF8Bytes: 9
+        )
+        expect(chunks.map { $0.map(\.index) } == [[0, 1], [2]],
+               "chunks at source item boundaries")
+
+        if failures == 0 {
+            print("BaiduTranslationClientTests: all checks passed")
+        } else {
+            fputs("BaiduTranslationClientTests: \(failures) failure(s)\n", stderr)
+            exit(1)
+        }
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ name: String
+    ) {
+        if condition() {
+            print("PASS: \(name)")
+        } else {
+            fail(name)
+        }
+    }
+
+    private static func expectThrows(
+        _ name: String,
+        _ operation: () throws -> Void
+    ) {
+        do {
+            try operation()
+            fail(name)
+        } catch {
+            print("PASS: \(name)")
+        }
+    }
+
+    private static func fail(_ name: String) {
+        failures += 1
+        fputs("FAIL: \(name)\n", stderr)
+    }
+}


### PR DESCRIPTION
## Motivation

Google Translate is unavailable in mainland China, which makes the existing translation feature unusable for users in that region. In addition, macshot currently does not provide a settings entry for changing the translation target language.

This PR adds Baidu Translate as an alternative provider and introduces a target-language selector in Settings, making the translation feature accessible and configurable for users in mainland China.

## Summary

- Add Baidu Translate as a translation provider.
- Add translation provider and target-language selectors to Settings.
- Add APP ID and Secret Key configuration fields shown only when Baidu Translate is selected.
- Keep the Baidu Secret Key out of portable settings exports.

## Implementation

- Use Baidu's official General Text Translation API with POST form requests and MD5 signatures.
- Map macshot language codes to Baidu-compatible language codes.
- Batch source text within API size limits and safely split long text.
- Apply shared request throttling to respect Baidu's standard 1 QPS limit.
- Preserve source ordering and empty entries across translated batches.
- Normalize embedded newlines to avoid response-count mismatches.
- Store APP ID and Secret Key in the app's local preferences.

## Testing

- Added a standalone regression test harness covering:
  - Provider registration
  - Credential validation
  - Secret export filtering
  - Language-code mapping
  - Official signature example
  - API response and error parsing
  - Multiline normalization
  - Long-text splitting
  - Shared request throttling
  - Settings row spacing
- Verified the macOS Debug build with Xcode.
- Manually verified the Baidu credential settings UI.

## Notes

- The Secret Key is stored locally in `UserDefaults`, following the selected implementation approach.
- The Secret Key is excluded from settings export by the existing secret-key filtering logic.