### PR TITLE
fix(editor): copy video as playable pasteboard MP4 data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - **GIF export uses gifski when available** (app bundle, `/opt/homebrew/bin`, or `/usr/local/bin`) — encodes on all cores and streams frames to disk, so memory stays flat and long recordings no longer crash at finalize. Smaller, better-looking GIFs; falls back to the built-in encoder when gifski is absent. Thanks @anten-ka! (#295, #296)
 - GIF conversion runs at user-initiated priority instead of background — several times faster on Apple Silicon, where background QoS is confined to efficiency cores. (#296)
 
+### Fixed
+
+- **Video editor Copy** — copying an MP4 recording now writes playable video data to the clipboard instead of a sandboxed file URL that many apps reject. (#329)
+
 ## [4.2.1] - 2026-07-10
 
 ### Added

--- a/macshot/UI/Editor/VideoEditorWindowController.swift
+++ b/macshot/UI/Editor/VideoEditorWindowController.swift
@@ -1500,23 +1500,20 @@ private final class VideoEditorView: NSView {
                     self.showStatus(L("Export failed"), isError: true)
                     return
                 }
-                let pasteboard = NSPasteboard.general
-                pasteboard.clearContents()
-                pasteboard.writeObjects([url as NSURL])
-                self.showStatus(L("Copied to clipboard!"))
+                // exportEditedTemp always re-encodes to an MP4 container
+                // (AVAssetWriter/AVAssetExportSession hardcode fileType .mp4),
+                // so the exported bytes are MP4 regardless of the source name.
+                self.copyMP4Data(from: url, contentIsMP4: true)
             }
             return
         }
 
         let url = savedURL ?? videoURL
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
 
         if isGIF || url.pathExtension.lowercased() == "gif" {
             copyGIFData(from: url)
         } else {
-            pasteboard.writeObjects([url as NSURL])
-            showStatus(L("Copied to clipboard!"))
+            copyMP4Data(from: url)
         }
     }
 
@@ -1568,6 +1565,34 @@ private final class VideoEditorView: NSView {
             item.setData(data, forType: NSPasteboard.PasteboardType("com.compuserve.gif"))
             item.setString(url.absoluteString, forType: .fileURL)
             pasteboard.writeObjects([item])
+        }
+        showStatus(L("Copied to clipboard!"))
+    }
+
+    /// Copy video as playable pasteboard data. Inline bytes are advertised as
+    /// `public.mpeg-4` ONLY when they really are MP4: either the export pipeline
+    /// re-encoded them (`contentIsMP4`, used by the edited branch), or the source
+    /// file's extension conforms to mpeg4Movie (direct source copy). A `.mov`
+    /// source opened in the editor would otherwise have its QuickTime bytes
+    /// mislabeled as MP4 and rejected by Mail/Notes/Preview — regressing #329.
+    /// Non-MP4 sources, oversized recordings, and read errors fall back to the
+    /// file URL (the pre-#329 behaviour) instead of an empty/mislabeled paste.
+    private func copyMP4Data(from url: URL, contentIsMP4: Bool = false) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        let isMP4 = contentIsMP4
+            || (UTType(filenameExtension: url.pathExtension)?.conforms(to: .mpeg4Movie) ?? false)
+        let byteCount = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? UInt64) ?? 0
+        // Data(contentsOf:) allocates the full buffer up front and can be
+        // jetsam-killed before `try?` catches, so skip inline data for non-MP4
+        // sources or recordings over ~150 MB and land the file URL instead.
+        if isMP4, byteCount <= 150_000_000, let data = try? Data(contentsOf: url) {
+            let item = NSPasteboardItem()
+            item.setData(data, forType: NSPasteboard.PasteboardType(UTType.mpeg4Movie.identifier))
+            item.setString(url.absoluteString, forType: .fileURL)
+            pasteboard.writeObjects([item])
+        } else {
+            pasteboard.writeObjects([url as NSURL])
         }
         showStatus(L("Copied to clipboard!"))
     }


### PR DESCRIPTION
Closes #329.

## Problem

Copy in the video editor wrote only a file URL to the pasteboard. Apps that do not resolve file URLs from the pasteboard (Mail, Notes, Preview) therefore could not paste the recording — the paste was empty.

## Fix

Write the video bytes inline on the pasteboard as `public.mpeg-4` alongside the file URL, so inline-preferring apps can paste it. The bytes are advertised as MP4 **only when they really are MP4**:

- **Edited export branch** — the export pipeline re-encodes to an MP4 container (`AVAssetExportSession` `outputFileType = .mp4` / `AVAssetWriter(fileType: .mp4)`), so the bytes are MP4 regardless of the source name. Passes `contentIsMP4: true`.
- **Direct source-copy branch** — gated on `UTType(filenameExtension:)?.conforms(to: .mpeg4Movie)`. `.mp4`/`.m4v` → inline bytes; `.mov` (QuickTime) → falls back to the file URL only (the pre-#329 behavior), so QuickTime bytes are never mislabeled as MP4 and rejected by inline-preferring apps.

Recordings over ~150 MB and read errors also fall back to the file URL. A `FileManager` size pre-check avoids the OOM/jetsam risk of `Data(contentsOf:)` on huge files, so the documented "huge file" fallback now actually delivers.

Also adds a CHANGELOG entry.

## Verification

- Build green (`xcodebuild build`).
- Confirmed at runtime that `UTType(filenameExtension:)?.conforms(to: .mpeg4Movie)` behaves as expected: `mp4` → true, `m4v` → true, `mov` → false, missing extension → false.
- [ ] Manual: paste a copied recording into Mail/Notes/Preview and confirm it pastes as playable video.

## Notes

Two pre-existing rough edges surface via this change but are intentionally **not** fixed here (separate concerns, they mirror the existing `copyGIFData` path): the `Data(contentsOf:)` read is synchronous on the main thread (bounded by the 150 MB cap, same as GIF), and `exportEditedTemp` names the temp file with the source extension while always writing MP4 bytes (only the inline path is correct today).
