### PR TITLE
feat: cancel scroll capture on Escape instead of finalizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Escape now cancels an in-progress scroll capture instead of finalizing it (#333).
+
 ## [4.2.2-beta.1] - 2026-07-11
 
 ### Added

--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -2949,6 +2949,19 @@ extension AppDelegate: OverlayWindowControllerDelegate {
         // onSessionDone fires asynchronously via handleScrollCaptureCompleted
     }
 
+    func overlayDidRequestCancelScrollCapture(_ controller: OverlayWindowController) {
+        // Esc cancels scroll capture: tear down WITHOUT delivering an image
+        // (cancelSession never fires onSessionDone), so nothing is saved, copied,
+        // or added to history. Mirrors the Accessibility-denied teardown block.
+        scrollCaptureController?.cancelSession()
+        scrollCaptureController = nil
+        scrollCapturePreviewPanel?.close()
+        scrollCapturePreviewPanel = nil
+        scrollCaptureOverlayController?.setScrollCaptureState(isActive: false)
+        scrollCaptureOverlayController = nil
+        dismissOverlays()
+    }
+
     func overlayDidRequestAccessibilityPermission(_ controller: OverlayWindowController) {
         dismissOverlays()
         let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary

--- a/macshot/UI/Editor/DetachedEditorWindowController.swift
+++ b/macshot/UI/Editor/DetachedEditorWindowController.swift
@@ -581,6 +581,7 @@ extension DetachedEditorWindowController: OverlayViewDelegate {
     func overlayViewDidRequestDetach() {}
     func overlayViewDidRequestScrollCapture(rect: NSRect) {}
     func overlayViewDidRequestStopScrollCapture() {}
+    func overlayViewDidRequestCancelScrollCapture() {}
     func overlayViewDidRequestToggleAutoScroll() {}
     func overlayViewDidRequestAccessibilityPermission() {}
     func overlayViewDidRequestInputMonitoringPermission() {}
@@ -695,6 +696,7 @@ private class AddCaptureOverlayHandler: NSObject, OverlayWindowControllerDelegat
     func overlayDidRequestStopRecording(_ controller: OverlayWindowController) {}
     func overlayDidRequestScrollCapture(_ controller: OverlayWindowController, rect: NSRect, screen: NSScreen) {}
     func overlayDidRequestStopScrollCapture(_ controller: OverlayWindowController) {}
+    func overlayDidRequestCancelScrollCapture(_ controller: OverlayWindowController) {}
     func overlayDidRequestToggleAutoScroll(_ controller: OverlayWindowController) {}
     func overlayDidRequestAccessibilityPermission(_ controller: OverlayWindowController) {}
     func overlayDidRequestInputMonitoringPermission(_ controller: OverlayWindowController) {}

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -24,6 +24,7 @@ protocol OverlayViewDelegate: AnyObject {
     func overlayViewDidRequestDetach()
     func overlayViewDidRequestScrollCapture(rect: NSRect)
     func overlayViewDidRequestStopScrollCapture()
+    func overlayViewDidRequestCancelScrollCapture()
     func overlayViewDidRequestToggleAutoScroll()
     func overlayViewDidRequestAccessibilityPermission()
     func overlayViewDidRequestInputMonitoringPermission()
@@ -817,7 +818,7 @@ class OverlayView: NSView {
         let handleScrollKey: (NSEvent) -> Void = { [weak self] event in
             guard let self = self, self.isScrollCapturing else { return }
             if event.keyCode == 53 {  // Escape
-                self.overlayDelegate?.overlayViewDidRequestStopScrollCapture()
+                self.overlayDelegate?.overlayViewDidRequestCancelScrollCapture()
             }
         }
         scrollCaptureKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
@@ -9005,7 +9006,7 @@ class OverlayView: NSView {
         switch event.keyCode {
         case 53:  // Escape
             if isScrollCapturing {
-                overlayDelegate?.overlayViewDidRequestStopScrollCapture()
+                overlayDelegate?.overlayViewDidRequestCancelScrollCapture()
                 return
             }
             if isAnchoredSelecting {

--- a/macshot/UI/Overlay/OverlayWindowController.swift
+++ b/macshot/UI/Overlay/OverlayWindowController.swift
@@ -73,6 +73,7 @@ protocol OverlayWindowControllerDelegate: AnyObject {
     func overlayDidRequestScrollCapture(
         _ controller: OverlayWindowController, rect: NSRect, screen: NSScreen)
     func overlayDidRequestStopScrollCapture(_ controller: OverlayWindowController)
+    func overlayDidRequestCancelScrollCapture(_ controller: OverlayWindowController)
     func overlayDidRequestToggleAutoScroll(_ controller: OverlayWindowController)
     func overlayDidRequestAccessibilityPermission(_ controller: OverlayWindowController)
     func overlayDidRequestInputMonitoringPermission(_ controller: OverlayWindowController)
@@ -738,6 +739,10 @@ extension OverlayWindowController: OverlayViewDelegate {
 
     func overlayViewDidRequestStopScrollCapture() {
         overlayDelegate?.overlayDidRequestStopScrollCapture(self)
+    }
+
+    func overlayViewDidRequestCancelScrollCapture() {
+        overlayDelegate?.overlayDidRequestCancelScrollCapture(self)
     }
 
     func overlayViewDidRequestToggleAutoScroll() {


### PR DESCRIPTION
Closes #333.

## Problem
Escape during an in-progress scroll capture **finalized** the capture — it saved/copied the partial image and added it to history. The natural expectation for Esc is to **cancel**.

## Fix
Esc now tears down the scroll-capture overlay **without** delivering an image: `scrollCaptureController?.cancelSession()` (which never fires `onSessionDone`, so nothing is saved, copied, or added to history), then closes the preview panel and dismisses the overlays. A new `overlayViewDidRequestCancelScrollCapture` / `overlayDidRequestCancelScrollCapture` pair is added to the overlay protocols alongside the existing stop path, and the two Esc key-handlers (global monitor + local) now route to it.

## Test
`xcodebuild -project macshot.xcodeproj -scheme macshot CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED** (no PR CI on this repo). Manual: start a scroll capture, press Esc → no image is saved/copied; previously the partial capture was finalized.