### PR TITLE
fix(gif): export GIFs at real-time speed for non-divisor frame rates

### DIFF
--- a/macshot/Capture/GIFEncoder.swift
+++ b/macshot/Capture/GIFEncoder.swift
@@ -53,10 +53,13 @@ final class GIFEncoder {
         lock.lock()
         defer { lock.unlock() }
 
-        // Throttle to target fps
-        let keepEvery = max(1, sourceEstimatedFPS / targetFPS)
+        // Fractional decimation: keep a frame whenever the target timeline
+        // advances. Exact for any source/target fps pair (e.g. 24 -> 15), not
+        // only when target divides source evenly — mirrors GifskiExporter.
         inputFrameCount += 1
-        guard inputFrameCount % keepEvery == 0 else { return }
+        let prevTargetIndex = (inputFrameCount - 1) * targetFPS / sourceEstimatedFPS
+        let targetIndex = inputFrameCount * targetFPS / sourceEstimatedFPS
+        guard targetIndex > prevTargetIndex else { return }
 
         guard let dest = destination else { return }
 


### PR DESCRIPTION
## Problem
A GIF exported via the built-in `GIFEncoder` (the non-gifski fallback) plays at the wrong speed whenever the source clip's frame rate is not an exact multiple of the chosen GIF frame rate. For example, a 24 fps recording exported to 15 fps plays ~1.6× too slow; 60 fps exported to 24 fps plays ~1.25× too slow. Only exact-divisor pairs (30→15, 60→15) come out at real time.

## Root cause
`GIFEncoder.addFrame` throttled frames with integer division:
```swift
let keepEvery = max(1, sourceEstimatedFPS / targetFPS)
guard inputFrameCount % keepEvery == 0 else { return }
```
For 24→15, `keepEvery = 24 / 15 = 1` (integer truncation), so **every** source frame is kept — but each frame is still stamped with a `1/targetFPS` (`1/15`) delay. 24 frames × 1/15 s ≈ 1.6 s for 1.0 s of footage. The kept-frame rate and the per-frame delay were derived from different assumptions and only coincided when `targetFPS` divided `sourceEstimatedFPS` evenly.

The sibling `GifskiExporter` (the preferred path) already decimates correctly with fractional timestamps — `GIFEncoder` did not.

## Solution
Replace the integer `keepEvery` modulo throttle with the same fractional decimation `GifskiExporter` uses — keep a frame exactly when the target timeline advances:
```swift
inputFrameCount += 1
let prevTargetIndex = (inputFrameCount - 1) * targetFPS / sourceEstimatedFPS
let targetIndex     = inputFrameCount     * targetFPS / sourceEstimatedFPS
guard targetIndex > prevTargetIndex else { return }
```
`delayTime = 1/targetFPS` is unchanged. With correct frame selection, the uniform `1/target` delay now reproduces the source's real-time duration for any fps pair: 24→15 keeps 15 frames over 1.0 s, 60→24 keeps 24, 60→15 keeps 15. Exact-divisor pairs (30→15, 60→15) are byte-for-byte unchanged, so there is no regression for the cases that already worked.

## Testing
- `xcodebuild -project macshot.xcodeproj -scheme macshot CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**.
- Hand-traced every pair against the old modulo throttle:
  - (30,15) and (60,15): identical kept-frame count and positions before/after (regression guard).
  - (24,15): 24→15 frames, 1.6 s → 1.0 s. (60,24): 30→24 frames, 1.25 s → 1.0 s.
- Confirmed `sourceEstimatedFPS ≥ 5` at this call site (init clamps `sourceEstimatedFPS = max(sourceFPS, fps)` and `fps` is clamped to ≥5 by the caller), so the integer division cannot divide by zero; integer overflow is negligible (`inputFrameCount × targetFPS` is tiny vs `Int64`).
- No new test target added (this repo intentionally ships no unit tests, per CONTRIBUTING).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
