### PR TITLE
Fix S3 uploads landing private on ACL-based providers (opt-in public-read)

### DIFF
--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -120,6 +120,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     private var s3SecretKeyField: NSSecureTextField!
     private var s3PublicURLField: NSTextField!
     private var s3PathPrefixField: NSTextField!
+    private var s3PublicReadCheckbox: NSButton!
     private var s3TestBtn: NSButton!
     private var s3StatusLabel: NSTextField!
     #endif
@@ -1832,6 +1833,17 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         stack.addArrangedSubview(labeledRow(L("Path Prefix:"), controls: [s3PathPrefixField]))
         stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
 
+        s3PublicReadCheckbox = NSButton(checkboxWithTitle: L("Make uploads publicly readable"), target: self, action: #selector(s3PublicReadChanged(_:)))
+        s3PublicReadCheckbox.state = UserDefaults.standard.bool(forKey: "s3PublicRead") ? .on : .off
+        stack.addArrangedSubview(indented(s3PublicReadCheckbox))
+        stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
+
+        let publicReadNote = NSTextField(wrappingLabelWithString: L("Sends the public-read ACL so uploaded files are viewable by anyone with the link. Needed for AWS S3, DigitalOcean Spaces, MinIO and Backblaze B2, which store objects privately by default. Leave off for Cloudflare R2, which has no ACLs and rejects the header."))
+        publicReadNote.font = NSFont.systemFont(ofSize: 10)
+        publicReadNote.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(indented(publicReadNote))
+        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
+
         s3TestBtn = NSButton(title: L("Test Connection"), target: self, action: #selector(s3TestTapped(_:)))
         s3TestBtn.bezelStyle = .rounded
 
@@ -2105,6 +2117,10 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         UserDefaults.standard.set(s3SecretKeyField.stringValue, forKey: "s3SecretAccessKey")
         UserDefaults.standard.set(s3PublicURLField.stringValue, forKey: "s3PublicURLBase")
         UserDefaults.standard.set(s3PathPrefixField.stringValue, forKey: "s3PathPrefix")
+    }
+
+    @objc private func s3PublicReadChanged(_ sender: NSButton) {
+        UserDefaults.standard.set(sender.state == .on, forKey: "s3PublicRead")
     }
 
     @objc private func s3TestTapped(_ sender: NSButton) {

--- a/macshot/Upload/S3Uploader.swift
+++ b/macshot/Upload/S3Uploader.swift
@@ -19,6 +19,7 @@ final class S3Uploader {
         let secretAccessKey: String
         let publicURLBase: String // e.g. "https://cdn.example.com" — used for the final link
         let pathPrefix: String    // e.g. "screenshots/" — optional prefix within bucket
+        let publicRead: Bool      // send `x-amz-acl: public-read` so the object is world-readable
 
         var isValid: Bool {
             !endpoint.isEmpty && !bucket.isEmpty && !accessKeyID.isEmpty && !secretAccessKey.isEmpty
@@ -34,7 +35,8 @@ final class S3Uploader {
             accessKeyID: ud.string(forKey: "s3AccessKeyID") ?? "",
             secretAccessKey: ud.string(forKey: "s3SecretAccessKey") ?? "",
             publicURLBase: ud.string(forKey: "s3PublicURLBase") ?? "",
-            pathPrefix: ud.string(forKey: "s3PathPrefix") ?? ""
+            pathPrefix: ud.string(forKey: "s3PathPrefix") ?? "",
+            publicRead: ud.bool(forKey: "s3PublicRead")
         )
     }
 
@@ -114,6 +116,12 @@ final class S3Uploader {
         request.httpMethod = "PUT"
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
         request.setValue("\(host)\(port)", forHTTPHeaderField: "Host")
+        // Providers that honour object ACLs (AWS S3, DigitalOcean Spaces, MinIO, Backblaze B2)
+        // store objects privately by default, so the public link 403s. Opt-in because R2 has
+        // no ACLs and rejects the header outright.
+        if cfg.publicRead {
+            request.setValue("public-read", forHTTPHeaderField: "x-amz-acl")
+        }
 
         // Sign the request
         let now = Date()
@@ -202,8 +210,13 @@ final class S3Uploader {
             .joined(separator: "/")
         let canonicalQueryString = url.query ?? ""
 
-        // Signed headers (sorted)
-        let signedHeaderNames = ["content-type", "host", "x-amz-content-sha256", "x-amz-date"]
+        // Signed headers (sorted). x-amz-acl is only present when the user opted into
+        // public-read; sending it unsigned would fail the signature check.
+        var signedHeaderNames = ["content-type", "host", "x-amz-content-sha256", "x-amz-date"]
+        if request.value(forHTTPHeaderField: "x-amz-acl") != nil {
+            signedHeaderNames.append("x-amz-acl")
+            signedHeaderNames.sort()
+        }
         let signedHeadersString = signedHeaderNames.joined(separator: ";")
 
         var canonicalHeaders = ""

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -360,10 +360,12 @@
 "Secret Key:" = "Secret Key:";
 "Public URL:" = "Public URL:";
 "Path Prefix:" = "Path Prefix:";
+"Make uploads publicly readable" = "Make uploads publicly readable";
 "API key:" = "API key:";
 "Upload History" = "Upload History";
 "No uploads yet." = "No uploads yet.";
 "Base URL for public access. If empty, the S3 endpoint URL is used (may not be publicly accessible)." = "Base URL for public access. If empty, the S3 endpoint URL is used (may not be publicly accessible).";
+"Sends the public-read ACL so uploaded files are viewable by anyone with the link. Needed for AWS S3, DigitalOcean Spaces, MinIO and Backblaze B2, which store objects privately by default. Leave off for Cloudflare R2, which has no ACLs and rejects the header." = "Sends the public-read ACL so uploaded files are viewable by anyone with the link. Needed for AWS S3, DigitalOcean Spaces, MinIO and Backblaze B2, which store objects privately by default. Leave off for Cloudflare R2, which has no ACLs and rejects the header.";
 "A shared key is included — get your own free key at imgbb.com/api if you hit rate limits. Images only (no video support)." = "A shared key is included — get your own free key at imgbb.com/api if you hit rate limits. Images only (no video support).";
 "Works with AWS S3, Cloudflare R2, MinIO, DigitalOcean Spaces, Backblaze B2, and other S3-compatible services. Supports images and videos." = "Works with AWS S3, Cloudflare R2, MinIO, DigitalOcean Spaces, Backblaze B2, and other S3-compatible services. Supports images and videos.";
 "Configure S3 in Preferences" = "Configure S3 in Preferences";


### PR DESCRIPTION
## Problem

`S3Uploader` never sends an ACL header. The signed header list is fixed at four entries:

```swift
// S3Uploader.swift
let signedHeaderNames = ["content-type", "host", "x-amz-content-sha256", "x-amz-date"]
```

On any provider that honours object ACLs (AWS S3, DigitalOcean Spaces, MinIO, Backblaze B2), objects default to private. The upload succeeds with a 200, `Test Connection` reports "Connection successful!", and macshot copies a link to the clipboard that returns `403 AccessDenied` when anyone opens it.

Reproduced against DigitalOcean Spaces:

```
$ curl -sI https://<space>.nyc3.cdn.digitaloceanspaces.com/files/Screenshot_2026-08-16_at_22-22-44.png
HTTP/1.1 403 Forbidden
<Error><Code>AccessDenied</Code>...
```

There is currently no way to fix this from inside macshot. The only workaround is a provider-side bucket policy.

This does not affect Cloudflare R2, which serves public objects through r2.dev or a custom domain and has no ACLs at all, which is likely why it went unnoticed.

## Change

Adds a **"Make uploads publicly readable"** checkbox to the S3 settings section, backed by `s3PublicRead`, **default off**.

When enabled:
- the PUT carries `x-amz-acl: public-read`
- `x-amz-acl` is appended to the SigV4 signed header list and re-sorted, so the signature still validates

When disabled the request is byte-for-byte what it is today.

Off by default for two reasons: R2 rejects the header outright, and making uploads world-readable should be a deliberate choice rather than a silent default.

## Files

| File | Change |
|---|---|
| `macshot/Upload/S3Uploader.swift` | `Config.publicRead`, conditional header, conditional signing |
| `macshot/UI/Windows/SettingsWindowController.swift` | checkbox + explanatory note + `s3PublicReadChanged(_:)` |
| `macshot/en.lproj/Localizable.strings` | two new keys |

## Deployment notes

- **No migration needed.** `UserDefaults.bool(forKey:)` returns `false` for an unset key, so existing installs keep exactly today's behaviour until the user ticks the box.
- **No new settings-export surface.** `SettingsPortability.secretSubstrings` already contains `"s3"`, so `s3PublicRead` is excluded from exports automatically by the existing fail-closed rule.
- **Files already uploaded stay private.** The ACL is applied at PUT time. Existing objects need `s3cmd setacl --acl-public --recursive` or a bucket policy.
- **Localization:** English keys added. The other 40 locales fall back to the English key until `/translate-missing` is run.
- **No new dependencies**, no SwiftUI, no change to the minimum macOS 12.3 target.

## Testing

- `swiftc -parse` clean on both changed files; `plutil -lint` clean on the strings file.
- Verified against DigitalOcean Spaces: unchecked reproduces the 403; checked returns a publicly readable object.
- Verified the checkbox-off path leaves the R2 request unchanged.

I do not have Xcode set up for a full build of this project, so please give it a compile before merging.
