### PR TITLE
fix(editor): round video timecode tenths to avoid off-by-one display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Video editor timecode rounding** — the timeline's tenths-of-a-second digit could read one low (e.g. 2.3s shown as "0:02.2") because it was truncated from a floating-point subtraction instead of rounded. Deriving minutes/seconds/tenths from a single rounded value fixes the digit and the boundary roll-over (1.999s now shows "0:02.0", not "0:01.9").
+
 ## [4.2.2-beta.1] - 2026-07-11
 
 ### Added

--- a/macshot/UI/Editor/VideoEditorWindowController.swift
+++ b/macshot/UI/Editor/VideoEditorWindowController.swift
@@ -1217,9 +1217,15 @@ private final class VideoEditorView: NSView {
     }
 
     private func formatTime(_ seconds: Double) -> String {
-        let m = Int(seconds) / 60
-        let s = Int(seconds) % 60
-        let ms = Int((seconds - floor(seconds)) * 10)
+        // Derive every field from the rounded total tenths-of-a-second. Computing
+        // the tenths digit separately as `(seconds - floor(seconds)) * 10` truncates
+        // a value like 2.3s (whose Double is 2.2999…) to ".2" instead of ".3", and
+        // never rounds up at the boundary — 1.999s displayed as "0:01.9" instead of
+        // "0:02.0". Rounding once at the top keeps minutes/seconds/tenths consistent.
+        let totalTenths = Int((seconds * 10).rounded())
+        let m = totalTenths / 600
+        let s = (totalTenths / 10) % 60
+        let ms = totalTenths % 10
         return String(format: "%d:%02d.%d", m, s, ms)
     }
 


### PR DESCRIPTION
## Problem

The video editor's timeline timecode occasionally shows the wrong tenths-of-a-second digit. A 2.3-second playhead position renders as `0:02.2` instead of `0:02.3`, and a value like 1.999s shows `0:01.9` instead of rolling over to `0:02.0`. The drift is small but consistent for a fixed input, so the same clip always labels wrong at the same spot.

## Root cause

`formatTime(_:)` derived each field independently:

```swift
let m = Int(seconds) / 60
let s = Int(seconds) % 60
let ms = Int((seconds - floor(seconds)) * 10)
```

The tenths digit is computed from `(seconds - floor(seconds)) * 10` and then truncated. The fractional part of most `Double` values is not exactly representable, so the product lands a hair below the intended integer and `Int(...)` truncates it one low. For example `2.3` is stored as `2.2999…`; `2.2999… - 2.0 = 0.2999…`, and `0.2999… * 10 = 2.9999…`, which truncates to `2` — so the label reads `.2`.

Because the tenths are derived separately from the minutes/seconds (which truncate the whole-second part), the boundary never rolls over either: `1.999s` keeps `m/s` from `Int(1.999) = 1` and `ms` from `Int(9.99) = 9`, giving `0:01.9` rather than `0:02.0`.

## Solution

Derive minutes, seconds, and tenths from a single rounded total tenths-of-a-second value, so all three fields stay consistent and rounding happens once at the top:

```swift
let totalTenths = Int((seconds * 10).rounded())
let m = totalTenths / 600
let s = (totalTenths / 10) % 60
let ms = totalTenths % 10
```

`2.3s` → `totalTenths = 23` → `0:02.3`. `1.999s` → `totalTenths = 20` → `0:02.0`. Clean values (`5.0`, `65.0`, `125.7`) are unchanged.

## Testing

- [x] Builds without warnings (`xcodebuild -configuration Debug`, ad-hoc, no signing)
- [x] Verified the rounding arithmetic standalone against the original formula — `0.3, 0.7, 1.3, 1.7, 2.3, 5.0, 65.0, 125.7, 1.999`: old code mislabeled `2.3` (`.2`) and `1.999` (`0:01.9`); new code labels all correctly
- [x] Doesn't change behavior for clean values (timeline labels for whole-second seeks are identical)
- [x] Commit message describes what and why

### Checklist
- [x] Builds without warnings
- [x] Tested manually (logic verified; no unit tests in this repo)
- [x] Doesn't break existing behavior
- [x] Commit message describes what and why

🤖 Generated with [Claude Code]
