### PR TITLE
perf(capture): capture displays sequentially, cursor display first (4.2s -> 0.2s on 4 displays)

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -111,6 +111,12 @@ private let sigtermHandler: @convention(c) (Int32) -> Void = { _ in
     kill(getpid(), SIGTERM)
 }
 
+/// Tracks whether the first (cursor-display) overlay has already been shown,
+/// so only that one marks the capture INTERACTIVE.
+private final class ProgressiveOverlayState {
+    var shownAny = false
+}
+
 private final class CaptureTimingTrace: @unchecked Sendable {
     private struct Entry {
         let label: String
@@ -1335,12 +1341,36 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // transient UI (menus, Spotlight) is preserved. If SCK fails or can't
         // cover every display, fall back to the synchronous CGWindowListCreateImage
         // path (which manually composites the cursor from the prebuilt context).
+        let progressive = ProgressiveOverlayState()
         Task { [weak self] in
             trace?.mark("background screenshot begin")
             var captures: [ScreenCapture]? = nil
             if #available(macOS 14.0, *) {
+                // Install each display's overlay as soon as its own capture
+                // lands, cursor display first, instead of waiting for all of them.
                 captures = await ScreenCaptureManager.captureAllScreensImmediatelySCK(
-                    timing: { label in trace?.mark(label) })
+                    priorityScreen: mouseScreen,
+                    timing: { label in trace?.mark(label) },
+                    onCapture: { capture in
+                        guard let self = self, self.isCapturing,
+                              self.captureSessionID == sessionID else { return }
+                        guard let controller = controllers.first(where: { $0.screen === capture.screen })
+                        else { return }
+                        let isFirst = !progressive.shownAny
+                        progressive.shownAny = true
+                        self.installAndShowOverlays(
+                            captures: [capture],
+                            controllers: [controller],
+                            mouseScreen: mouseScreen,
+                            applyFullScreen: didApplyFullScreen,
+                            applyFullScreenRecord: didApplyFullScreenRecord,
+                            autoStartRecord: didApplyFullScreenRecordAutoStart,
+                            markInteractive: isFirst)
+                    })
+            }
+            if let captures, progressive.shownAny {
+                trace?.mark("background screenshot end count=\(captures.count) (progressive)")
+                return
             }
             let finalCaptures = captures ?? ScreenCaptureManager.captureAllScreensImmediately(
                 context: captureContext,
@@ -1368,7 +1398,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         mouseScreen: NSScreen?,
         applyFullScreen: Bool,
         applyFullScreenRecord: Bool,
-        autoStartRecord: Bool
+        autoStartRecord: Bool,
+        markInteractive: Bool = true
     ) {
         if captures.isEmpty {
             captureTimingTrace?.mark("no captures returned — bailing out")
@@ -1408,6 +1439,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             }
         }
 
+        guard markInteractive else { return }
         captureTimingTrace?.mark("overlays installed and shown — INTERACTIVE")
         // Beacon: schedule periodic main-runloop marks so we can see if the
         // runloop is alive between INTERACTIVE and the first user event.

--- a/macshot/Capture/ScreenCaptureManager.swift
+++ b/macshot/Capture/ScreenCaptureManager.swift
@@ -134,13 +134,17 @@ class ScreenCaptureManager {
     /// CGWindowListCreateImage path.
     @available(macOS 14.0, *)
     static func captureAllScreensImmediatelySCK(
-        timing: (@Sendable (String) -> Void)? = nil
+        priorityScreen: NSScreen? = nil,
+        timing: (@Sendable (String) -> Void)? = nil,
+        onCapture: ((ScreenCapture) -> Void)? = nil
     ) async -> [ScreenCapture]? {
         let showsCursor = UserDefaults.standard.bool(forKey: "captureCursor")
         if #available(macOS 26.0, *) {
             if let captures = await captureAllScreensImmediatelySCKRect(
                 showsCursor: showsCursor,
-                timing: timing
+                priorityScreen: priorityScreen,
+                timing: timing,
+                onCapture: onCapture
             ) {
                 return captures
             }
@@ -218,7 +222,9 @@ class ScreenCaptureManager {
     @available(macOS 26.0, *)
     private static func captureAllScreensImmediatelySCKRect(
         showsCursor: Bool,
-        timing: (@Sendable (String) -> Void)? = nil
+        priorityScreen: NSScreen? = nil,
+        timing: (@Sendable (String) -> Void)? = nil,
+        onCapture: ((ScreenCapture) -> Void)? = nil
     ) async -> [ScreenCapture]? {
         let screens = NSScreen.screens
         guard !screens.isEmpty else {
@@ -234,45 +240,49 @@ class ScreenCaptureManager {
         // captured with the raw AppKit frame come back vertically shifted with a
         // black stripe where the rect fell off the display (#291, #294).
         let primaryHeight = screens[0].frame.maxY
-        let captures = await withTaskGroup(
-            of: ScreenCapture?.self,
-            returning: [ScreenCapture].self
-        ) { group in
-            for (index, screen) in screens.enumerated() {
-                group.addTask {
-                    let appKitFrame = screen.frame
-                    let rect = CGRect(
-                        x: appKitFrame.origin.x,
-                        y: primaryHeight - appKitFrame.maxY,
-                        width: appKitFrame.width,
-                        height: appKitFrame.height)
-                    let config = SCScreenshotConfiguration()
-                    config.width = Int(rect.width * screen.backingScaleFactor)
-                    config.height = Int(rect.height * screen.backingScaleFactor)
-                    config.showsCursor = showsCursor
-                    config.displayIntent = .local
-                    config.dynamicRange = .sdr
-                    timing?("SCK rect capture begin screen=\(index) rect=\(Int(rect.origin.x)),\(Int(rect.origin.y)) \(Int(rect.width))x\(Int(rect.height))")
-                    let result = await captureScreenshotOutput(rect: rect, configuration: config)
-                    guard
-                        result.error == nil,
-                        let output = result.output,
-                        let image = output.sdrImage ?? output.hdrImage
-                    else {
-                        let reason = result.error?.localizedDescription ?? "no image returned"
-                        timing?("SCK rect capture failed screen=\(index) error=\(reason)")
-                        return nil
-                    }
-                    timing?("SCK rect capture end screen=\(index) pixels=\(image.width)x\(image.height)")
-                    return ScreenCapture(screen: screen, image: image)
-                }
+        // NOTE: capture displays SEQUENTIALLY, not concurrently.
+        // On macOS 26 replayd serialises concurrent SCScreenshotManager requests
+        // anyway, and charges ~1.3s per queued request instead of ~380ms. On a
+        // 4-display Mac that is 3.9s concurrent vs 1.5s sequential (2.5x).
+        // Capture the cursor's display first and hand each capture back through
+        // onCapture the moment it lands, so the overlay on the display the user
+        // is looking at goes interactive after ONE capture, not after all of them.
+        var order = Array(screens.enumerated())
+        if let priority = priorityScreen,
+           let hit = order.firstIndex(where: { $0.element === priority }), hit != 0 {
+            let entry = order.remove(at: hit)
+            order.insert(entry, at: 0)
+            timing?("SCK rect: prioritised cursor display index=\(entry.offset)")
+        }
+        var captures: [ScreenCapture] = []
+        for (index, screen) in order {
+            let appKitFrame = screen.frame
+            let rect = CGRect(
+                x: appKitFrame.origin.x,
+                y: primaryHeight - appKitFrame.maxY,
+                width: appKitFrame.width,
+                height: appKitFrame.height)
+            let config = SCScreenshotConfiguration()
+            config.width = Int(rect.width * screen.backingScaleFactor)
+            config.height = Int(rect.height * screen.backingScaleFactor)
+            config.showsCursor = showsCursor
+            config.displayIntent = .local
+            config.dynamicRange = .sdr
+            timing?("SCK rect capture begin screen=\(index) rect=\(Int(rect.origin.x)),\(Int(rect.origin.y)) \(Int(rect.width))x\(Int(rect.height))")
+            let result = await captureScreenshotOutput(rect: rect, configuration: config)
+            guard
+                result.error == nil,
+                let output = result.output,
+                let image = output.sdrImage ?? output.hdrImage
+            else {
+                let reason = result.error?.localizedDescription ?? "no image returned"
+                timing?("SCK rect capture failed screen=\(index) error=\(reason)")
+                continue
             }
-
-            var results: [ScreenCapture] = []
-            for await capture in group {
-                if let capture { results.append(capture) }
-            }
-            return results
+            timing?("SCK rect capture end screen=\(index) pixels=\(image.width)x\(image.height)")
+            let capture = ScreenCapture(screen: screen, image: image)
+            captures.append(capture)
+            onCapture?(capture)
         }
 
         guard captures.count == screens.count else {


### PR DESCRIPTION
Fixes the multi-display capture latency described in #348.

### What

`captureAllScreensImmediatelySCKRect` fans out one `SCScreenshotManager.captureScreenshot(rect:)` per display via `withTaskGroup`. On macOS 26 `replayd` serialises those requests anyway **and charges far more per queued request** than for the same requests issued one at a time, so the fan-out is slower than a plain loop, and the penalty grows with display count.

Two changes:

**1. Sequential capture instead of `withTaskGroup`.** The captures were already being serialised downstream; issuing them one at a time removes the queueing penalty.

**2. Cursor display first + progressive overlay install.** The display under the pointer is captured first and handed back through a new `onCapture` callback as soon as it lands, so its overlay is installed and marked INTERACTIVE after one capture instead of after all of them. The other displays are captured and shown behind the already-interactive overlay.

`installAndShowOverlays` gains a `markInteractive: Bool = true` parameter so only the first (cursor) display marks the trace INTERACTIVE. The default preserves existing behaviour for the batch callers, and the non-SCK fallback path is untouched.

### Measured

Mac Studio, macOS 26.6.1, 4 displays (2x 6720x3780, 3840x2160, 2560x1600), all 2x HiDPI. Same source, same build flags, only this code path differing. Numbers are hotkey to `overlays installed and shown — INTERACTIVE`, from the app's own `capture-timing` trace.

| Build | Time to interactive |
|---|---|
| `withTaskGroup` (current) | 3316 / 3506 ms |
| sequential loop | 1394 / 1475 ms |
| sequential + cursor first | **190 / 213 ms** |

Shipped 4.2.1 on the same machine measured 4196 / 4213 / 4301 ms.

Before, four captures starting together and finishing 1.3 s apart:

```
   1.8 ms  capture begin screen=0/1/2/3   (all within 1.5 ms)
 233.6 ms  end screen=0
1458.0 ms  end screen=1
2864.9 ms  end screen=2
4282.1 ms  end screen=3
4300.9 ms  INTERACTIVE
```

After:

```
   1.8 ms  prioritised cursor display index=1
   1.8 ms  capture begin screen=1
 183.0 ms  capture end screen=1
 189.5 ms  INTERACTIVE
 190.2 ms  capture begin screen=0
 608.4 ms  end screen=0
1037.9 ms  end screen=2
1403.2 ms  end screen=3
```

### Notes

- Single-display setups are unaffected in shape: one capture, one overlay, same as before.
- A failed capture now `continue`s rather than returning nil into the task group. The existing `captures.count == screens.count` guard still triggers the fallback if any display fails, so behaviour on failure is unchanged.
- Not addressed here, filed in the issue: a second hotkey press landing while the previous capture's remaining displays are still in flight queues behind them (~1320 ms instead of ~200 ms). `captureSessionID` guards the overlay install but the in-flight captures keep running.

### Testing

Manual, on the 4-display setup above, using the built-in `capture-timing` trace. Verified: overlay appears on the cursor's display first and is immediately draggable; the other displays fill in behind it; selections on a display whose capture has not yet landed still work once it appears; single-display behaviour unchanged.

Built and run from `main` with the changes applied. No unit tests exist in the project.
