### PR TITLE
Show progress during video export (#323)

### DIFF
--- a/macshot/UI/Editor/VideoEditorWindowController.swift
+++ b/macshot/UI/Editor/VideoEditorWindowController.swift
@@ -209,6 +209,9 @@ private final class VideoEditorView: NSView {
     private var statusMessage: String?
     private var statusIsError: Bool = false
     private var statusTimer: Timer?
+    /// Guards against re-entrant Save/Copy while an export is running (#323 —
+    /// users repeatedly click Save when a long export gives no feedback).
+    private var isExporting: Bool = false
 
     // Layout
     private let timelinePad: CGFloat = 20
@@ -1476,7 +1479,49 @@ private final class VideoEditorView: NSView {
         needsDisplay = true
     }
 
+    /// Runs the correct MP4 export pipeline (custom reencode for non-High
+    /// quality, else AVAssetExportSession) and surfaces progress as a
+    /// persistent "Exporting... X%" status — the same feedback GIF export
+    /// already gives (#323). Calls `completion(success)` on the main thread.
+    private func performExport(asset: AVAsset, timeRange: CMTimeRange, outputURL: URL, completion: @escaping (Bool) -> Void) {
+        isExporting = true
+        let onProgress: (Double) -> Void = { [weak self] fraction in
+            DispatchQueue.main.async {
+                self?.showStatus(String(format: L("Exporting...") + " %d%%", Int(fraction * 100)), persist: true)
+            }
+        }
+        let done: (Bool) -> Void = { [weak self] success in
+            DispatchQueue.main.async {
+                self?.isExporting = false
+                completion(success)
+            }
+        }
+
+        if exportQuality != .high {
+            reencodeExport(asset: asset, timeRange: timeRange, outputURL: outputURL, progress: onProgress, completion: done)
+        } else {
+            guard let session = exportSession(asset: asset, timeRange: timeRange, outputURL: outputURL) else {
+                done(false)
+                return
+            }
+            // AVAssetExportSession has no per-frame callback — poll its
+            // `progress` on a main run-loop timer while the export runs.
+            let timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { [weak session] t in
+                guard let session = session else { t.invalidate(); return }
+                onProgress(Double(session.progress))
+            }
+            Task {
+                await session.export()
+                await MainActor.run {
+                    timer.invalidate()
+                    done(session.status == .completed)
+                }
+            }
+        }
+    }
+
     private func copyToClipboard() {
+        guard !isExporting else { return }
         // If GIF mode is selected but no GIF has been saved yet, convert to a temp GIF first
         if exportAsGIF && !isGIF && !(savedURL?.pathExtension.lowercased() == "gif") {
             showStatus(L("Converting to GIF…"))
@@ -1538,25 +1583,9 @@ private final class VideoEditorView: NSView {
         let tmpURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".\(videoURL.pathExtension)")
         let timeRange = CMTimeRange(start: CMTime(seconds: trimStart, preferredTimescale: 600),
                                     end: CMTime(seconds: trimEnd, preferredTimescale: 600))
-        // reencodeExport can complete from its background queue on early
-        // exits — always hop to main before touching pasteboard/UI.
-        let done: (Bool) -> Void = { success in
-            DispatchQueue.main.async {
-                if !success { try? FileManager.default.removeItem(at: tmpURL) }
-                completion(success ? tmpURL : nil)
-            }
-        }
-        if exportQuality != .high {
-            reencodeExport(asset: asset, timeRange: timeRange, outputURL: tmpURL, completion: done)
-        } else {
-            guard let session = exportSession(asset: asset, timeRange: timeRange, outputURL: tmpURL) else {
-                done(false)
-                return
-            }
-            Task {
-                await session.export()
-                await MainActor.run { done(session.status == .completed) }
-            }
+        performExport(asset: asset, timeRange: timeRange, outputURL: tmpURL) { success in
+            if !success { try? FileManager.default.removeItem(at: tmpURL) }
+            completion(success ? tmpURL : nil)
         }
     }
 
@@ -1638,6 +1667,7 @@ private final class VideoEditorView: NSView {
     }
 
     private func saveVideo() {
+        guard !isExporting else { return }
         if exportAsGIF && !isGIF {
             // GIF mode: need Save As panel since extension changes
             saveVideoAs()
@@ -1937,7 +1967,6 @@ private final class VideoEditorView: NSView {
     }
 
     private func saveToDestination(_ destURL: URL, dirURL: URL?) {
-        let needsRecompress = exportQuality != .high
         let needsExport = hasPendingEdits
 
         if !needsExport {
@@ -1972,14 +2001,14 @@ private final class VideoEditorView: NSView {
         }
 
         guard let asset = asset else { return }
-        showStatus(L("Exporting..."))
+        showStatus(L("Exporting..."), persist: true)
 
         let tmpURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".\(videoURL.pathExtension)")
         let startTime = CMTime(seconds: trimStart, preferredTimescale: 600)
         let endTime = CMTime(seconds: trimEnd, preferredTimescale: 600)
         let timeRange = CMTimeRange(start: startTime, end: endTime)
 
-        let onCompletion: (Bool) -> Void = { [weak self] success in
+        performExport(asset: asset, timeRange: timeRange, outputURL: tmpURL) { [weak self] success in
             guard let self = self else { return }
             if success {
                 try? FileManager.default.removeItem(at: destURL)
@@ -1997,25 +2026,12 @@ private final class VideoEditorView: NSView {
                 try? FileManager.default.removeItem(at: tmpURL)
             }
         }
-
-        if needsRecompress {
-            reencodeExport(asset: asset, timeRange: timeRange, outputURL: tmpURL, completion: onCompletion)
-        } else {
-            guard let session = exportSession(asset: asset, timeRange: timeRange, outputURL: tmpURL) else {
-                showStatus(L("Export failed"), isError: true)
-                return
-            }
-            Task {
-                await session.export()
-                await MainActor.run { onCompletion(session.status == .completed) }
-            }
-        }
     }
 
     /// Re-encode pipeline with explicit bitrate control via AVAssetReader/Writer.
     /// Used when the user selects a non-High quality preset so the bitrate
     /// actually takes effect (AVAssetExportSession presets hardcode bitrate).
-    private func reencodeExport(asset: AVAsset, timeRange: CMTimeRange, outputURL: URL, completion: @escaping (Bool) -> Void) {
+    private func reencodeExport(asset: AVAsset, timeRange: CMTimeRange, outputURL: URL, progress: ((Double) -> Void)? = nil, completion: @escaping (Bool) -> Void) {
         guard let videoTrack = asset.tracks(withMediaType: .video).first else {
             completion(false)
             return
@@ -2166,7 +2182,10 @@ private final class VideoEditorView: NSView {
                 let videoQueue = DispatchQueue(label: "macshot.export.video")
                 let audioQueue = DispatchQueue(label: "macshot.export.audio")
 
-                // Pump video
+                // Pump video. Progress is driven off the video track only
+                // (audio finishes near-instantly and would muddy the estimate).
+                let totalSeconds = CMTimeGetSeconds(readerTimeRange.duration)
+                var lastReportedPct = -1
                 group.enter()
                 videoInput.requestMediaDataWhenReady(on: videoQueue) {
                     while videoInput.isReadyForMoreMediaData {
@@ -2184,6 +2203,15 @@ private final class VideoEditorView: NSView {
                                 videoInput.markAsFinished()
                                 group.leave()
                                 return
+                            }
+                        }
+                        // Report processed-time / total-time, throttled to whole
+                        // percent so the callback fires ~100x, not per frame.
+                        if let progress = progress, totalSeconds > 0 {
+                            let pct = Int(min(1.0, CMTimeGetSeconds(shifted) / totalSeconds) * 100)
+                            if pct != lastReportedPct {
+                                lastReportedPct = pct
+                                progress(Double(pct) / 100.0)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Closes #323. MP4 export gave no progress feedback: the transient "Exporting..." status disappeared after 3s, so users assumed the export had stalled and repeatedly clicked Save (the reporter clicked 4 times).

Both MP4 export pipelines now surface `Exporting... X%` — the same feedback GIF export already provides — using the existing `showStatus` renderer (no new UI, matching colors).

- **`reencodeExport`** (non-High quality path): reports progress from the video pump loop as `processedPTS / totalDuration`, throttled to whole percent, reusing the same `(Double) -> Void` callback contract as `GifskiExporter`.
- **`performExport`**: new helper that unifies the previously-duplicated dispatch across `exportEditedTemp` and `saveToDestination`. Non-High quality → `reencodeExport`; High quality → `AVAssetExportSession` with a 0.2s timer polling its `.progress`.
- **`isExporting` guard**: blocks re-entrant Save/Copy while an export is running.

## Testing

- Release build (`xcodebuild -configuration Release`, Xcode 26.6) — succeeds, no strict-concurrency errors.
- Manually verified in the video editor on a real 50MB recording: percentage counts up to completion on both the High-quality (AVAssetExportSession) and reduced-quality (reencode) paths; Save/Copy is inert mid-export.

## Notes

Single-file change (+65/-37 in `VideoEditorWindowController.swift`). GIF export was already covered by #295 and is untouched.