### PR TITLE
fix(save): avoid clobbering an existing file when de-dup name exhausts

### DIFF
--- a/macshot/Services/ImageSaveService.swift
+++ b/macshot/Services/ImageSaveService.swift
@@ -210,19 +210,30 @@ enum ImageSaveService {
     }
 
     private static func uniqueFileURL(in dirURL: URL, filename: String) -> URL {
+        let base = (filename as NSString).deletingPathExtension
+        let ext = (filename as NSString).pathExtension
+
         var candidate = dirURL.appendingPathComponent(filename)
         guard FileManager.default.fileExists(atPath: candidate.path) else { return candidate }
 
-        let base = (filename as NSString).deletingPathExtension
-        let ext = (filename as NSString).pathExtension
+        // Walk "name (N)" until a free slot is found. The two sibling dedup
+        // loops in this app — ClipboardBackingStore.makeUniqueURL and
+        // AppDelegate.moveRecording — both cap the counter and fall back to a
+        // unique name (or nil) on exhaustion. Returning the last checked
+        // candidate here, as the old `while counter < 1000` loop did, hands
+        // back a path that already exists and the caller silently overwrites a
+        // saved screenshot. A timestamp-less filename template makes that
+        // reachable (every save collides), so fall back to a UUID-suffixed
+        // name instead of clobbering.
         var counter = 2
-        while counter < 1000 {
+        while FileManager.default.fileExists(atPath: candidate.path) {
             let nextName = ext.isEmpty ? "\(base) (\(counter))" : "\(base) (\(counter)).\(ext)"
             candidate = dirURL.appendingPathComponent(nextName)
-            if !FileManager.default.fileExists(atPath: candidate.path) {
-                return candidate
-            }
             counter += 1
+            if counter > 1000 {
+                let fallback = ext.isEmpty ? "\(base) \(UUID().uuidString)" : "\(base) \(UUID().uuidString).\(ext)"
+                return dirURL.appendingPathComponent(fallback)
+            }
         }
         return candidate
     }


### PR DESCRIPTION
## Problem

When saving a screenshot to the configured folder and the chosen filename is already taken 999 times over, `ImageSaveService.uniqueFileURL` returns a path that already exists on disk, and the caller silently overwrites that previously saved screenshot.

## Root cause

`uniqueFileURL(in:filename:)` de-duplicates with:

```swift
var counter = 2
while counter < 1000 {
    let nextName = … "\(base) (\(counter))" …
    candidate = dirURL.appendingPathComponent(nextName)
    if !FileManager.default.fileExists(atPath: candidate.path) {
        return candidate
    }
    counter += 1
}
return candidate   // ← last checked candidate, which exists
```

When every `name (2)` … `name (999)` slot is taken, the loop exits via the `counter < 1000` condition and returns `candidate` — the last path it checked, which **does** exist. `writeImage` then calls `imageData.write(to: fileURL)` on it and overwrites a saved image with no warning.

This is the **only one of the three** sibling de-dup loops in the app that clobbers:

| Loop | Exhaustion behavior |
| --- | --- |
| `ClipboardBackingStore.makeUniqueURL` | falls back to `<uuid>.<ext>` |
| `AppDelegate.moveRecording` | returns `nil` (caller leaves the tmp file) |
| `ImageSaveService.uniqueFileURL` | **returns an existing path → silent overwrite** |

The exhaustion is reachable, not just theoretical: a timestamp-less filename template (e.g. `{window}` only, or a custom static name) means every save into the same folder collides, so a folder holding 999 such screenshots loses the next one.

## Solution

Switch to a `while FileManager.default.fileExists` loop with the same 1000 cap, and on exhaustion fall back to a UUID-suffixed name that preserves the base — mirroring `ClipboardBackingStore.makeUniqueURL`:

```swift
var counter = 2
while FileManager.default.fileExists(atPath: candidate.path) {
    let nextName = … "\(base) (\(counter))" …
    candidate = dirURL.appendingPathComponent(nextName)
    counter += 1
    if counter > 1000 {
        let fallback = ext.isEmpty ? "\(base) \(UUID().uuidString)" : "\(base) \(UUID().uuidString).\(ext)"
        return dirURL.appendingPathComponent(fallback)
    }
}
return candidate
```

Normal saves (the first free `name (N)`) are unchanged; only the exhausted path now yields a fresh unique name instead of an existing one.

## Testing

- [x] Builds without warnings (`xcodebuild -configuration Debug`, ad-hoc, no signing)
- [x] No unit tests in this repo; traced the loop by hand for the common case (first free slot returned immediately) and the exhaustion case (UUID fallback returned instead of an existing path)
- [x] Doesn't change behavior for normal saves — only the previously-clobbering exhaustion branch differs
- [x] Commit message describes what and why

### Checklist
- [x] Builds without warnings
- [x] Tested manually (logic traced; no unit tests in this repo)
- [x] Doesn't break existing behavior
- [x] Commit message describes what and why

🤖 Generated with [Claude Code]
