### PR TITLE
feat: add table recognition and Excel export

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -193,6 +193,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     private var pinControllers: [PinWindowController] = []
     private var thumbnailControllers: [FloatingThumbnailController] = []
     private var ocrController: OCRResultController?
+    private var tableRecognitionController: TableRecognitionResultController?
     private var historyMenu: NSMenu?
     private var historyOverlayController: HistoryOverlayController?
     private var isCapturing = false
@@ -2454,6 +2455,43 @@ extension AppDelegate: OverlayWindowControllerDelegate {
             ocrController = ocr
             ocr.show()
         }
+    }
+
+    func overlayDidRequestTableRecognition(
+        _ controller: OverlayWindowController,
+        result: Result<RecognizedTable, Error>
+    ) {
+        dismissOverlays(refocusPreviousApp: false)
+
+        switch result {
+        case .success(let table):
+            do {
+                tableRecognitionController?.close()
+                let resultController = try TableRecognitionResultController(table: table)
+                resultController.onClose = { [weak self, weak resultController] in
+                    if self?.tableRecognitionController === resultController {
+                        self?.tableRecognitionController = nil
+                    }
+                }
+                tableRecognitionController = resultController
+                resultController.show()
+            } catch {
+                showTableRecognitionError(error)
+            }
+
+        case .failure(let error):
+            showTableRecognitionError(error)
+        }
+    }
+
+    private func showTableRecognitionError(_ error: Error) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = L("Table Recognition Failed")
+        alert.informativeText = error.localizedDescription
+        alert.alertStyle = .warning
+        alert.runModal()
+        returnFocusIfNeeded()
     }
 
     func overlayDidRequestUpload(_ controller: OverlayWindowController, image: NSImage, annotationData: CaptureAnnotationData?) {

--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -2466,8 +2466,8 @@ extension AppDelegate: OverlayWindowControllerDelegate {
         switch result {
         case .success(let table):
             do {
-                tableRecognitionController?.close()
                 let resultController = try TableRecognitionResultController(table: table)
+                tableRecognitionController?.close()
                 resultController.onClose = { [weak self, weak resultController] in
                     if self?.tableRecognitionController === resultController {
                         self?.tableRecognitionController = nil

--- a/macshot/Services/ClipboardBackingStore.swift
+++ b/macshot/Services/ClipboardBackingStore.swift
@@ -26,7 +26,11 @@ enum ClipboardBackingStore {
     }()
 
     static func writeImageData(_ data: Data) -> URL? {
-        let url = makeUniqueURL(fileExtension: "png")
+        writeFileData(data, fileExtension: "png")
+    }
+
+    static func writeFileData(_ data: Data, fileExtension: String) -> URL? {
+        let url = makeUniqueURL(fileExtension: fileExtension)
         do {
             try data.write(to: url, options: .atomic)
             return url

--- a/macshot/Services/TableGridDetector.swift
+++ b/macshot/Services/TableGridDetector.swift
@@ -1,0 +1,105 @@
+import CoreGraphics
+
+struct TableGrid {
+    let horizontalSeparators: [CGFloat]
+    let verticalSeparators: [CGFloat]
+}
+
+enum TableGridDetector {
+    static func detect(cgImage: CGImage) -> TableGrid? {
+        let width = cgImage.width
+        let height = cgImage.height
+        guard width >= 20, height >= 20 else { return nil }
+
+        var grayscale = Array(repeating: UInt8.max, count: width * height)
+        let rendered = grayscale.withUnsafeMutableBytes { bytes -> Bool in
+            guard let context = CGContext(
+                data: bytes.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width,
+                space: CGColorSpaceCreateDeviceGray(),
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            ) else { return false }
+            context.setFillColor(gray: 1, alpha: 1)
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+            context.interpolationQuality = .none
+            context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+        guard rendered else { return nil }
+
+        let horizontal = separatorPositions(
+            axisLength: height,
+            sampleLength: width,
+            mergeDistance: max(3, min(width, height) / 250)
+        ) { position, sample in
+            grayscale[position * width + sample] <= 242
+        }.map { 1 - (CGFloat($0) + 0.5) / CGFloat(height) }
+
+        let vertical = separatorPositions(
+            axisLength: width,
+            sampleLength: height,
+            mergeDistance: max(3, min(width, height) / 250)
+        ) { position, sample in
+            grayscale[sample * width + position] <= 242
+        }.map { (CGFloat($0) + 0.5) / CGFloat(width) }
+
+        guard horizontal.count >= 3 else { return nil }
+        return TableGrid(horizontalSeparators: horizontal, verticalSeparators: vertical)
+    }
+
+    private static func separatorPositions(
+        axisLength: Int,
+        sampleLength: Int,
+        mergeDistance: Int,
+        isLinePixel: (Int, Int) -> Bool
+    ) -> [Int] {
+        let sampleStride = max(1, sampleLength / 1_500)
+        let sampleCount = (sampleLength + sampleStride - 1) / sampleStride
+        let minimumRunLength = max(1, Int(Double(sampleCount) * 0.45))
+        var candidates: [Int] = []
+
+        for position in 1..<(axisLength - 1) {
+            var runLength = 0
+            var pendingGap = 0
+            var longestRun = 0
+            var sample = 0
+            while sample < sampleLength {
+                if isLinePixel(position, sample) {
+                    runLength += pendingGap + 1
+                    pendingGap = 0
+                    longestRun = max(longestRun, runLength)
+                    if longestRun >= minimumRunLength {
+                        candidates.append(position)
+                        break
+                    }
+                } else if runLength > 0, pendingGap < 2 {
+                    pendingGap += 1
+                } else {
+                    runLength = 0
+                    pendingGap = 0
+                }
+                sample += sampleStride
+            }
+        }
+
+        var groups: [[Int]] = []
+        for candidate in candidates {
+            if let last = groups.indices.last,
+               candidate - (groups[last].last ?? candidate) <= mergeDistance {
+                groups[last].append(candidate)
+            } else {
+                groups.append([candidate])
+            }
+        }
+        return groups.flatMap { group -> [Int] in
+            guard let first = group.first, let last = group.last else { return [] }
+            if last - first > mergeDistance * 2 {
+                return [first, last]
+            }
+            return [group.reduce(0, +) / group.count]
+        }
+    }
+}

--- a/macshot/Services/TableRecognition.swift
+++ b/macshot/Services/TableRecognition.swift
@@ -3,9 +3,11 @@ import Vision
 
 struct RecognizedTable: Equatable {
     let rows: [[String]]
+    let columnCount: Int
 
-    var columnCount: Int {
-        rows.map(\.count).max() ?? 0
+    nonisolated init(rows: [[String]]) {
+        self.rows = rows
+        self.columnCount = rows.map(\.count).max() ?? 0
     }
 
     var tsv: String {
@@ -139,6 +141,28 @@ enum VisionTableRecognizer {
 }
 
 enum TableStructureDetector {
+    private enum ColumnAlignment: CaseIterable, Sendable {
+        case left
+        case center
+        case right
+    }
+
+    private struct ColumnAnchor: Sendable {
+        let position: CGFloat
+        let center: CGFloat
+        let alignment: ColumnAlignment
+    }
+
+    private struct AnchorCandidate: Sendable {
+        let anchor: ColumnAnchor
+        let blockIndices: Set<Int>
+    }
+
+    private struct AnchorCluster {
+        var blocks: [(offset: Int, element: TableTextBlock)]
+        var positions: [CGFloat]
+    }
+
     private struct RowCluster {
         var blocks: [TableTextBlock]
 
@@ -270,14 +294,16 @@ enum TableStructureDetector {
             cells[row, default: [:]][column, default: []].append(block)
         }
 
-        let occupiedRows = cells.keys.sorted(by: >)
+        let occupiedRows = cells.keys.sorted()
         let occupiedColumns = Set(cells.values.flatMap(\.keys)).sorted()
         guard occupiedRows.count >= 2,
+              let firstRow = occupiedRows.first,
+              let lastRow = occupiedRows.last,
               let firstColumn = occupiedColumns.first,
               let lastColumn = occupiedColumns.last,
               lastColumn > firstColumn else { return nil }
 
-        let rows = occupiedRows.map { row in
+        let rows = (firstRow...lastRow).reversed().map { row in
             (firstColumn...lastColumn).map { column in
                 cellText(cells[row]?[column] ?? [])
             }
@@ -333,7 +359,7 @@ enum TableStructureDetector {
             .joined(separator: "\n")
     }
 
-    private nonisolated static func columnAnchors(from rows: [RowCluster]) -> [CGFloat]? {
+    private nonisolated static func columnAnchors(from rows: [RowCluster]) -> [ColumnAnchor]? {
         let candidates = rows
             .filter { $0.blocks.count >= 2 }
             .flatMap(\.blocks)
@@ -343,32 +369,79 @@ enum TableStructureDetector {
             $0.boundingBox.width / CGFloat(max($0.text.count, 1))
         }
         let tolerance = min(max(median(characterWidths) * 1.5, 0.006), 0.025)
-        var clusters: [[TableTextBlock]] = []
-        for block in candidates.sorted(by: { $0.boundingBox.minX < $1.boundingBox.minX }) {
-            if let last = clusters.indices.last,
-               abs(median(clusters[last].map(\.boundingBox.minX)) - block.boundingBox.minX)
-                   <= tolerance {
-                clusters[last].append(block)
-            } else {
-                clusters.append([block])
+
+        let indexedCandidates = Array(candidates.enumerated())
+        var anchorCandidates: [AnchorCandidate] = []
+        for alignment in ColumnAlignment.allCases {
+            var clusters: [AnchorCluster] = []
+            for block in indexedCandidates.sorted(by: {
+                alignedPosition(of: $0.element, alignment: alignment)
+                    < alignedPosition(of: $1.element, alignment: alignment)
+            }) {
+                let position = alignedPosition(of: block.element, alignment: alignment)
+                if let last = clusters.indices.last,
+                   abs(medianOfSorted(clusters[last].positions) - position) <= tolerance {
+                    clusters[last].blocks.append(block)
+                    clusters[last].positions.append(position)
+                } else {
+                    clusters.append(AnchorCluster(blocks: [block], positions: [position]))
+                }
+            }
+
+            for cluster in clusters where cluster.blocks.count >= 2 {
+                anchorCandidates.append(AnchorCandidate(
+                    anchor: ColumnAnchor(
+                        position: medianOfSorted(cluster.positions),
+                        center: median(cluster.blocks.map(\.element.boundingBox.midX)),
+                        alignment: alignment
+                    ),
+                    blockIndices: Set(cluster.blocks.map(\.offset))
+                ))
             }
         }
 
-        let anchors = clusters
-            .filter { $0.count >= 2 }
-            .map { median($0.map(\.boundingBox.minX)) }
-            .sorted()
+        var usedBlockIndices: Set<Int> = []
+        var anchors: [ColumnAnchor] = []
+        for candidate in anchorCandidates.sorted(by: {
+            if $0.blockIndices.count != $1.blockIndices.count {
+                return $0.blockIndices.count > $1.blockIndices.count
+            }
+            return $0.anchor.center < $1.anchor.center
+        }) where candidate.blockIndices.isDisjoint(with: usedBlockIndices) {
+            anchors.append(candidate.anchor)
+            usedBlockIndices.formUnion(candidate.blockIndices)
+        }
+        anchors.sort { $0.center < $1.center }
         return anchors.count >= 2 ? anchors : nil
     }
 
     private nonisolated static func columnIndex(
         for block: TableTextBlock,
-        anchors: [CGFloat]
+        anchors: [ColumnAnchor]
     ) -> Int {
         anchors.indices.min {
-            abs(anchors[$0] - block.boundingBox.minX)
-                < abs(anchors[$1] - block.boundingBox.minX)
+            abs(anchors[$0].position - alignedPosition(
+                of: block,
+                alignment: anchors[$0].alignment
+            )) < abs(anchors[$1].position - alignedPosition(
+                of: block,
+                alignment: anchors[$1].alignment
+            ))
         } ?? 0
+    }
+
+    private nonisolated static func alignedPosition(
+        of block: TableTextBlock,
+        alignment: ColumnAlignment
+    ) -> CGFloat {
+        switch alignment {
+        case .left:
+            return block.boundingBox.minX
+        case .center:
+            return block.boundingBox.midX
+        case .right:
+            return block.boundingBox.maxX
+        }
     }
 
     private nonisolated static func readingOrder(
@@ -389,10 +462,15 @@ enum TableStructureDetector {
     private nonisolated static func median(_ values: [CGFloat]) -> CGFloat {
         guard !values.isEmpty else { return 0 }
         let sorted = values.sorted()
-        let middle = sorted.count / 2
-        if sorted.count.isMultiple(of: 2) {
-            return (sorted[middle - 1] + sorted[middle]) / 2
+        return medianOfSorted(sorted)
+    }
+
+    private nonisolated static func medianOfSorted(_ values: [CGFloat]) -> CGFloat {
+        guard !values.isEmpty else { return 0 }
+        let middle = values.count / 2
+        if values.count.isMultiple(of: 2) {
+            return (values[middle - 1] + values[middle]) / 2
         }
-        return sorted[middle]
+        return values[middle]
     }
 }

--- a/macshot/Services/TableRecognition.swift
+++ b/macshot/Services/TableRecognition.swift
@@ -1,0 +1,398 @@
+import Foundation
+import Vision
+
+struct RecognizedTable: Equatable {
+    let rows: [[String]]
+
+    var columnCount: Int {
+        rows.map(\.count).max() ?? 0
+    }
+
+    var tsv: String {
+        rows.map { row in
+            (0..<columnCount).map { column in
+                guard column < row.count else { return "" }
+                return Self.tsvCell(row[column])
+            }.joined(separator: "\t")
+        }.joined(separator: "\n")
+    }
+
+    private static func tsvCell(_ value: String) -> String {
+        let normalized = value
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        guard normalized.contains(where: { $0 == "\t" || $0 == "\n" || $0 == "\"" }) else {
+            return normalized
+        }
+        return "\"\(normalized.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+}
+
+struct TableTextBlock: Equatable {
+    let text: String
+    let boundingBox: CGRect
+}
+
+enum TableRecognitionError: LocalizedError {
+    case noTextDetected
+    case noTableStructureDetected
+
+    var errorDescription: String? {
+        switch self {
+        case .noTextDetected:
+            return L("No text was detected in the selected area.")
+        case .noTableStructureDetected:
+            return L("No table structure was detected. Select a table with at least two rows and two columns.")
+        }
+    }
+}
+
+enum VisionTableRecognizer {
+
+    static func recognize(
+        cgImage: CGImage,
+        completionHandler: @escaping (Result<RecognizedTable, Error>) -> Void
+    ) {
+        VisionOCR.performTextRecognition(cgImage: cgImage) { request, error in
+            let observations = request.results as? [VNRecognizedTextObservation] ?? []
+            let blocks = observations.flatMap(textBlocks(from:))
+
+            guard !blocks.isEmpty else {
+                completionHandler(.failure(error ?? TableRecognitionError.noTextDetected))
+                return
+            }
+            let grid = TableGridDetector.detect(cgImage: cgImage)
+            guard let table = TableStructureDetector.detect(blocks: blocks, grid: grid) else {
+                completionHandler(.failure(TableRecognitionError.noTableStructureDetected))
+                return
+            }
+            completionHandler(.success(table))
+        }
+    }
+
+    private nonisolated static func textBlocks(
+        from observation: VNRecognizedTextObservation
+    ) -> [TableTextBlock] {
+        guard let candidate = observation.topCandidates(1).first else { return [] }
+        let text = normalized(candidate.string)
+        guard !text.isEmpty else { return [] }
+
+        let fallback = TableTextBlock(text: text, boundingBox: observation.boundingBox)
+        let matches = try? NSRegularExpression(pattern: "\\S+").matches(
+            in: candidate.string,
+            range: NSRange(candidate.string.startIndex..., in: candidate.string)
+        )
+        guard let matches, matches.count > 1 else { return [fallback] }
+
+        let tokens = matches.compactMap { match -> TableTextBlock? in
+            guard let range = Range(match.range, in: candidate.string),
+                  let rectangle = try? candidate.boundingBox(for: range) else { return nil }
+            let token = normalized(String(candidate.string[range]))
+            guard !token.isEmpty else { return nil }
+            return TableTextBlock(text: token, boundingBox: rectangle.boundingBox)
+        }.sorted { $0.boundingBox.midX < $1.boundingBox.midX }
+
+        guard tokens.count == matches.count else { return [fallback] }
+
+        let characterWidths = tokens.map {
+            $0.boundingBox.width / CGFloat(max($0.text.count, 1))
+        }
+        let medianCharacterWidth = median(characterWidths)
+        let medianHeight = median(tokens.map(\.boundingBox.height))
+        let cellGapThreshold = max(medianCharacterWidth * 2.5, medianHeight * 0.18)
+
+        var groups: [[TableTextBlock]] = []
+        for token in tokens {
+            if let previous = groups.last?.last {
+                let gap = token.boundingBox.minX - previous.boundingBox.maxX
+                if gap <= cellGapThreshold {
+                    groups[groups.count - 1].append(token)
+                    continue
+                }
+            }
+            groups.append([token])
+        }
+
+        guard groups.count > 1 else { return [fallback] }
+        return groups.map { group in
+            let box = group.dropFirst().reduce(group[0].boundingBox) { $0.union($1.boundingBox) }
+            return TableTextBlock(
+                text: group.map(\.text).joined(separator: " "),
+                boundingBox: box
+            )
+        }
+    }
+
+    private nonisolated static func normalized(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private nonisolated static func median(_ values: [CGFloat]) -> CGFloat {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+}
+
+enum TableStructureDetector {
+    private struct RowCluster {
+        var blocks: [TableTextBlock]
+
+        nonisolated var centerY: CGFloat {
+            median(blocks.map(\.boundingBox.midY))
+        }
+
+        nonisolated var height: CGFloat {
+            median(blocks.map(\.boundingBox.height))
+        }
+    }
+
+    nonisolated static func detect(
+        blocks: [TableTextBlock],
+        grid: TableGrid? = nil
+    ) -> RecognizedTable? {
+        let usableBlocks = blocks.filter {
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && $0.boundingBox.width > 0
+                && $0.boundingBox.height > 0
+        }
+        guard !usableBlocks.isEmpty else { return nil }
+
+        var rowClusters: [RowCluster] = []
+        for block in usableBlocks.sorted(by: readingOrder) {
+            let matchingRow = rowClusters.indices
+                .filter { isSameRow(block, row: rowClusters[$0]) }
+                .min { lhs, rhs in
+                    abs(rowClusters[lhs].centerY - block.boundingBox.midY)
+                        < abs(rowClusters[rhs].centerY - block.boundingBox.midY)
+                }
+
+            if let matchingRow {
+                rowClusters[matchingRow].blocks.append(block)
+            } else {
+                rowClusters.append(RowCluster(blocks: [block]))
+            }
+        }
+
+        rowClusters.sort { $0.centerY > $1.centerY }
+        for index in rowClusters.indices {
+            rowClusters[index].blocks.sort { $0.boundingBox.midX < $1.boundingBox.midX }
+        }
+
+        guard rowClusters.count >= 2 else { return nil }
+        if let grid, let gridTable = tableUsingGrid(
+            blocks: usableBlocks,
+            visualRows: rowClusters,
+            grid: grid
+        ) {
+            return gridTable
+        }
+        guard let anchors = columnAnchors(from: rowClusters) else { return nil }
+
+        let minimumSeedColumns = max(2, (anchors.count + 1) / 2)
+        let rowSeeds = rowClusters.filter { row in
+            Set(row.blocks.map { columnIndex(for: $0, anchors: anchors) }).count
+                >= minimumSeedColumns
+        }
+        guard rowSeeds.count >= 2 else { return nil }
+
+        var physicalRows = Array(repeating: [RowCluster](), count: rowSeeds.count)
+        for row in rowClusters {
+            let nearestSeed = rowSeeds.indices.min {
+                abs(rowSeeds[$0].centerY - row.centerY)
+                    < abs(rowSeeds[$1].centerY - row.centerY)
+            } ?? 0
+            physicalRows[nearestSeed].append(row)
+        }
+
+        let rows = physicalRows.map { visualRows -> [String] in
+            var cellLines = Array(repeating: [String](), count: anchors.count)
+            for visualRow in visualRows.sorted(by: { $0.centerY > $1.centerY }) {
+                var fragments = Array(repeating: [TableTextBlock](), count: anchors.count)
+                for block in visualRow.blocks {
+                    fragments[columnIndex(for: block, anchors: anchors)].append(block)
+                }
+                for column in fragments.indices where !fragments[column].isEmpty {
+                    let line = fragments[column]
+                        .sorted { $0.boundingBox.minX < $1.boundingBox.minX }
+                        .map(\.text)
+                        .joined(separator: " ")
+                    cellLines[column].append(line)
+                }
+            }
+            return cellLines.map { $0.joined(separator: "\n") }
+        }
+
+        return RecognizedTable(rows: rows)
+    }
+
+    private nonisolated static func tableUsingGrid(
+        blocks: [TableTextBlock],
+        visualRows: [RowCluster],
+        grid: TableGrid
+    ) -> RecognizedTable? {
+        guard let horizontalBoundaries = relevantBoundaries(
+            grid.horizontalSeparators,
+            contentMin: blocks.map(\.boundingBox.minY).min() ?? 0,
+            contentMax: blocks.map(\.boundingBox.maxY).max() ?? 1
+        ) else { return nil }
+
+        let verticalBoundaries = grid.verticalSeparators.count >= 3
+            ? relevantBoundaries(
+                grid.verticalSeparators,
+                contentMin: blocks.map(\.boundingBox.minX).min() ?? 0,
+                contentMax: blocks.map(\.boundingBox.maxX).max() ?? 1
+            )
+            : nil
+        let geometryAnchors = verticalBoundaries == nil ? columnAnchors(from: visualRows) : nil
+        guard verticalBoundaries != nil || geometryAnchors != nil else { return nil }
+
+        var cells: [Int: [Int: [TableTextBlock]]] = [:]
+        for block in blocks {
+            guard let row = bandIndex(block.boundingBox.midY, boundaries: horizontalBoundaries)
+            else { continue }
+            let column: Int
+            if let verticalBoundaries {
+                guard let gridColumn = bandIndex(
+                    block.boundingBox.midX,
+                    boundaries: verticalBoundaries
+                ) else { continue }
+                column = gridColumn
+            } else if let geometryAnchors {
+                column = columnIndex(for: block, anchors: geometryAnchors)
+            } else {
+                continue
+            }
+            cells[row, default: [:]][column, default: []].append(block)
+        }
+
+        let occupiedRows = cells.keys.sorted(by: >)
+        let occupiedColumns = Set(cells.values.flatMap(\.keys)).sorted()
+        guard occupiedRows.count >= 2,
+              let firstColumn = occupiedColumns.first,
+              let lastColumn = occupiedColumns.last,
+              lastColumn > firstColumn else { return nil }
+
+        let rows = occupiedRows.map { row in
+            (firstColumn...lastColumn).map { column in
+                cellText(cells[row]?[column] ?? [])
+            }
+        }
+        return RecognizedTable(rows: rows)
+    }
+
+    private nonisolated static func relevantBoundaries(
+        _ separators: [CGFloat],
+        contentMin: CGFloat,
+        contentMax: CGFloat
+    ) -> [CGFloat]? {
+        let sorted = ([CGFloat(0)] + separators + [CGFloat(1)]).sorted()
+        guard let lower = sorted.last(where: { $0 <= contentMin }),
+              let upper = sorted.first(where: { $0 >= contentMax }),
+              upper > lower else { return nil }
+        let boundaries = sorted.filter { $0 >= lower && $0 <= upper }
+        return boundaries.count >= 3 ? boundaries : nil
+    }
+
+    private nonisolated static func bandIndex(
+        _ position: CGFloat,
+        boundaries: [CGFloat]
+    ) -> Int? {
+        guard let upper = boundaries.firstIndex(where: { $0 > position }), upper > 0 else {
+            return nil
+        }
+        return upper - 1
+    }
+
+    private nonisolated static func cellText(_ blocks: [TableTextBlock]) -> String {
+        var lines: [RowCluster] = []
+        for block in blocks.sorted(by: readingOrder) {
+            if let matchingLine = lines.indices
+                .filter({ isSameRow(block, row: lines[$0]) })
+                .min(by: {
+                    abs(lines[$0].centerY - block.boundingBox.midY)
+                        < abs(lines[$1].centerY - block.boundingBox.midY)
+                }) {
+                lines[matchingLine].blocks.append(block)
+            } else {
+                lines.append(RowCluster(blocks: [block]))
+            }
+        }
+        return lines
+            .sorted { $0.centerY > $1.centerY }
+            .map { line in
+                line.blocks
+                    .sorted { $0.boundingBox.minX < $1.boundingBox.minX }
+                    .map(\.text)
+                    .joined(separator: " ")
+            }
+            .joined(separator: "\n")
+    }
+
+    private nonisolated static func columnAnchors(from rows: [RowCluster]) -> [CGFloat]? {
+        let candidates = rows
+            .filter { $0.blocks.count >= 2 }
+            .flatMap(\.blocks)
+        guard !candidates.isEmpty else { return nil }
+
+        let characterWidths = candidates.map {
+            $0.boundingBox.width / CGFloat(max($0.text.count, 1))
+        }
+        let tolerance = min(max(median(characterWidths) * 1.5, 0.006), 0.025)
+        var clusters: [[TableTextBlock]] = []
+        for block in candidates.sorted(by: { $0.boundingBox.minX < $1.boundingBox.minX }) {
+            if let last = clusters.indices.last,
+               abs(median(clusters[last].map(\.boundingBox.minX)) - block.boundingBox.minX)
+                   <= tolerance {
+                clusters[last].append(block)
+            } else {
+                clusters.append([block])
+            }
+        }
+
+        let anchors = clusters
+            .filter { $0.count >= 2 }
+            .map { median($0.map(\.boundingBox.minX)) }
+            .sorted()
+        return anchors.count >= 2 ? anchors : nil
+    }
+
+    private nonisolated static func columnIndex(
+        for block: TableTextBlock,
+        anchors: [CGFloat]
+    ) -> Int {
+        anchors.indices.min {
+            abs(anchors[$0] - block.boundingBox.minX)
+                < abs(anchors[$1] - block.boundingBox.minX)
+        } ?? 0
+    }
+
+    private nonisolated static func readingOrder(
+        _ lhs: TableTextBlock,
+        _ rhs: TableTextBlock
+    ) -> Bool {
+        if abs(lhs.boundingBox.midY - rhs.boundingBox.midY) > 0.001 {
+            return lhs.boundingBox.midY > rhs.boundingBox.midY
+        }
+        return lhs.boundingBox.minX < rhs.boundingBox.minX
+    }
+
+    private nonisolated static func isSameRow(_ block: TableTextBlock, row: RowCluster) -> Bool {
+        let tolerance = max(block.boundingBox.height, row.height) * 0.6
+        return abs(block.boundingBox.midY - row.centerY) <= tolerance
+    }
+
+    private nonisolated static func median(_ values: [CGFloat]) -> CGFloat {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+}

--- a/macshot/Services/XLSXWriter.swift
+++ b/macshot/Services/XLSXWriter.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+enum XLSXWriterError: LocalizedError {
+    case workbookTooLarge
+
+    var errorDescription: String? {
+        L("The recognized table is too large to create an Excel file.")
+    }
+}
+
+enum XLSXWriter {
+
+    static func data(for table: RecognizedTable) throws -> Data {
+        let entries = [
+            ZipEntry(path: "[Content_Types].xml", data: xmlData(contentTypesXML)),
+            ZipEntry(path: "_rels/.rels", data: xmlData(rootRelationshipsXML)),
+            ZipEntry(path: "xl/workbook.xml", data: xmlData(workbookXML)),
+            ZipEntry(path: "xl/_rels/workbook.xml.rels", data: xmlData(workbookRelationshipsXML)),
+            ZipEntry(path: "xl/worksheets/sheet1.xml", data: xmlData(worksheetXML(for: table))),
+        ]
+        return try makeZip(entries: entries)
+    }
+
+    private static let contentTypesXML = """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+    </Types>
+    """
+
+    private static let rootRelationshipsXML = """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+    </Relationships>
+    """
+
+    private static let workbookXML = """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+    </workbook>
+    """
+
+    private static let workbookRelationshipsXML = """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+    </Relationships>
+    """
+
+    private static func worksheetXML(for table: RecognizedTable) -> String {
+        let rowXML = table.rows.enumerated().map { rowIndex, row in
+            let cells = row.enumerated().compactMap { columnIndex, value -> String? in
+                guard !value.isEmpty else { return nil }
+                let reference = "\(columnName(columnIndex))\(rowIndex + 1)"
+                return "<c r=\"\(reference)\" t=\"inlineStr\"><is><t xml:space=\"preserve\">\(escapedXML(value))</t></is></c>"
+            }.joined()
+            return "<row r=\"\(rowIndex + 1)\">\(cells)</row>"
+        }.joined()
+
+        let endCell = "\(columnName(max(table.columnCount - 1, 0)))\(max(table.rows.count, 1))"
+        return """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <dimension ref="A1:\(endCell)"/>
+          <sheetData>\(rowXML)</sheetData>
+        </worksheet>
+        """
+    }
+
+    private static func columnName(_ zeroBasedIndex: Int) -> String {
+        var index = zeroBasedIndex + 1
+        var result = ""
+        while index > 0 {
+            index -= 1
+            result = String(UnicodeScalar(65 + index % 26)!) + result
+            index /= 26
+        }
+        return result
+    }
+
+    private static func escapedXML(_ value: String) -> String {
+        let validScalars = value.unicodeScalars.filter { scalar in
+            scalar.value == 0x9 || scalar.value == 0xA || scalar.value == 0xD
+                || scalar.value >= 0x20
+        }
+        return String(String.UnicodeScalarView(validScalars))
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    private static func xmlData(_ string: String) -> Data {
+        Data(string.utf8)
+    }
+
+    private struct ZipEntry {
+        let path: String
+        let data: Data
+    }
+
+    private struct CentralDirectoryEntry {
+        let pathData: Data
+        let crc32: UInt32
+        let size: UInt32
+        let localHeaderOffset: UInt32
+    }
+
+    private static func makeZip(entries: [ZipEntry]) throws -> Data {
+        var archive = Data()
+        var centralEntries: [CentralDirectoryEntry] = []
+
+        for entry in entries {
+            let pathData = Data(entry.path.utf8)
+            guard entry.data.count <= Int(UInt32.max),
+                  archive.count <= Int(UInt32.max),
+                  pathData.count <= Int(UInt16.max) else {
+                throw XLSXWriterError.workbookTooLarge
+            }
+
+            let size = UInt32(entry.data.count)
+            let crc = crc32(entry.data)
+            let offset = UInt32(archive.count)
+
+            archive.appendUInt32(0x04034b50)
+            archive.appendUInt16(20)
+            archive.appendUInt16(0)
+            archive.appendUInt16(0)
+            archive.appendUInt16(0)
+            archive.appendUInt16(0)
+            archive.appendUInt32(crc)
+            archive.appendUInt32(size)
+            archive.appendUInt32(size)
+            archive.appendUInt16(UInt16(pathData.count))
+            archive.appendUInt16(0)
+            archive.append(pathData)
+            archive.append(entry.data)
+
+            centralEntries.append(CentralDirectoryEntry(
+                pathData: pathData,
+                crc32: crc,
+                size: size,
+                localHeaderOffset: offset
+            ))
+        }
+
+        guard archive.count <= Int(UInt32.max), centralEntries.count <= Int(UInt16.max) else {
+            throw XLSXWriterError.workbookTooLarge
+        }
+        let centralDirectoryOffset = UInt32(archive.count)
+
+        for entry in centralEntries {
+            archive.appendUInt32(0x02014b50)
+            archive.appendUInt16(20)
+            archive.appendUInt16(20)
+            archive.appendUInt16(0)
+            archive.appendUInt16(0)
+            archive.appendUInt16(0)
+            archive.appendUInt16(0)
+            archive.appendUInt32(entry.crc32)
+            archive.appendUInt32(entry.size)
+            archive.appendUInt32(entry.size)
+            archive.appendUInt16(UInt16(entry.pathData.count))
+            archive.appendUInt16(0)
+            archive.appendUInt16(0)
+            archive.appendUInt16(0)
+            archive.appendUInt16(0)
+            archive.appendUInt32(0)
+            archive.appendUInt32(entry.localHeaderOffset)
+            archive.append(entry.pathData)
+        }
+
+        guard archive.count <= Int(UInt32.max) else {
+            throw XLSXWriterError.workbookTooLarge
+        }
+        let centralDirectorySize = UInt32(archive.count) - centralDirectoryOffset
+        let entryCount = UInt16(centralEntries.count)
+
+        archive.appendUInt32(0x06054b50)
+        archive.appendUInt16(0)
+        archive.appendUInt16(0)
+        archive.appendUInt16(entryCount)
+        archive.appendUInt16(entryCount)
+        archive.appendUInt32(centralDirectorySize)
+        archive.appendUInt32(centralDirectoryOffset)
+        archive.appendUInt16(0)
+        return archive
+    }
+
+    private static func crc32(_ data: Data) -> UInt32 {
+        var crc = UInt32.max
+        for byte in data {
+            let tableIndex = Int((crc ^ UInt32(byte)) & 0xff)
+            crc = crcTable[tableIndex] ^ (crc >> 8)
+        }
+        return crc ^ UInt32.max
+    }
+
+    private static let crcTable: [UInt32] = (0..<256).map { value in
+        var crc = UInt32(value)
+        for _ in 0..<8 {
+            crc = (crc & 1) == 1 ? 0xedb88320 ^ (crc >> 1) : crc >> 1
+        }
+        return crc
+    }
+}
+
+private extension Data {
+    mutating func appendUInt16(_ value: UInt16) {
+        append(contentsOf: [UInt8(value & 0xff), UInt8((value >> 8) & 0xff)])
+    }
+
+    mutating func appendUInt32(_ value: UInt32) {
+        append(contentsOf: [
+            UInt8(value & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 24) & 0xff),
+        ])
+    }
+}

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -12,6 +12,7 @@ protocol OverlayViewDelegate: AnyObject {
     func overlayViewDidRequestSaveAs()
     func overlayViewDidRequestPin()
     func overlayViewDidRequestOCR()
+    func overlayViewDidRequestTableRecognition()
     func overlayViewDidRequestQuickSave()
     func overlayViewDidRequestFileSave()
     func overlayViewDidRequestUpload()
@@ -33,6 +34,10 @@ protocol OverlayViewDelegate: AnyObject {
     func overlayViewDidChangeWindowSnapState()
     func overlayViewRemoteSelectionDidFinish(_ rect: NSRect)
     func overlayViewDidRequestAddCapture()
+}
+
+extension OverlayViewDelegate {
+    func overlayViewDidRequestTableRecognition() {}
 }
 
 /// An entry in the undo/redo history.
@@ -8151,6 +8156,8 @@ class OverlayView: NSView {
             overlayDelegate?.overlayViewDidRequestPin()
         case .ocr:
             overlayDelegate?.overlayViewDidRequestOCR()
+        case .tableRecognition:
+            overlayDelegate?.overlayViewDidRequestTableRecognition()
         case .autoRedact:
             performAutoRedact()
         case .removeBackground:

--- a/macshot/UI/Overlay/OverlayWindowController.swift
+++ b/macshot/UI/Overlay/OverlayWindowController.swift
@@ -66,6 +66,10 @@ protocol OverlayWindowControllerDelegate: AnyObject {
     func overlayDidConfirm(_ controller: OverlayWindowController, capturedImage: NSImage?, annotationData: CaptureAnnotationData?)
     func overlayDidRequestPin(_ controller: OverlayWindowController, image: NSImage, annotationData: CaptureAnnotationData?)
     func overlayDidRequestOCR(_ controller: OverlayWindowController, result: OCRScanResult, image: NSImage?)
+    func overlayDidRequestTableRecognition(
+        _ controller: OverlayWindowController,
+        result: Result<RecognizedTable, Error>
+    )
     func overlayDidRequestUpload(_ controller: OverlayWindowController, image: NSImage, annotationData: CaptureAnnotationData?)
     func overlayDidRequestStartRecording(
         _ controller: OverlayWindowController, rect: NSRect, screen: NSScreen)
@@ -83,6 +87,13 @@ protocol OverlayWindowControllerDelegate: AnyObject {
     func overlayDidFinishRemoteResize(_ controller: OverlayWindowController, globalRect: NSRect)
     func overlayCrossScreenImage(_ controller: OverlayWindowController) -> NSImage?
     func overlayDidChangeWindowSnapState(_ controller: OverlayWindowController)
+}
+
+extension OverlayWindowControllerDelegate {
+    func overlayDidRequestTableRecognition(
+        _ controller: OverlayWindowController,
+        result: Result<RecognizedTable, Error>
+    ) {}
 }
 
 /// Manages one fullscreen overlay per screen.
@@ -628,6 +639,23 @@ extension OverlayWindowController: OverlayViewDelegate {
                     self.playCopySound()
                     self.dismiss()
                     self.overlayDelegate?.overlayDidRequestOCR(self, result: result, image: capturedImage)
+                }
+            }
+        }
+    }
+
+    func overlayViewDidRequestTableRecognition() {
+        guard let image = captureRegion(),
+              let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            VisionTableRecognizer.recognize(cgImage: cgImage) { [weak self] result in
+                guard let self else { return }
+                DispatchQueue.main.async {
+                    self.dismiss()
+                    self.overlayDelegate?.overlayDidRequestTableRecognition(self, result: result)
                 }
             }
         }

--- a/macshot/UI/Toolbar/ToolbarDefinitions.swift
+++ b/macshot/UI/Toolbar/ToolbarDefinitions.swift
@@ -17,6 +17,7 @@ enum ToolbarButtonAction {
     case save
     case pin
     case ocr
+    case tableRecognition
     case autoRedact
     case beautify
     case beautifyStyle
@@ -72,6 +73,7 @@ enum ToolbarCustomAction: Int {
     case invertColors = 1011
     case share = 1012
     case effects = 1013
+    case tableRecognition = 1014
 
     static var allKnownActions: [ToolbarCustomAction] {
         var actions: [ToolbarCustomAction] = []
@@ -81,6 +83,7 @@ enum ToolbarCustomAction: Int {
         actions.append(contentsOf: [
             .pin, .ocr, .beautify, .removeBackground, .autoRedact, .reserved1007,
             .translate, .record, .scrollCapture, .invertColors, .share, .effects,
+            .tableRecognition,
         ])
         return actions
     }
@@ -94,7 +97,7 @@ enum ToolbarCustomAction: Int {
         #if !OFFLINE
         actions.append(.upload)
         #endif
-        actions.append(contentsOf: [.pin, .ocr, .translate, .scrollCapture, .record])
+        actions.append(contentsOf: [.pin, .ocr, .tableRecognition, .translate, .scrollCapture, .record])
         return actions
     }
 
@@ -107,7 +110,9 @@ enum ToolbarCustomAction: Int {
         #if !OFFLINE
         actions.append(.upload)
         #endif
-        actions.append(contentsOf: [.pin, .ocr, .autoRedact, .translate, .record, .scrollCapture, .share])
+        actions.append(contentsOf: [
+            .pin, .ocr, .tableRecognition, .autoRedact, .translate, .record, .scrollCapture, .share,
+        ])
         return actions
     }
 
@@ -118,6 +123,7 @@ enum ToolbarCustomAction: Int {
         #endif
         case .pin: return L("Pin (floating window)")
         case .ocr: return L("OCR & QR")
+        case .tableRecognition: return L("Table Recognition")
         case .beautify: return L("Beautify")
         case .removeBackground: return L("Remove Background")
         case .autoRedact: return L("Auto-Redact sensitive data")
@@ -149,6 +155,13 @@ enum ToolbarCustomAction: Int {
             return ToolbarButton(action: .pin, sfSymbol: "pin.fill", tooltip: L("Pin"))
         case .ocr:
             return ToolbarButton(action: .ocr, sfSymbol: "doc.text.viewfinder", tooltip: L("OCR & QR"))
+        case .tableRecognition:
+            guard !isEditorMode else { return nil }
+            return ToolbarButton(
+                action: .tableRecognition,
+                sfSymbol: "tablecells",
+                tooltip: L("Table Recognition")
+            )
         case .beautify:
             var button = ToolbarButton(action: .beautify, sfSymbol: "sparkles", tooltip: L("Beautify"))
             if beautifyEnabled {

--- a/macshot/UI/Windows/TableRecognitionResultController.swift
+++ b/macshot/UI/Windows/TableRecognitionResultController.swift
@@ -1,0 +1,282 @@
+import Cocoa
+import UniformTypeIdentifiers
+
+class TableRecognitionResultController: NSObject {
+    private var window: NSPanel?
+    private let table: RecognizedTable
+    private let workbookData: Data
+    private let temporaryWorkbookURL: URL
+
+    /// Invoked once when the result window closes so its owner can release it.
+    var onClose: (() -> Void)?
+
+    init(table: RecognizedTable) throws {
+        self.table = table
+        self.workbookData = try XLSXWriter.data(for: table)
+        self.temporaryWorkbookURL = TmpScratchDirectory.makeURL(
+            filename: "recognized-table-\(UUID().uuidString).xlsx"
+        )
+        super.init()
+        try workbookData.write(to: temporaryWorkbookURL, options: .atomic)
+        buildWindow()
+    }
+
+    private func buildWindow() {
+        let width: CGFloat = 760
+        let height: CGFloat = 500
+        let screen = NSScreen.main ?? NSScreen.screens[0]
+        let origin = NSPoint(
+            x: screen.visibleFrame.midX - width / 2,
+            y: screen.visibleFrame.midY - height / 2
+        )
+
+        let panel = TableResultPanel(
+            contentRect: NSRect(origin: origin, size: NSSize(width: width, height: height)),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = L("Table Recognition")
+        panel.level = .floating
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = false
+        panel.delegate = self
+        panel.minSize = NSSize(width: 620, height: 360)
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        contentView.autoresizingMask = [.width, .height]
+
+        let titleLabel = NSTextField(labelWithString: L("Table recognition succeeded"))
+        titleLabel.font = NSFont.systemFont(ofSize: 17, weight: .semibold)
+        titleLabel.frame = NSRect(x: 20, y: height - 42, width: width - 40, height: 24)
+        titleLabel.autoresizingMask = [.width, .minYMargin]
+        contentView.addSubview(titleLabel)
+
+        let summary = String(
+            format: L("%d rows · %d columns"),
+            table.rows.count,
+            table.columnCount
+        )
+        let summaryLabel = NSTextField(labelWithString: summary)
+        summaryLabel.font = NSFont.systemFont(ofSize: 12)
+        summaryLabel.textColor = .secondaryLabelColor
+        summaryLabel.frame = NSRect(x: 20, y: height - 64, width: width - 40, height: 18)
+        summaryLabel.autoresizingMask = [.width, .minYMargin]
+        contentView.addSubview(summaryLabel)
+
+        let footerHeight: CGFloat = 64
+        let scrollView = NSScrollView(frame: NSRect(
+            x: 20,
+            y: footerHeight,
+            width: width - 40,
+            height: height - footerHeight - 78
+        ))
+        scrollView.autoresizingMask = [.width, .height]
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .bezelBorder
+
+        let preview = NSTableView()
+        preview.dataSource = self
+        preview.delegate = self
+        preview.usesAlternatingRowBackgroundColors = true
+        preview.rowHeight = 25
+        preview.columnAutoresizingStyle = .noColumnAutoresizing
+        for column in 0..<table.columnCount {
+            let identifier = NSUserInterfaceItemIdentifier("column-\(column)")
+            let tableColumn = NSTableColumn(identifier: identifier)
+            tableColumn.title = Self.columnName(column)
+            tableColumn.width = 120
+            tableColumn.minWidth = 60
+            tableColumn.maxWidth = 360
+            preview.addTableColumn(tableColumn)
+        }
+        scrollView.documentView = preview
+        contentView.addSubview(scrollView)
+
+        let separator = NSBox(frame: NSRect(x: 0, y: footerHeight - 1, width: width, height: 1))
+        separator.boxType = .separator
+        separator.autoresizingMask = [.width, .maxYMargin]
+        contentView.addSubview(separator)
+
+        let buttonStack = NSStackView(frame: NSRect(x: 20, y: 18, width: width - 40, height: 30))
+        buttonStack.orientation = .horizontal
+        buttonStack.alignment = .centerY
+        buttonStack.distribution = .fillEqually
+        buttonStack.spacing = 8
+        buttonStack.autoresizingMask = [.width, .maxYMargin]
+
+        let openButton = makeButton(title: L("Open Excel File"), action: #selector(openExcelFile))
+        let saveButton = makeButton(title: L("Save As..."), action: #selector(saveAs))
+        let copyFileButton = makeButton(title: L("Copy Excel File"), action: #selector(copyExcelFile))
+        let copyTSVButton = makeButton(title: L("Copy as TSV"), action: #selector(copyAsTSV))
+        let closeButton = makeButton(title: L("Close"), action: #selector(close))
+        for button in [openButton, saveButton, copyFileButton, copyTSVButton, closeButton] {
+            buttonStack.addArrangedSubview(button)
+        }
+        contentView.addSubview(buttonStack)
+
+        panel.contentView = contentView
+        self.window = panel
+    }
+
+    private func makeButton(title: String, action: Selector) -> NSButton {
+        let button = NSButton(title: title, target: self, action: action)
+        button.bezelStyle = .rounded
+        return button
+    }
+
+    func show() {
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @objc private func openExcelFile() {
+        let url = temporaryWorkbookURL
+        close()
+        NSWorkspace.shared.open(url)
+    }
+
+    @objc private func saveAs() {
+        guard let window else { return }
+        let panel = NSSavePanel()
+        panel.title = L("Save Recognized Table")
+        panel.nameFieldStringValue = L("Recognized Table.xlsx")
+        if let xlsxType = UTType(filenameExtension: "xlsx") {
+            panel.allowedContentTypes = [xlsxType]
+        }
+        panel.isExtensionHidden = false
+        panel.canCreateDirectories = true
+        panel.beginSheetModal(for: window) { [weak self] response in
+            guard response == .OK, let self, let url = panel.url else { return }
+            do {
+                try self.workbookData.write(to: url, options: .atomic)
+                self.close()
+            } catch {
+                self.showWriteError(error)
+            }
+        }
+    }
+
+    @objc private func copyExcelFile() {
+        guard let url = ClipboardBackingStore.writeFileData(
+            workbookData,
+            fileExtension: "xlsx"
+        ) else {
+            showWriteError(nil)
+            return
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        guard pasteboard.writeObjects([url as NSURL]) else {
+            showWriteError(nil)
+            return
+        }
+        close()
+    }
+
+    @objc private func copyAsTSV() {
+        guard !table.tsv.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(table.tsv, forType: .string)
+        close()
+    }
+
+    @objc func close() {
+        window?.close()
+    }
+
+    private func showWriteError(_ error: Error?) {
+        let alert = NSAlert()
+        alert.messageText = L("Could Not Create Excel File")
+        alert.informativeText = error?.localizedDescription
+            ?? L("The Excel file could not be written. Please try again.")
+        alert.alertStyle = .warning
+        if let window {
+            alert.beginSheetModal(for: window)
+        }
+    }
+
+    private static func columnName(_ zeroBasedIndex: Int) -> String {
+        var index = zeroBasedIndex + 1
+        var result = ""
+        while index > 0 {
+            index -= 1
+            result = String(UnicodeScalar(65 + index % 26)!) + result
+            index /= 26
+        }
+        return result
+    }
+}
+
+extension TableRecognitionResultController: NSTableViewDataSource, NSTableViewDelegate {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        table.rows.count
+    }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard let tableColumn,
+              let column = Int(tableColumn.identifier.rawValue.replacingOccurrences(of: "column-", with: ""))
+        else { return nil }
+
+        let identifier = NSUserInterfaceItemIdentifier("recognized-table-cell")
+        let cell: NSTableCellView
+        if let reused = tableView.makeView(withIdentifier: identifier, owner: self) as? NSTableCellView {
+            cell = reused
+        } else {
+            cell = NSTableCellView()
+            cell.identifier = identifier
+            cell.wantsLayer = true
+            cell.layer?.masksToBounds = true
+            let textField = NSTextField(labelWithString: "")
+            textField.translatesAutoresizingMaskIntoConstraints = false
+            textField.usesSingleLineMode = true
+            textField.maximumNumberOfLines = 1
+            textField.lineBreakMode = .byTruncatingTail
+            textField.cell?.truncatesLastVisibleLine = true
+            textField.isSelectable = true
+            cell.textField = textField
+            cell.addSubview(textField)
+            NSLayoutConstraint.activate([
+                textField.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 6),
+                textField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -6),
+                textField.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            ])
+        }
+
+        let value = column < table.rows[row].count ? table.rows[row][column] : ""
+        cell.textField?.stringValue = value.replacingOccurrences(of: "\n", with: " ↵ ")
+        cell.textField?.toolTip = value.isEmpty ? nil : value
+        return cell
+    }
+}
+
+extension TableRecognitionResultController: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        guard window != nil else { return }
+        window?.delegate = nil
+        window = nil
+        onClose?()
+        onClose = nil
+        MainActor.assumeIsolated {
+            (NSApp.delegate as? AppDelegate)?.returnFocusIfNeeded()
+        }
+    }
+}
+
+private class TableResultPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+           event.keyCode == 13 {
+            performClose(nil)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+}

--- a/macshot/UI/Windows/TableRecognitionResultController.swift
+++ b/macshot/UI/Windows/TableRecognitionResultController.swift
@@ -6,6 +6,7 @@ class TableRecognitionResultController: NSObject {
     private let table: RecognizedTable
     private let workbookData: Data
     private let temporaryWorkbookURL: URL
+    private var removesTemporaryWorkbookOnClose = true
 
     /// Invoked once when the result window closes so its owner can release it.
     var onClose: (() -> Void)?
@@ -134,9 +135,12 @@ class TableRecognitionResultController: NSObject {
     }
 
     @objc private func openExcelFile() {
-        let url = temporaryWorkbookURL
+        guard NSWorkspace.shared.open(temporaryWorkbookURL) else {
+            showOpenError()
+            return
+        }
+        removesTemporaryWorkbookOnClose = false
         close()
-        NSWorkspace.shared.open(url)
     }
 
     @objc private func saveAs() {
@@ -200,6 +204,16 @@ class TableRecognitionResultController: NSObject {
         }
     }
 
+    private func showOpenError() {
+        let alert = NSAlert()
+        alert.messageText = L("Could Not Open Excel File")
+        alert.informativeText = L("No application is available to open Excel files.")
+        alert.alertStyle = .warning
+        if let window {
+            alert.beginSheetModal(for: window)
+        }
+    }
+
     private static func columnName(_ zeroBasedIndex: Int) -> String {
         var index = zeroBasedIndex + 1
         var result = ""
@@ -257,6 +271,9 @@ extension TableRecognitionResultController: NSTableViewDataSource, NSTableViewDe
 extension TableRecognitionResultController: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         guard window != nil else { return }
+        if removesTemporaryWorkbookOnClose {
+            try? FileManager.default.removeItem(at: temporaryWorkbookURL)
+        }
         window?.delegate = nil
         window = nil
         onClose?()

--- a/macshot/ar.lproj/Localizable.strings
+++ b/macshot/ar.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "التحديد محاذى بالفعل";
 "Space to move. Release to annotate and edit" = "اضغط على مفتاح المسافة للتحريك. حرّره لإضافة التعليقات التوضيحية والتحرير";
 "Space to move. Release to finish" = "اضغط على مفتاح المسافة للتحريك. حرّره للإنهاء";
+
+/* Table Recognition Window */
+"Table Recognition" = "التعرف على الجداول";
+"Table recognition succeeded" = "تم التعرف على الجدول بنجاح";
+"%d rows · %d columns" = "%d صفوف · %d أعمدة";
+"Open Excel File" = "فتح ملف Excel";
+"Copy Excel File" = "نسخ ملف Excel";
+"Copy as TSV" = "نسخ بصيغة TSV";
+"Save Recognized Table" = "حفظ الجدول الذي تم التعرف عليه";
+"Recognized Table.xlsx" = "الجدول الذي تم التعرف عليه.xlsx";
+"Table Recognition Failed" = "فشل التعرف على الجدول";
+"No text was detected in the selected area." = "لم يتم اكتشاف أي نص في المنطقة المحددة.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "لم يتم اكتشاف بنية جدول. حدد جدولاً يحتوي على صفين وعمودين على الأقل.";
+"The recognized table is too large to create an Excel file." = "الجدول الذي تم التعرف عليه كبير جدًا بحيث يتعذر إنشاء ملف Excel.";
+"Could Not Create Excel File" = "تعذّر إنشاء ملف Excel";
+"The Excel file could not be written. Please try again." = "تعذّرت كتابة ملف Excel. يرجى المحاولة مرة أخرى.";
+"Could Not Open Excel File" = "تعذّر فتح ملف Excel";
+"No application is available to open Excel files." = "لا يتوفر تطبيق لفتح ملفات Excel.";

--- a/macshot/bg.lproj/Localizable.strings
+++ b/macshot/bg.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Селекцията вече е подравнена";
 "Space to move. Release to annotate and edit" = "Задръжте интервала за преместване. Отпуснете за анотиране и редактиране";
 "Space to move. Release to finish" = "Задръжте интервала за преместване. Отпуснете за завършване";
+
+/* Table Recognition Window */
+"Table Recognition" = "Разпознаване на таблица";
+"Table recognition succeeded" = "Таблицата е разпозната успешно";
+"%d rows · %d columns" = "%d реда · %d колони";
+"Open Excel File" = "Отваряне на Excel файл";
+"Copy Excel File" = "Копиране на Excel файл";
+"Copy as TSV" = "Копиране като TSV";
+"Save Recognized Table" = "Запазване на разпознатата таблица";
+"Recognized Table.xlsx" = "Разпозната таблица.xlsx";
+"Table Recognition Failed" = "Неуспешно разпознаване на таблица";
+"No text was detected in the selected area." = "В избраната област не беше открит текст.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Не беше открита структура на таблица. Изберете таблица с поне два реда и две колони.";
+"The recognized table is too large to create an Excel file." = "Разпознатата таблица е твърде голяма за създаване на Excel файл.";
+"Could Not Create Excel File" = "Excel файлът не можа да бъде създаден";
+"The Excel file could not be written. Please try again." = "Excel файлът не можа да бъде записан. Опитайте отново.";
+"Could Not Open Excel File" = "Excel файлът не можа да бъде отворен";
+"No application is available to open Excel files." = "Няма налично приложение за отваряне на Excel файлове.";

--- a/macshot/bn.lproj/Localizable.strings
+++ b/macshot/bn.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "নির্বাচন ইতিমধ্যে সারিবদ্ধ";
 "Space to move. Release to annotate and edit" = "সরাতে স্পেস চেপে ধরুন। টীকা যোগ ও সম্পাদনা করতে ছেড়ে দিন";
 "Space to move. Release to finish" = "সরাতে স্পেস চেপে ধরুন। শেষ করতে ছেড়ে দিন";
+
+/* Table Recognition Window */
+"Table Recognition" = "টেবিল শনাক্তকরণ";
+"Table recognition succeeded" = "টেবিল সফলভাবে শনাক্ত হয়েছে";
+"%d rows · %d columns" = "%dটি সারি · %dটি কলাম";
+"Open Excel File" = "Excel ফাইল খুলুন";
+"Copy Excel File" = "Excel ফাইল কপি করুন";
+"Copy as TSV" = "TSV হিসেবে কপি করুন";
+"Save Recognized Table" = "শনাক্ত করা টেবিল সংরক্ষণ করুন";
+"Recognized Table.xlsx" = "শনাক্ত করা টেবিল.xlsx";
+"Table Recognition Failed" = "টেবিল শনাক্তকরণ ব্যর্থ";
+"No text was detected in the selected area." = "নির্বাচিত এলাকায় কোনো টেক্সট শনাক্ত হয়নি।";
+"No table structure was detected. Select a table with at least two rows and two columns." = "কোনো টেবিলের কাঠামো শনাক্ত হয়নি। কমপক্ষে দুইটি সারি ও দুইটি কলামযুক্ত একটি টেবিল নির্বাচন করুন।";
+"The recognized table is too large to create an Excel file." = "শনাক্ত করা টেবিলটি Excel ফাইল তৈরির জন্য অত্যন্ত বড়।";
+"Could Not Create Excel File" = "Excel ফাইল তৈরি করা যায়নি";
+"The Excel file could not be written. Please try again." = "Excel ফাইলটি লেখা যায়নি। আবার চেষ্টা করুন।";
+"Could Not Open Excel File" = "Excel ফাইল খোলা যায়নি";
+"No application is available to open Excel files." = "Excel ফাইল খোলার জন্য কোনো অ্যাপ্লিকেশন উপলভ্য নেই।";

--- a/macshot/ca.lproj/Localizable.strings
+++ b/macshot/ca.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "La selecció ja està alineada";
 "Space to move. Release to annotate and edit" = "Mantén premuda la barra espai per moure. Deixa-la anar per anotar i editar";
 "Space to move. Release to finish" = "Mantén premuda la barra espai per moure. Deixa-la anar per acabar";
+
+/* Table Recognition Window */
+"Table Recognition" = "Reconeixement de taules";
+"Table recognition succeeded" = "La taula s'ha reconegut correctament";
+"%d rows · %d columns" = "%d files · %d columnes";
+"Open Excel File" = "Obrir el fitxer d'Excel";
+"Copy Excel File" = "Copiar el fitxer d'Excel";
+"Copy as TSV" = "Copiar com a TSV";
+"Save Recognized Table" = "Desar la taula reconeguda";
+"Recognized Table.xlsx" = "Taula reconeguda.xlsx";
+"Table Recognition Failed" = "Ha fallat el reconeixement de la taula";
+"No text was detected in the selected area." = "No s'ha detectat text a l'àrea seleccionada.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "No s'ha detectat cap estructura de taula. Seleccioneu una taula amb almenys dues files i dues columnes.";
+"The recognized table is too large to create an Excel file." = "La taula reconeguda és massa gran per crear un fitxer d'Excel.";
+"Could Not Create Excel File" = "No s'ha pogut crear el fitxer d'Excel";
+"The Excel file could not be written. Please try again." = "No s'ha pogut escriure el fitxer d'Excel. Torneu-ho a provar.";
+"Could Not Open Excel File" = "No s'ha pogut obrir el fitxer d'Excel";
+"No application is available to open Excel files." = "No hi ha cap aplicació disponible per obrir fitxers d'Excel.";

--- a/macshot/cs.lproj/Localizable.strings
+++ b/macshot/cs.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Výběr je již zarovnán";
 "Space to move. Release to annotate and edit" = "Podržením mezerníku přesunete. Uvolněním můžete přidávat anotace a upravovat";
 "Space to move. Release to finish" = "Podržením mezerníku přesunete. Uvolněním dokončíte";
+
+/* Table Recognition Window */
+"Table Recognition" = "Rozpoznávání tabulky";
+"Table recognition succeeded" = "Tabulka byla úspěšně rozpoznána";
+"%d rows · %d columns" = "%d řádků · %d sloupců";
+"Open Excel File" = "Otevřít soubor Excel";
+"Copy Excel File" = "Kopírovat soubor Excel";
+"Copy as TSV" = "Kopírovat jako TSV";
+"Save Recognized Table" = "Uložit rozpoznanou tabulku";
+"Recognized Table.xlsx" = "Rozpoznaná tabulka.xlsx";
+"Table Recognition Failed" = "Rozpoznání tabulky se nezdařilo";
+"No text was detected in the selected area." = "Ve vybrané oblasti nebyl zjištěn žádný text.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Nebyla zjištěna struktura tabulky. Vyberte tabulku s alespoň dvěma řádky a dvěma sloupci.";
+"The recognized table is too large to create an Excel file." = "Rozpoznaná tabulka je příliš velká pro vytvoření souboru Excel.";
+"Could Not Create Excel File" = "Soubor Excel se nepodařilo vytvořit";
+"The Excel file could not be written. Please try again." = "Soubor Excel se nepodařilo zapsat. Zkuste to znovu.";
+"Could Not Open Excel File" = "Soubor Excel se nepodařilo otevřít";
+"No application is available to open Excel files." = "Pro otevírání souborů Excel není k dispozici žádná aplikace.";

--- a/macshot/da.lproj/Localizable.strings
+++ b/macshot/da.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Markeringen flugter allerede med kanterne";
 "Space to move. Release to annotate and edit" = "Hold mellemrumstasten nede for at flytte. Slip for at annotere og redigere";
 "Space to move. Release to finish" = "Hold mellemrumstasten nede for at flytte. Slip for at afslutte";
+
+/* Table Recognition Window */
+"Table Recognition" = "Tabelgenkendelse";
+"Table recognition succeeded" = "Tabellen blev genkendt";
+"%d rows · %d columns" = "%d rækker · %d kolonner";
+"Open Excel File" = "Åbn Excel-fil";
+"Copy Excel File" = "Kopiér Excel-fil";
+"Copy as TSV" = "Kopiér som TSV";
+"Save Recognized Table" = "Gem genkendt tabel";
+"Recognized Table.xlsx" = "Genkendt tabel.xlsx";
+"Table Recognition Failed" = "Tabelgenkendelse mislykkedes";
+"No text was detected in the selected area." = "Der blev ikke fundet tekst i det valgte område.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Der blev ikke fundet en tabelstruktur. Vælg en tabel med mindst to rækker og to kolonner.";
+"The recognized table is too large to create an Excel file." = "Den genkendte tabel er for stor til at oprette en Excel-fil.";
+"Could Not Create Excel File" = "Kunne ikke oprette Excel-fil";
+"The Excel file could not be written. Please try again." = "Excel-filen kunne ikke skrives. Prøv igen.";
+"Could Not Open Excel File" = "Kunne ikke åbne Excel-fil";
+"No application is available to open Excel files." = "Der er ingen tilgængelig app til at åbne Excel-filer.";

--- a/macshot/de.lproj/Localizable.strings
+++ b/macshot/de.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "Auswahl ist bereits ausgerichtet";
 "Space to move. Release to annotate and edit" = "Leertaste zum Verschieben gedrückt halten. Loslassen, um zu kommentieren und zu bearbeiten";
 "Space to move. Release to finish" = "Leertaste zum Verschieben gedrückt halten. Loslassen, um abzuschließen";
+
+/* Table Recognition Window */
+"Table Recognition" = "Tabellenerkennung";
+"Table recognition succeeded" = "Tabelle erfolgreich erkannt";
+"%d rows · %d columns" = "%d Zeilen · %d Spalten";
+"Open Excel File" = "Excel-Datei öffnen";
+"Copy Excel File" = "Excel-Datei kopieren";
+"Copy as TSV" = "Als TSV kopieren";
+"Save Recognized Table" = "Erkannte Tabelle sichern";
+"Recognized Table.xlsx" = "Erkannte Tabelle.xlsx";
+"Table Recognition Failed" = "Tabellenerkennung fehlgeschlagen";
+"No text was detected in the selected area." = "Im ausgewählten Bereich wurde kein Text erkannt.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Es wurde keine Tabellenstruktur erkannt. Wähle eine Tabelle mit mindestens zwei Zeilen und zwei Spalten aus.";
+"The recognized table is too large to create an Excel file." = "Die erkannte Tabelle ist zu groß, um eine Excel-Datei zu erstellen.";
+"Could Not Create Excel File" = "Excel-Datei konnte nicht erstellt werden";
+"The Excel file could not be written. Please try again." = "Die Excel-Datei konnte nicht geschrieben werden. Versuche es erneut.";
+"Could Not Open Excel File" = "Excel-Datei konnte nicht geöffnet werden";
+"No application is available to open Excel files." = "Es ist keine App zum Öffnen von Excel-Dateien verfügbar.";

--- a/macshot/el.lproj/Localizable.strings
+++ b/macshot/el.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "Η επιλογή είναι ήδη ευθυγραμμισμένη";
 "Space to move. Release to annotate and edit" = "Κρατήστε πατημένο το πλήκτρο διαστήματος για μετακίνηση. Αφήστε το για σχολιασμό και επεξεργασία";
 "Space to move. Release to finish" = "Κρατήστε πατημένο το πλήκτρο διαστήματος για μετακίνηση. Αφήστε το για ολοκλήρωση";
+
+/* Table Recognition Window */
+"Table Recognition" = "Αναγνώριση πίνακα";
+"Table recognition succeeded" = "Ο πίνακας αναγνωρίστηκε επιτυχώς";
+"%d rows · %d columns" = "%d γραμμές · %d στήλες";
+"Open Excel File" = "Άνοιγμα αρχείου Excel";
+"Copy Excel File" = "Αντιγραφή αρχείου Excel";
+"Copy as TSV" = "Αντιγραφή ως TSV";
+"Save Recognized Table" = "Αποθήκευση αναγνωρισμένου πίνακα";
+"Recognized Table.xlsx" = "Αναγνωρισμένος πίνακας.xlsx";
+"Table Recognition Failed" = "Η αναγνώριση πίνακα απέτυχε";
+"No text was detected in the selected area." = "Δεν εντοπίστηκε κείμενο στην επιλεγμένη περιοχή.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Δεν εντοπίστηκε δομή πίνακα. Επιλέξτε έναν πίνακα με τουλάχιστον δύο γραμμές και δύο στήλες.";
+"The recognized table is too large to create an Excel file." = "Ο αναγνωρισμένος πίνακας είναι πολύ μεγάλος για τη δημιουργία αρχείου Excel.";
+"Could Not Create Excel File" = "Δεν ήταν δυνατή η δημιουργία του αρχείου Excel";
+"The Excel file could not be written. Please try again." = "Δεν ήταν δυνατή η εγγραφή του αρχείου Excel. Δοκιμάστε ξανά.";
+"Could Not Open Excel File" = "Δεν ήταν δυνατό το άνοιγμα του αρχείου Excel";
+"No application is available to open Excel files." = "Δεν υπάρχει διαθέσιμη εφαρμογή για το άνοιγμα αρχείων Excel.";

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -434,6 +434,8 @@
 "The recognized table is too large to create an Excel file." = "The recognized table is too large to create an Excel file.";
 "Could Not Create Excel File" = "Could Not Create Excel File";
 "The Excel file could not be written. Please try again." = "The Excel file could not be written. Please try again.";
+"Could Not Open Excel File" = "Could Not Open Excel File";
+"No application is available to open Excel files." = "No application is available to open Excel files.";
 
 /* Upload Toast */
 "URL copied to the clipboard" = "URL copied to the clipboard";

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -419,6 +419,22 @@
 "QR Codes" = "QR Codes";
 "Open Link" = "Open Link";
 
+/* Table Recognition Window */
+"Table Recognition" = "Table Recognition";
+"Table recognition succeeded" = "Table recognition succeeded";
+"%d rows · %d columns" = "%d rows · %d columns";
+"Open Excel File" = "Open Excel File";
+"Copy Excel File" = "Copy Excel File";
+"Copy as TSV" = "Copy as TSV";
+"Save Recognized Table" = "Save Recognized Table";
+"Recognized Table.xlsx" = "Recognized Table.xlsx";
+"Table Recognition Failed" = "Table Recognition Failed";
+"No text was detected in the selected area." = "No text was detected in the selected area.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "No table structure was detected. Select a table with at least two rows and two columns.";
+"The recognized table is too large to create an Excel file." = "The recognized table is too large to create an Excel file.";
+"Could Not Create Excel File" = "Could Not Create Excel File";
+"The Excel file could not be written. Please try again." = "The Excel file could not be written. Please try again.";
+
 /* Upload Toast */
 "URL copied to the clipboard" = "URL copied to the clipboard";
 "Uploading... %d%%" = "Uploading... %d%%";

--- a/macshot/es.lproj/Localizable.strings
+++ b/macshot/es.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "La selección ya está alineada";
 "Space to move. Release to annotate and edit" = "Mantén pulsada la barra espaciadora para mover. Suéltala para anotar y editar";
 "Space to move. Release to finish" = "Mantén pulsada la barra espaciadora para mover. Suéltala para terminar";
+
+/* Table Recognition Window */
+"Table Recognition" = "Reconocimiento de tablas";
+"Table recognition succeeded" = "La tabla se ha reconocido correctamente";
+"%d rows · %d columns" = "%d filas · %d columnas";
+"Open Excel File" = "Abrir archivo de Excel";
+"Copy Excel File" = "Copiar archivo de Excel";
+"Copy as TSV" = "Copiar como TSV";
+"Save Recognized Table" = "Guardar tabla reconocida";
+"Recognized Table.xlsx" = "Tabla reconocida.xlsx";
+"Table Recognition Failed" = "Error al reconocer la tabla";
+"No text was detected in the selected area." = "No se ha detectado texto en el área seleccionada.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "No se ha detectado una estructura de tabla. Selecciona una tabla con al menos dos filas y dos columnas.";
+"The recognized table is too large to create an Excel file." = "La tabla reconocida es demasiado grande para crear un archivo de Excel.";
+"Could Not Create Excel File" = "No se pudo crear el archivo de Excel";
+"The Excel file could not be written. Please try again." = "No se pudo escribir el archivo de Excel. Inténtalo de nuevo.";
+"Could Not Open Excel File" = "No se pudo abrir el archivo de Excel";
+"No application is available to open Excel files." = "No hay ninguna aplicación disponible para abrir archivos de Excel.";

--- a/macshot/fa.lproj/Localizable.strings
+++ b/macshot/fa.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "محدودهٔ انتخاب از قبل تراز است";
 "Space to move. Release to annotate and edit" = "برای جابه‌جایی، کلید فاصله را نگه دارید. برای حاشیه‌نویسی و ویرایش رها کنید";
 "Space to move. Release to finish" = "برای جابه‌جایی، کلید فاصله را نگه دارید. برای پایان دادن رها کنید";
+
+/* Table Recognition Window */
+"Table Recognition" = "تشخیص جدول";
+"Table recognition succeeded" = "جدول با موفقیت تشخیص داده شد";
+"%d rows · %d columns" = "%d ردیف · %d ستون";
+"Open Excel File" = "باز کردن فایل Excel";
+"Copy Excel File" = "کپی فایل Excel";
+"Copy as TSV" = "کپی به‌صورت TSV";
+"Save Recognized Table" = "ذخیره جدول تشخیص‌داده‌شده";
+"Recognized Table.xlsx" = "جدول تشخیص‌داده‌شده.xlsx";
+"Table Recognition Failed" = "تشخیص جدول ناموفق بود";
+"No text was detected in the selected area." = "هیچ متنی در ناحیه انتخاب‌شده تشخیص داده نشد.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "هیچ ساختار جدولی تشخیص داده نشد. جدولی با حداقل دو ردیف و دو ستون انتخاب کنید.";
+"The recognized table is too large to create an Excel file." = "جدول تشخیص‌داده‌شده برای ایجاد فایل Excel بیش از حد بزرگ است.";
+"Could Not Create Excel File" = "فایل Excel ایجاد نشد";
+"The Excel file could not be written. Please try again." = "فایل Excel نوشته نشد. دوباره تلاش کنید.";
+"Could Not Open Excel File" = "فایل Excel باز نشد";
+"No application is available to open Excel files." = "هیچ برنامه‌ای برای باز کردن فایل‌های Excel در دسترس نیست.";

--- a/macshot/fi.lproj/Localizable.strings
+++ b/macshot/fi.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Valinta on jo kohdistettu";
 "Space to move. Release to annotate and edit" = "Siirrä pitämällä välilyöntiä painettuna. Vapauta lisätäksesi merkintöjä ja muokataksesi";
 "Space to move. Release to finish" = "Siirrä pitämällä välilyöntiä painettuna. Vapauta lopettaaksesi";
+
+/* Table Recognition Window */
+"Table Recognition" = "Taulukon tunnistus";
+"Table recognition succeeded" = "Taulukko tunnistettiin onnistuneesti";
+"%d rows · %d columns" = "%d riviä · %d saraketta";
+"Open Excel File" = "Avaa Excel-tiedosto";
+"Copy Excel File" = "Kopioi Excel-tiedosto";
+"Copy as TSV" = "Kopioi TSV-muodossa";
+"Save Recognized Table" = "Tallenna tunnistettu taulukko";
+"Recognized Table.xlsx" = "Tunnistettu taulukko.xlsx";
+"Table Recognition Failed" = "Taulukon tunnistus epäonnistui";
+"No text was detected in the selected area." = "Valitulla alueella ei havaittu tekstiä.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Taulukkorakennetta ei havaittu. Valitse taulukko, jossa on vähintään kaksi riviä ja kaksi saraketta.";
+"The recognized table is too large to create an Excel file." = "Tunnistettu taulukko on liian suuri Excel-tiedoston luomiseen.";
+"Could Not Create Excel File" = "Excel-tiedostoa ei voitu luoda";
+"The Excel file could not be written. Please try again." = "Excel-tiedostoa ei voitu kirjoittaa. Yritä uudelleen.";
+"Could Not Open Excel File" = "Excel-tiedostoa ei voitu avata";
+"No application is available to open Excel files." = "Excel-tiedostojen avaamiseen ei ole käytettävissä sovellusta.";

--- a/macshot/fil.lproj/Localizable.strings
+++ b/macshot/fil.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "Naka-align na ang pinili";
 "Space to move. Release to annotate and edit" = "Pindutin nang matagal ang Space para ilipat. Bitawan para mag-anotate at mag-edit";
 "Space to move. Release to finish" = "Pindutin nang matagal ang Space para ilipat. Bitawan para tapusin";
+
+/* Table Recognition Window */
+"Table Recognition" = "Pagkilala ng Talahanayan";
+"Table recognition succeeded" = "Matagumpay na nakilala ang talahanayan";
+"%d rows · %d columns" = "%d hilera · %d column";
+"Open Excel File" = "Buksan ang Excel File";
+"Copy Excel File" = "Kopyahin ang Excel File";
+"Copy as TSV" = "Kopyahin bilang TSV";
+"Save Recognized Table" = "I-save ang Nakilalang Talahanayan";
+"Recognized Table.xlsx" = "Nakilalang Talahanayan.xlsx";
+"Table Recognition Failed" = "Nabigo ang Pagkilala ng Talahanayan";
+"No text was detected in the selected area." = "Walang text na natukoy sa napiling bahagi.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Walang natukoy na istruktura ng talahanayan. Pumili ng talahanayan na may hindi bababa sa dalawang hilera at dalawang column.";
+"The recognized table is too large to create an Excel file." = "Masyadong malaki ang nakilalang talahanayan para gumawa ng Excel file.";
+"Could Not Create Excel File" = "Hindi Magawa ang Excel File";
+"The Excel file could not be written. Please try again." = "Hindi maisulat ang Excel file. Pakisubukang muli.";
+"Could Not Open Excel File" = "Hindi Mabuksan ang Excel File";
+"No application is available to open Excel files." = "Walang available na application para magbukas ng mga Excel file.";

--- a/macshot/fr.lproj/Localizable.strings
+++ b/macshot/fr.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "La sélection est déjà alignée";
 "Space to move. Release to annotate and edit" = "Maintenez la barre d'espace pour déplacer. Relâchez pour annoter et modifier";
 "Space to move. Release to finish" = "Maintenez la barre d'espace pour déplacer. Relâchez pour terminer";
+
+/* Table Recognition Window */
+"Table Recognition" = "Reconnaissance de tableau";
+"Table recognition succeeded" = "Le tableau a été reconnu";
+"%d rows · %d columns" = "%d lignes · %d colonnes";
+"Open Excel File" = "Ouvrir le fichier Excel";
+"Copy Excel File" = "Copier le fichier Excel";
+"Copy as TSV" = "Copier au format TSV";
+"Save Recognized Table" = "Enregistrer le tableau reconnu";
+"Recognized Table.xlsx" = "Tableau reconnu.xlsx";
+"Table Recognition Failed" = "Échec de la reconnaissance du tableau";
+"No text was detected in the selected area." = "Aucun texte n’a été détecté dans la zone sélectionnée.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Aucune structure de tableau n’a été détectée. Sélectionnez un tableau comportant au moins deux lignes et deux colonnes.";
+"The recognized table is too large to create an Excel file." = "Le tableau reconnu est trop volumineux pour créer un fichier Excel.";
+"Could Not Create Excel File" = "Impossible de créer le fichier Excel";
+"The Excel file could not be written. Please try again." = "Impossible d’écrire le fichier Excel. Réessayez.";
+"Could Not Open Excel File" = "Impossible d’ouvrir le fichier Excel";
+"No application is available to open Excel files." = "Aucune application n’est disponible pour ouvrir les fichiers Excel.";

--- a/macshot/he.lproj/Localizable.strings
+++ b/macshot/he.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "הבחירה כבר מיושרת";
 "Space to move. Release to annotate and edit" = "החזיקו את מקש הרווח כדי להזיז. שחררו כדי להוסיף הערות ולערוך";
 "Space to move. Release to finish" = "החזיקו את מקש הרווח כדי להזיז. שחררו כדי לסיים";
+
+/* Table Recognition Window */
+"Table Recognition" = "זיהוי טבלה";
+"Table recognition succeeded" = "הטבלה זוהתה בהצלחה";
+"%d rows · %d columns" = "%d שורות · %d עמודות";
+"Open Excel File" = "פתח קובץ Excel";
+"Copy Excel File" = "העתק קובץ Excel";
+"Copy as TSV" = "העתק כ-TSV";
+"Save Recognized Table" = "שמור את הטבלה שזוהתה";
+"Recognized Table.xlsx" = "טבלה שזוהתה.xlsx";
+"Table Recognition Failed" = "זיהוי הטבלה נכשל";
+"No text was detected in the selected area." = "לא זוהה טקסט באזור שנבחר.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "לא זוהה מבנה טבלה. יש לבחור טבלה עם לפחות שתי שורות ושתי עמודות.";
+"The recognized table is too large to create an Excel file." = "הטבלה שזוהתה גדולה מדי ליצירת קובץ Excel.";
+"Could Not Create Excel File" = "לא ניתן ליצור את קובץ ה-Excel";
+"The Excel file could not be written. Please try again." = "לא ניתן לכתוב את קובץ ה-Excel. יש לנסות שוב.";
+"Could Not Open Excel File" = "לא ניתן לפתוח את קובץ ה-Excel";
+"No application is available to open Excel files." = "אין יישום זמין לפתיחת קובצי Excel.";

--- a/macshot/hi.lproj/Localizable.strings
+++ b/macshot/hi.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "चयन पहले से संरेखित है";
 "Space to move. Release to annotate and edit" = "स्थानांतरित करने के लिए Spacebar दबाए रखें। एनोटेट और संपादित करने के लिए छोड़ें";
 "Space to move. Release to finish" = "स्थानांतरित करने के लिए Spacebar दबाए रखें। समाप्त करने के लिए छोड़ें";
+
+/* Table Recognition Window */
+"Table Recognition" = "तालिका पहचान";
+"Table recognition succeeded" = "तालिका सफलतापूर्वक पहचानी गई";
+"%d rows · %d columns" = "%d पंक्तियाँ · %d कॉलम";
+"Open Excel File" = "Excel फ़ाइल खोलें";
+"Copy Excel File" = "Excel फ़ाइल कॉपी करें";
+"Copy as TSV" = "TSV के रूप में कॉपी करें";
+"Save Recognized Table" = "पहचानी गई तालिका सहेजें";
+"Recognized Table.xlsx" = "पहचानी गई तालिका.xlsx";
+"Table Recognition Failed" = "तालिका पहचान विफल";
+"No text was detected in the selected area." = "चुने गए क्षेत्र में कोई टेक्स्ट नहीं मिला।";
+"No table structure was detected. Select a table with at least two rows and two columns." = "तालिका की संरचना नहीं मिली। कम से कम दो पंक्तियों और दो कॉलम वाली तालिका चुनें।";
+"The recognized table is too large to create an Excel file." = "पहचानी गई तालिका Excel फ़ाइल बनाने के लिए बहुत बड़ी है।";
+"Could Not Create Excel File" = "Excel फ़ाइल नहीं बनाई जा सकी";
+"The Excel file could not be written. Please try again." = "Excel फ़ाइल लिखी नहीं जा सकी। फिर से कोशिश करें।";
+"Could Not Open Excel File" = "Excel फ़ाइल नहीं खोली जा सकी";
+"No application is available to open Excel files." = "Excel फ़ाइलें खोलने के लिए कोई ऐप उपलब्ध नहीं है।";

--- a/macshot/hr.lproj/Localizable.strings
+++ b/macshot/hr.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Odabir je već poravnat";
 "Space to move. Release to annotate and edit" = "Držite razmaknicu za pomicanje. Otpustite za dodavanje bilješki i uređivanje";
 "Space to move. Release to finish" = "Držite razmaknicu za pomicanje. Otpustite za završetak";
+
+/* Table Recognition Window */
+"Table Recognition" = "Prepoznavanje tablice";
+"Table recognition succeeded" = "Tablica je uspješno prepoznata";
+"%d rows · %d columns" = "%d redaka · %d stupaca";
+"Open Excel File" = "Otvori Excel datoteku";
+"Copy Excel File" = "Kopiraj Excel datoteku";
+"Copy as TSV" = "Kopiraj kao TSV";
+"Save Recognized Table" = "Spremi prepoznatu tablicu";
+"Recognized Table.xlsx" = "Prepoznata tablica.xlsx";
+"Table Recognition Failed" = "Prepoznavanje tablice nije uspjelo";
+"No text was detected in the selected area." = "U odabranom području nije pronađen tekst.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Struktura tablice nije pronađena. Odaberite tablicu s najmanje dva retka i dva stupca.";
+"The recognized table is too large to create an Excel file." = "Prepoznata tablica prevelika je za izradu Excel datoteke.";
+"Could Not Create Excel File" = "Nije moguće izraditi Excel datoteku";
+"The Excel file could not be written. Please try again." = "Nije moguće zapisati Excel datoteku. Pokušajte ponovno.";
+"Could Not Open Excel File" = "Nije moguće otvoriti Excel datoteku";
+"No application is available to open Excel files." = "Nije dostupna aplikacija za otvaranje Excel datoteka.";

--- a/macshot/hu.lproj/Localizable.strings
+++ b/macshot/hu.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "A kijelölés már igazítva van";
 "Space to move. Release to annotate and edit" = "Tartsd lenyomva a szóközt a mozgatáshoz. Engedd fel a jegyzeteléshez és szerkesztéshez";
 "Space to move. Release to finish" = "Tartsd lenyomva a szóközt a mozgatáshoz. Engedd fel a befejezéshez";
+
+/* Table Recognition Window */
+"Table Recognition" = "Táblázatfelismerés";
+"Table recognition succeeded" = "A táblázat felismerése sikerült";
+"%d rows · %d columns" = "%d sor · %d oszlop";
+"Open Excel File" = "Excel-fájl megnyitása";
+"Copy Excel File" = "Excel-fájl másolása";
+"Copy as TSV" = "Másolás TSV-ként";
+"Save Recognized Table" = "Felismert táblázat mentése";
+"Recognized Table.xlsx" = "Felismert táblázat.xlsx";
+"Table Recognition Failed" = "A táblázatfelismerés sikertelen";
+"No text was detected in the selected area." = "A kijelölt területen nem található szöveg.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Nem található táblázatszerkezet. Jelöljön ki egy legalább két sorból és két oszlopból álló táblázatot.";
+"The recognized table is too large to create an Excel file." = "A felismert táblázat túl nagy Excel-fájl létrehozásához.";
+"Could Not Create Excel File" = "Az Excel-fájl nem hozható létre";
+"The Excel file could not be written. Please try again." = "Az Excel-fájl nem írható. Próbálja újra.";
+"Could Not Open Excel File" = "Az Excel-fájl nem nyitható meg";
+"No application is available to open Excel files." = "Nem érhető el alkalmazás az Excel-fájlok megnyitásához.";

--- a/macshot/id.lproj/Localizable.strings
+++ b/macshot/id.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Pilihan sudah sejajar";
 "Space to move. Release to annotate and edit" = "Tahan Spacebar untuk memindahkan. Lepaskan untuk membuat anotasi dan mengedit";
 "Space to move. Release to finish" = "Tahan Spacebar untuk memindahkan. Lepaskan untuk selesai";
+
+/* Table Recognition Window */
+"Table Recognition" = "Pengenalan Tabel";
+"Table recognition succeeded" = "Tabel berhasil dikenali";
+"%d rows · %d columns" = "%d baris · %d kolom";
+"Open Excel File" = "Buka File Excel";
+"Copy Excel File" = "Salin File Excel";
+"Copy as TSV" = "Salin sebagai TSV";
+"Save Recognized Table" = "Simpan Tabel yang Dikenali";
+"Recognized Table.xlsx" = "Tabel yang Dikenali.xlsx";
+"Table Recognition Failed" = "Pengenalan Tabel Gagal";
+"No text was detected in the selected area." = "Tidak ada teks yang terdeteksi di area yang dipilih.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Struktur tabel tidak terdeteksi. Pilih tabel dengan setidaknya dua baris dan dua kolom.";
+"The recognized table is too large to create an Excel file." = "Tabel yang dikenali terlalu besar untuk membuat file Excel.";
+"Could Not Create Excel File" = "File Excel Tidak Dapat Dibuat";
+"The Excel file could not be written. Please try again." = "File Excel tidak dapat ditulis. Coba lagi.";
+"Could Not Open Excel File" = "File Excel Tidak Dapat Dibuka";
+"No application is available to open Excel files." = "Tidak ada aplikasi yang tersedia untuk membuka file Excel.";

--- a/macshot/it.lproj/Localizable.strings
+++ b/macshot/it.lproj/Localizable.strings
@@ -663,3 +663,21 @@
 "Selection is already aligned" = "La selezione è già allineata";
 "Space to move. Release to annotate and edit" = "Tieni premuta la barra spaziatrice per spostare. Rilascia per annotare e modificare";
 "Space to move. Release to finish" = "Tieni premuta la barra spaziatrice per spostare. Rilascia per terminare";
+
+/* Table Recognition Window */
+"Table Recognition" = "Riconoscimento tabella";
+"Table recognition succeeded" = "Tabella riconosciuta correttamente";
+"%d rows · %d columns" = "%d righe · %d colonne";
+"Open Excel File" = "Apri file Excel";
+"Copy Excel File" = "Copia file Excel";
+"Copy as TSV" = "Copia come TSV";
+"Save Recognized Table" = "Salva tabella riconosciuta";
+"Recognized Table.xlsx" = "Tabella riconosciuta.xlsx";
+"Table Recognition Failed" = "Riconoscimento tabella non riuscito";
+"No text was detected in the selected area." = "Non è stato rilevato testo nell’area selezionata.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Non è stata rilevata una struttura di tabella. Seleziona una tabella con almeno due righe e due colonne.";
+"The recognized table is too large to create an Excel file." = "La tabella riconosciuta è troppo grande per creare un file Excel.";
+"Could Not Create Excel File" = "Impossibile creare il file Excel";
+"The Excel file could not be written. Please try again." = "Impossibile scrivere il file Excel. Riprova.";
+"Could Not Open Excel File" = "Impossibile aprire il file Excel";
+"No application is available to open Excel files." = "Non è disponibile alcuna applicazione per aprire i file Excel.";

--- a/macshot/ja.lproj/Localizable.strings
+++ b/macshot/ja.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "選択範囲はすでに揃っています";
 "Space to move. Release to annotate and edit" = "スペースバーを押している間は移動できます。離すと注釈の追加と編集に戻ります";
 "Space to move. Release to finish" = "スペースバーを押している間は移動できます。離すと完了します";
+
+/* Table Recognition Window */
+"Table Recognition" = "表の認識";
+"Table recognition succeeded" = "表を認識しました";
+"%d rows · %d columns" = "%d行 · %d列";
+"Open Excel File" = "Excelファイルを開く";
+"Copy Excel File" = "Excelファイルをコピー";
+"Copy as TSV" = "TSVとしてコピー";
+"Save Recognized Table" = "認識した表を保存";
+"Recognized Table.xlsx" = "認識した表.xlsx";
+"Table Recognition Failed" = "表の認識に失敗しました";
+"No text was detected in the selected area." = "選択範囲にテキストが検出されませんでした。";
+"No table structure was detected. Select a table with at least two rows and two columns." = "表の構造が検出されませんでした。2行2列以上の表を選択してください。";
+"The recognized table is too large to create an Excel file." = "認識した表が大きすぎるため、Excelファイルを作成できません。";
+"Could Not Create Excel File" = "Excelファイルを作成できませんでした";
+"The Excel file could not be written. Please try again." = "Excelファイルを書き込めませんでした。もう一度お試しください。";
+"Could Not Open Excel File" = "Excelファイルを開けませんでした";
+"No application is available to open Excel files." = "Excelファイルを開けるアプリケーションがありません。";

--- a/macshot/ko.lproj/Localizable.strings
+++ b/macshot/ko.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "선택 영역이 이미 정렬되어 있습니다";
 "Space to move. Release to annotate and edit" = "스페이스바로 이동. 놓으면 주석 및 편집";
 "Space to move. Release to finish" = "스페이스바로 이동. 놓으면 완료";
+
+/* Table Recognition Window */
+"Table Recognition" = "표 인식";
+"Table recognition succeeded" = "표를 인식했습니다";
+"%d rows · %d columns" = "%d행 · %d열";
+"Open Excel File" = "Excel 파일 열기";
+"Copy Excel File" = "Excel 파일 복사";
+"Copy as TSV" = "TSV로 복사";
+"Save Recognized Table" = "인식한 표 저장";
+"Recognized Table.xlsx" = "인식한 표.xlsx";
+"Table Recognition Failed" = "표 인식 실패";
+"No text was detected in the selected area." = "선택한 영역에서 텍스트가 감지되지 않았습니다.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "표 구조가 감지되지 않았습니다. 행과 열이 각각 두 개 이상인 표를 선택하십시오.";
+"The recognized table is too large to create an Excel file." = "인식한 표가 너무 커서 Excel 파일을 만들 수 없습니다.";
+"Could Not Create Excel File" = "Excel 파일을 만들 수 없음";
+"The Excel file could not be written. Please try again." = "Excel 파일을 쓸 수 없습니다. 다시 시도하십시오.";
+"Could Not Open Excel File" = "Excel 파일을 열 수 없음";
+"No application is available to open Excel files." = "Excel 파일을 열 수 있는 앱이 없습니다.";

--- a/macshot/ms.lproj/Localizable.strings
+++ b/macshot/ms.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "Pilihan sudah sejajar";
 "Space to move. Release to annotate and edit" = "Space untuk alih. Lepaskan untuk anotasi dan sunting";
 "Space to move. Release to finish" = "Space untuk alih. Lepaskan untuk selesai";
+
+/* Table Recognition Window */
+"Table Recognition" = "Pengecaman Jadual";
+"Table recognition succeeded" = "Jadual berjaya dicam";
+"%d rows · %d columns" = "%d baris · %d lajur";
+"Open Excel File" = "Buka Fail Excel";
+"Copy Excel File" = "Salin Fail Excel";
+"Copy as TSV" = "Salin sebagai TSV";
+"Save Recognized Table" = "Simpan Jadual yang Dicam";
+"Recognized Table.xlsx" = "Jadual yang Dicam.xlsx";
+"Table Recognition Failed" = "Pengecaman Jadual Gagal";
+"No text was detected in the selected area." = "Tiada teks dikesan dalam kawasan yang dipilih.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Tiada struktur jadual dikesan. Pilih jadual dengan sekurang-kurangnya dua baris dan dua lajur.";
+"The recognized table is too large to create an Excel file." = "Jadual yang dicam terlalu besar untuk mencipta fail Excel.";
+"Could Not Create Excel File" = "Fail Excel Tidak Dapat Dicipta";
+"The Excel file could not be written. Please try again." = "Fail Excel tidak dapat ditulis. Cuba lagi.";
+"Could Not Open Excel File" = "Fail Excel Tidak Dapat Dibuka";
+"No application is available to open Excel files." = "Tiada aplikasi tersedia untuk membuka fail Excel.";

--- a/macshot/nb.lproj/Localizable.strings
+++ b/macshot/nb.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Markeringen er allerede justert etter kantene";
 "Space to move. Release to annotate and edit" = "Mellomrom for å flytte. Slipp for å kommentere og redigere";
 "Space to move. Release to finish" = "Mellomrom for å flytte. Slipp for å fullføre";
+
+/* Table Recognition Window */
+"Table Recognition" = "Tabellgjenkjenning";
+"Table recognition succeeded" = "Tabellen ble gjenkjent";
+"%d rows · %d columns" = "%d rader · %d kolonner";
+"Open Excel File" = "Åpne Excel-fil";
+"Copy Excel File" = "Kopier Excel-fil";
+"Copy as TSV" = "Kopier som TSV";
+"Save Recognized Table" = "Lagre gjenkjent tabell";
+"Recognized Table.xlsx" = "Gjenkjent tabell.xlsx";
+"Table Recognition Failed" = "Tabellgjenkjenning mislyktes";
+"No text was detected in the selected area." = "Ingen tekst ble funnet i det valgte området.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Ingen tabellstruktur ble funnet. Velg en tabell med minst to rader og to kolonner.";
+"The recognized table is too large to create an Excel file." = "Den gjenkjente tabellen er for stor til å opprette en Excel-fil.";
+"Could Not Create Excel File" = "Kunne ikke opprette Excel-fil";
+"The Excel file could not be written. Please try again." = "Excel-filen kunne ikke skrives. Prøv igjen.";
+"Could Not Open Excel File" = "Kunne ikke åpne Excel-filen";
+"No application is available to open Excel files." = "Ingen tilgjengelig app kan åpne Excel-filer.";

--- a/macshot/nl.lproj/Localizable.strings
+++ b/macshot/nl.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "Selectie is al uitgelijnd";
 "Space to move. Release to annotate and edit" = "Spatie om te verplaatsen. Laat los om te annoteren en bewerken";
 "Space to move. Release to finish" = "Spatie om te verplaatsen. Laat los om te voltooien";
+
+/* Table Recognition Window */
+"Table Recognition" = "Tabelherkenning";
+"Table recognition succeeded" = "Tabel is herkend";
+"%d rows · %d columns" = "%d rijen · %d kolommen";
+"Open Excel File" = "Excel-bestand openen";
+"Copy Excel File" = "Excel-bestand kopiëren";
+"Copy as TSV" = "Kopieer als TSV";
+"Save Recognized Table" = "Herkende tabel bewaren";
+"Recognized Table.xlsx" = "Herkende tabel.xlsx";
+"Table Recognition Failed" = "Tabelherkenning mislukt";
+"No text was detected in the selected area." = "Er is geen tekst gedetecteerd in het geselecteerde gebied.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Er is geen tabelstructuur gedetecteerd. Selecteer een tabel met minstens twee rijen en twee kolommen.";
+"The recognized table is too large to create an Excel file." = "De herkende tabel is te groot om een Excel-bestand te maken.";
+"Could Not Create Excel File" = "Excel-bestand kon niet worden gemaakt";
+"The Excel file could not be written. Please try again." = "Excel-bestand kon niet worden geschreven. Probeer het opnieuw.";
+"Could Not Open Excel File" = "Excel-bestand kon niet worden geopend";
+"No application is available to open Excel files." = "Er is geen app beschikbaar om Excel-bestanden te openen.";

--- a/macshot/pl.lproj/Localizable.strings
+++ b/macshot/pl.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Zaznaczenie jest już wyrównane";
 "Space to move. Release to annotate and edit" = "Spacja, aby przesunąć. Puść, aby opisać i edytować";
 "Space to move. Release to finish" = "Spacja, aby przesunąć. Puść, aby zakończyć";
+
+/* Table Recognition Window */
+"Table Recognition" = "Rozpoznawanie tabeli";
+"Table recognition succeeded" = "Tabela została rozpoznana";
+"%d rows · %d columns" = "%d wierszy · %d kolumn";
+"Open Excel File" = "Otwórz plik Excel";
+"Copy Excel File" = "Kopiuj plik Excel";
+"Copy as TSV" = "Kopiuj jako TSV";
+"Save Recognized Table" = "Zapisz rozpoznaną tabelę";
+"Recognized Table.xlsx" = "Rozpoznana tabela.xlsx";
+"Table Recognition Failed" = "Nie udało się rozpoznać tabeli";
+"No text was detected in the selected area." = "Nie wykryto tekstu w zaznaczonym obszarze.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Nie wykryto struktury tabeli. Zaznacz tabelę zawierającą co najmniej dwa wiersze i dwie kolumny.";
+"The recognized table is too large to create an Excel file." = "Rozpoznana tabela jest zbyt duża, aby utworzyć plik Excel.";
+"Could Not Create Excel File" = "Nie można utworzyć pliku Excel";
+"The Excel file could not be written. Please try again." = "Nie można zapisać pliku Excel. Spróbuj ponownie.";
+"Could Not Open Excel File" = "Nie można otworzyć pliku Excel";
+"No application is available to open Excel files." = "Brak aplikacji do otwierania plików Excel.";

--- a/macshot/pt-BR.lproj/Localizable.strings
+++ b/macshot/pt-BR.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "A seleção já está alinhada";
 "Space to move. Release to annotate and edit" = "Espaço para mover. Solte para anotar e editar";
 "Space to move. Release to finish" = "Espaço para mover. Solte para concluir";
+
+/* Table Recognition Window */
+"Table Recognition" = "Reconhecimento de tabela";
+"Table recognition succeeded" = "Tabela reconhecida com sucesso";
+"%d rows · %d columns" = "%d linhas · %d colunas";
+"Open Excel File" = "Abrir arquivo do Excel";
+"Copy Excel File" = "Copiar arquivo do Excel";
+"Copy as TSV" = "Copiar como TSV";
+"Save Recognized Table" = "Salvar tabela reconhecida";
+"Recognized Table.xlsx" = "Tabela reconhecida.xlsx";
+"Table Recognition Failed" = "Falha no reconhecimento da tabela";
+"No text was detected in the selected area." = "Nenhum texto foi detectado na área selecionada.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Nenhuma estrutura de tabela foi detectada. Selecione uma tabela com pelo menos duas linhas e duas colunas.";
+"The recognized table is too large to create an Excel file." = "A tabela reconhecida é grande demais para criar um arquivo do Excel.";
+"Could Not Create Excel File" = "Não foi possível criar o arquivo do Excel";
+"The Excel file could not be written. Please try again." = "Não foi possível gravar o arquivo do Excel. Tente novamente.";
+"Could Not Open Excel File" = "Não foi possível abrir o arquivo do Excel";
+"No application is available to open Excel files." = "Não há nenhum aplicativo disponível para abrir arquivos do Excel.";

--- a/macshot/pt.lproj/Localizable.strings
+++ b/macshot/pt.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "A seleção já está alinhada";
 "Space to move. Release to annotate and edit" = "Espaço para mover. Solte para anotar e editar";
 "Space to move. Release to finish" = "Espaço para mover. Solte para concluir";
+
+/* Table Recognition Window */
+"Table Recognition" = "Reconhecimento de tabela";
+"Table recognition succeeded" = "Tabela reconhecida com sucesso";
+"%d rows · %d columns" = "%d linhas · %d colunas";
+"Open Excel File" = "Abrir ficheiro Excel";
+"Copy Excel File" = "Copiar ficheiro Excel";
+"Copy as TSV" = "Copiar como TSV";
+"Save Recognized Table" = "Guardar tabela reconhecida";
+"Recognized Table.xlsx" = "Tabela reconhecida.xlsx";
+"Table Recognition Failed" = "Falha no reconhecimento da tabela";
+"No text was detected in the selected area." = "Não foi detetado texto na área selecionada.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Não foi detetada uma estrutura de tabela. Selecione uma tabela com pelo menos duas linhas e duas colunas.";
+"The recognized table is too large to create an Excel file." = "A tabela reconhecida é demasiado grande para criar um ficheiro Excel.";
+"Could Not Create Excel File" = "Não foi possível criar o ficheiro Excel";
+"The Excel file could not be written. Please try again." = "Não foi possível escrever o ficheiro Excel. Tente novamente.";
+"Could Not Open Excel File" = "Não foi possível abrir o ficheiro Excel";
+"No application is available to open Excel files." = "Não está disponível nenhuma aplicação para abrir ficheiros Excel.";

--- a/macshot/ro.lproj/Localizable.strings
+++ b/macshot/ro.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Selecția este deja aliniată";
 "Space to move. Release to annotate and edit" = "Spațiu pentru mutare. Eliberează pentru a adăuga adnotări și a edita";
 "Space to move. Release to finish" = "Spațiu pentru mutare. Eliberează pentru a finaliza";
+
+/* Table Recognition Window */
+"Table Recognition" = "Recunoașterea tabelului";
+"Table recognition succeeded" = "Tabelul a fost recunoscut";
+"%d rows · %d columns" = "%d rânduri · %d coloane";
+"Open Excel File" = "Deschide fișierul Excel";
+"Copy Excel File" = "Copiază fișierul Excel";
+"Copy as TSV" = "Copiază ca TSV";
+"Save Recognized Table" = "Salvează tabelul recunoscut";
+"Recognized Table.xlsx" = "Tabel recunoscut.xlsx";
+"Table Recognition Failed" = "Recunoașterea tabelului a eșuat";
+"No text was detected in the selected area." = "Nu a fost detectat text în zona selectată.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Nu a fost detectată o structură de tabel. Selectează un tabel cu cel puțin două rânduri și două coloane.";
+"The recognized table is too large to create an Excel file." = "Tabelul recunoscut este prea mare pentru a crea un fișier Excel.";
+"Could Not Create Excel File" = "Fișierul Excel nu a putut fi creat";
+"The Excel file could not be written. Please try again." = "Fișierul Excel nu a putut fi scris. Încearcă din nou.";
+"Could Not Open Excel File" = "Fișierul Excel nu a putut fi deschis";
+"No application is available to open Excel files." = "Nu este disponibilă nicio aplicație pentru deschiderea fișierelor Excel.";

--- a/macshot/ru.lproj/Localizable.strings
+++ b/macshot/ru.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Область уже выровнена";
 "Space to move. Release to annotate and edit" = "Пробел — перемещение. Отпустите, чтобы добавить аннотации и перейти к редактированию";
 "Space to move. Release to finish" = "Пробел — перемещение. Отпустите, чтобы завершить";
+
+/* Table Recognition Window */
+"Table Recognition" = "Распознавание таблицы";
+"Table recognition succeeded" = "Таблица успешно распознана";
+"%d rows · %d columns" = "%d строк · %d столбцов";
+"Open Excel File" = "Открыть файл Excel";
+"Copy Excel File" = "Копировать файл Excel";
+"Copy as TSV" = "Копировать как TSV";
+"Save Recognized Table" = "Сохранить распознанную таблицу";
+"Recognized Table.xlsx" = "Распознанная таблица.xlsx";
+"Table Recognition Failed" = "Не удалось распознать таблицу";
+"No text was detected in the selected area." = "В выбранной области текст не обнаружен.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Структура таблицы не обнаружена. Выберите таблицу, содержащую не менее двух строк и двух столбцов.";
+"The recognized table is too large to create an Excel file." = "Распознанная таблица слишком велика для создания файла Excel.";
+"Could Not Create Excel File" = "Не удалось создать файл Excel";
+"The Excel file could not be written. Please try again." = "Не удалось записать файл Excel. Повторите попытку.";
+"Could Not Open Excel File" = "Не удалось открыть файл Excel";
+"No application is available to open Excel files." = "Нет приложения для открытия файлов Excel.";

--- a/macshot/sk.lproj/Localizable.strings
+++ b/macshot/sk.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Výber je už zarovnaný";
 "Space to move. Release to annotate and edit" = "Medzerník na presun. Pustite pre anotovanie a úpravy";
 "Space to move. Release to finish" = "Medzerník na presun. Pustite pre dokončenie";
+
+/* Table Recognition Window */
+"Table Recognition" = "Rozpoznávanie tabuľky";
+"Table recognition succeeded" = "Tabuľka bola úspešne rozpoznaná";
+"%d rows · %d columns" = "%d riadkov · %d stĺpcov";
+"Open Excel File" = "Otvoriť súbor Excel";
+"Copy Excel File" = "Kopírovať súbor Excel";
+"Copy as TSV" = "Kopírovať ako TSV";
+"Save Recognized Table" = "Uložiť rozpoznanú tabuľku";
+"Recognized Table.xlsx" = "Rozpoznaná tabuľka.xlsx";
+"Table Recognition Failed" = "Rozpoznávanie tabuľky zlyhalo";
+"No text was detected in the selected area." = "Vo vybratej oblasti nebol zistený žiadny text.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Nebola zistená štruktúra tabuľky. Vyberte tabuľku s aspoň dvoma riadkami a dvoma stĺpcami.";
+"The recognized table is too large to create an Excel file." = "Rozpoznaná tabuľka je príliš veľká na vytvorenie súboru Excel.";
+"Could Not Create Excel File" = "Súbor Excel sa nepodarilo vytvoriť";
+"The Excel file could not be written. Please try again." = "Súbor Excel sa nepodarilo zapísať. Skúste to znova.";
+"Could Not Open Excel File" = "Súbor Excel sa nepodarilo otvoriť";
+"No application is available to open Excel files." = "Na otváranie súborov Excel nie je k dispozícii žiadna aplikácia.";

--- a/macshot/sr.lproj/Localizable.strings
+++ b/macshot/sr.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "Izbor je već poravnat";
 "Space to move. Release to annotate and edit" = "Držite razmaknicu za pomeranje. Otpustite za dodavanje napomena i uređivanje";
 "Space to move. Release to finish" = "Držite razmaknicu za pomeranje. Otpustite da završite";
+
+/* Table Recognition Window */
+"Table Recognition" = "Препознавање табеле";
+"Table recognition succeeded" = "Табела је успешно препозната";
+"%d rows · %d columns" = "%d редова · %d колона";
+"Open Excel File" = "Отвори Excel датотеку";
+"Copy Excel File" = "Копирај Excel датотеку";
+"Copy as TSV" = "Копирај као TSV";
+"Save Recognized Table" = "Сачувај препознату табелу";
+"Recognized Table.xlsx" = "Препозната табела.xlsx";
+"Table Recognition Failed" = "Препознавање табеле није успело";
+"No text was detected in the selected area." = "У изабраној области није откривен текст.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Структура табеле није откривена. Изаберите табелу са најмање два реда и две колоне.";
+"The recognized table is too large to create an Excel file." = "Препозната табела је превелика за прављење Excel датотеке.";
+"Could Not Create Excel File" = "Excel датотека није могла да се направи";
+"The Excel file could not be written. Please try again." = "Excel датотека није могла да се запише. Покушајте поново.";
+"Could Not Open Excel File" = "Excel датотека није могла да се отвори";
+"No application is available to open Excel files." = "Ниједна апликација за отварање Excel датотека није доступна.";

--- a/macshot/sv.lproj/Localizable.strings
+++ b/macshot/sv.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Markeringen är redan justerad";
 "Space to move. Release to annotate and edit" = "Håll ned mellanslag för att flytta. Släpp för att kommentera och redigera";
 "Space to move. Release to finish" = "Håll ned mellanslag för att flytta. Släpp för att slutföra";
+
+/* Table Recognition Window */
+"Table Recognition" = "Tabelligenkänning";
+"Table recognition succeeded" = "Tabellen har identifierats";
+"%d rows · %d columns" = "%d rader · %d kolumner";
+"Open Excel File" = "Öppna Excel-fil";
+"Copy Excel File" = "Kopiera Excel-fil";
+"Copy as TSV" = "Kopiera som TSV";
+"Save Recognized Table" = "Spara identifierad tabell";
+"Recognized Table.xlsx" = "Identifierad tabell.xlsx";
+"Table Recognition Failed" = "Tabelligenkänningen misslyckades";
+"No text was detected in the selected area." = "Ingen text hittades i det markerade området.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Ingen tabellstruktur hittades. Markera en tabell med minst två rader och två kolumner.";
+"The recognized table is too large to create an Excel file." = "Den identifierade tabellen är för stor för att skapa en Excel-fil.";
+"Could Not Create Excel File" = "Det gick inte att skapa Excel-filen";
+"The Excel file could not be written. Please try again." = "Det gick inte att skriva Excel-filen. Försök igen.";
+"Could Not Open Excel File" = "Det gick inte att öppna Excel-filen";
+"No application is available to open Excel files." = "Det finns ingen tillgänglig app för att öppna Excel-filer.";

--- a/macshot/ta.lproj/Localizable.strings
+++ b/macshot/ta.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "தேர்வு ஏற்கனவே சீரமைக்கப்பட்டுள்ளது";
 "Space to move. Release to annotate and edit" = "நகர்த்த ஸ்பேஸ் விசையைப் பிடிக்கவும். குறிப்புரையிட்டு திருத்த விடுவிக்கவும்";
 "Space to move. Release to finish" = "நகர்த்த ஸ்பேஸ் விசையைப் பிடிக்கவும். முடிக்க விடுவிக்கவும்";
+
+/* Table Recognition Window */
+"Table Recognition" = "அட்டவணை அடையாளம்";
+"Table recognition succeeded" = "அட்டவணை வெற்றிகரமாக அடையாளம் காணப்பட்டது";
+"%d rows · %d columns" = "%d வரிசைகள் · %d நெடுவரிசைகள்";
+"Open Excel File" = "Excel கோப்பைத் திற";
+"Copy Excel File" = "Excel கோப்பை நகலெடு";
+"Copy as TSV" = "TSV ஆக நகலெடு";
+"Save Recognized Table" = "அடையாளம் கண்ட அட்டவணையைச் சேமி";
+"Recognized Table.xlsx" = "அடையாளம் கண்ட அட்டவணை.xlsx";
+"Table Recognition Failed" = "அட்டவணை அடையாளம் தோல்வியடைந்தது";
+"No text was detected in the selected area." = "தேர்ந்தெடுத்த பகுதியில் உரை எதுவும் கண்டறியப்படவில்லை.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "அட்டவணை அமைப்பு எதுவும் கண்டறியப்படவில்லை. குறைந்தது இரண்டு வரிசைகள் மற்றும் இரண்டு நெடுவரிசைகள் உள்ள அட்டவணையைத் தேர்ந்தெடுக்கவும்.";
+"The recognized table is too large to create an Excel file." = "அடையாளம் கண்ட அட்டவணை Excel கோப்பை உருவாக்க முடியாத அளவுக்குப் பெரியது.";
+"Could Not Create Excel File" = "Excel கோப்பை உருவாக்க முடியவில்லை";
+"The Excel file could not be written. Please try again." = "Excel கோப்பை எழுத முடியவில்லை. மீண்டும் முயற்சிக்கவும்.";
+"Could Not Open Excel File" = "Excel கோப்பைத் திறக்க முடியவில்லை";
+"No application is available to open Excel files." = "Excel கோப்புகளைத் திறக்க எந்தப் பயன்பாடும் இல்லை.";

--- a/macshot/th.lproj/Localizable.strings
+++ b/macshot/th.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "ขอบเขตการเลือกตรงแนวอยู่แล้ว";
 "Space to move. Release to annotate and edit" = "กด Space ค้างไว้เพื่อย้าย ปล่อยเพื่อใส่คำอธิบายประกอบและแก้ไข";
 "Space to move. Release to finish" = "กด Space ค้างไว้เพื่อย้าย ปล่อยเพื่อเสร็จสิ้น";
+
+/* Table Recognition Window */
+"Table Recognition" = "การรู้จำตาราง";
+"Table recognition succeeded" = "รู้จำตารางสำเร็จ";
+"%d rows · %d columns" = "%d แถว · %d คอลัมน์";
+"Open Excel File" = "เปิดไฟล์ Excel";
+"Copy Excel File" = "คัดลอกไฟล์ Excel";
+"Copy as TSV" = "คัดลอกเป็น TSV";
+"Save Recognized Table" = "บันทึกตารางที่รู้จำ";
+"Recognized Table.xlsx" = "ตารางที่รู้จำ.xlsx";
+"Table Recognition Failed" = "การรู้จำตารางล้มเหลว";
+"No text was detected in the selected area." = "ไม่พบข้อความในพื้นที่ที่เลือก";
+"No table structure was detected. Select a table with at least two rows and two columns." = "ไม่พบโครงสร้างตาราง โปรดเลือกตารางที่มีอย่างน้อยสองแถวและสองคอลัมน์";
+"The recognized table is too large to create an Excel file." = "ตารางที่รู้จำมีขนาดใหญ่เกินกว่าจะสร้างไฟล์ Excel";
+"Could Not Create Excel File" = "ไม่สามารถสร้างไฟล์ Excel ได้";
+"The Excel file could not be written. Please try again." = "ไม่สามารถเขียนไฟล์ Excel ได้ โปรดลองอีกครั้ง";
+"Could Not Open Excel File" = "ไม่สามารถเปิดไฟล์ Excel ได้";
+"No application is available to open Excel files." = "ไม่มีแอปพลิเคชันสำหรับเปิดไฟล์ Excel";

--- a/macshot/tr.lproj/Localizable.strings
+++ b/macshot/tr.lproj/Localizable.strings
@@ -682,3 +682,21 @@
 "Selection is already aligned" = "Seçim zaten hizalı";
 "Space to move. Release to annotate and edit" = "Taşımak için Boşluk tuşunu basılı tutun. Açıklama eklemek ve düzenlemek için bırakın";
 "Space to move. Release to finish" = "Taşımak için Boşluk tuşunu basılı tutun. Bitirmek için bırakın";
+
+/* Table Recognition Window */
+"Table Recognition" = "Tablo Tanıma";
+"Table recognition succeeded" = "Tablo başarıyla tanındı";
+"%d rows · %d columns" = "%d satır · %d sütun";
+"Open Excel File" = "Excel Dosyasını Aç";
+"Copy Excel File" = "Excel Dosyasını Kopyala";
+"Copy as TSV" = "TSV Olarak Kopyala";
+"Save Recognized Table" = "Tanınan Tabloyu Kaydet";
+"Recognized Table.xlsx" = "Tanınan Tablo.xlsx";
+"Table Recognition Failed" = "Tablo Tanıma Başarısız";
+"No text was detected in the selected area." = "Seçilen alanda metin algılanmadı.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Tablo yapısı algılanmadı. En az iki satır ve iki sütun içeren bir tablo seçin.";
+"The recognized table is too large to create an Excel file." = "Tanınan tablo bir Excel dosyası oluşturmak için çok büyük.";
+"Could Not Create Excel File" = "Excel Dosyası Oluşturulamadı";
+"The Excel file could not be written. Please try again." = "Excel dosyası yazılamadı. Lütfen tekrar deneyin.";
+"Could Not Open Excel File" = "Excel Dosyası Açılamadı";
+"No application is available to open Excel files." = "Excel dosyalarını açabilecek bir uygulama yok.";

--- a/macshot/uk.lproj/Localizable.strings
+++ b/macshot/uk.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Виділення вже вирівняно";
 "Space to move. Release to annotate and edit" = "Утримуйте Пробіл, щоб перемістити. Відпустіть, щоб додати анотацію та редагувати";
 "Space to move. Release to finish" = "Утримуйте Пробіл, щоб перемістити. Відпустіть, щоб завершити";
+
+/* Table Recognition Window */
+"Table Recognition" = "Розпізнавання таблиці";
+"Table recognition succeeded" = "Таблицю успішно розпізнано";
+"%d rows · %d columns" = "%d рядків · %d стовпців";
+"Open Excel File" = "Відкрити файл Excel";
+"Copy Excel File" = "Копіювати файл Excel";
+"Copy as TSV" = "Копіювати як TSV";
+"Save Recognized Table" = "Зберегти розпізнану таблицю";
+"Recognized Table.xlsx" = "Розпізнана таблиця.xlsx";
+"Table Recognition Failed" = "Не вдалося розпізнати таблицю";
+"No text was detected in the selected area." = "У вибраній області текст не виявлено.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Структуру таблиці не виявлено. Виберіть таблицю, що містить принаймні два рядки та два стовпці.";
+"The recognized table is too large to create an Excel file." = "Розпізнана таблиця завелика для створення файлу Excel.";
+"Could Not Create Excel File" = "Не вдалося створити файл Excel";
+"The Excel file could not be written. Please try again." = "Не вдалося записати файл Excel. Спробуйте ще раз.";
+"Could Not Open Excel File" = "Не вдалося відкрити файл Excel";
+"No application is available to open Excel files." = "Немає програми для відкриття файлів Excel.";

--- a/macshot/vi.lproj/Localizable.strings
+++ b/macshot/vi.lproj/Localizable.strings
@@ -680,3 +680,21 @@
 "Selection is already aligned" = "Vùng chọn đã được căn chỉnh";
 "Space to move. Release to annotate and edit" = "Giữ phím cách để di chuyển. Thả ra để chú thích và chỉnh sửa";
 "Space to move. Release to finish" = "Giữ phím cách để di chuyển. Thả ra để hoàn tất";
+
+/* Table Recognition Window */
+"Table Recognition" = "Nhận dạng bảng";
+"Table recognition succeeded" = "Đã nhận dạng bảng thành công";
+"%d rows · %d columns" = "%d hàng · %d cột";
+"Open Excel File" = "Mở tệp Excel";
+"Copy Excel File" = "Sao chép tệp Excel";
+"Copy as TSV" = "Sao chép dưới dạng TSV";
+"Save Recognized Table" = "Lưu bảng đã nhận dạng";
+"Recognized Table.xlsx" = "Bảng đã nhận dạng.xlsx";
+"Table Recognition Failed" = "Không thể nhận dạng bảng";
+"No text was detected in the selected area." = "Không phát hiện thấy văn bản trong vùng đã chọn.";
+"No table structure was detected. Select a table with at least two rows and two columns." = "Không phát hiện thấy cấu trúc bảng. Hãy chọn bảng có ít nhất hai hàng và hai cột.";
+"The recognized table is too large to create an Excel file." = "Bảng đã nhận dạng quá lớn để tạo tệp Excel.";
+"Could Not Create Excel File" = "Không thể tạo tệp Excel";
+"The Excel file could not be written. Please try again." = "Không thể ghi tệp Excel. Vui lòng thử lại.";
+"Could Not Open Excel File" = "Không thể mở tệp Excel";
+"No application is available to open Excel files." = "Không có ứng dụng nào để mở tệp Excel.";

--- a/macshot/zh-Hans.lproj/Localizable.strings
+++ b/macshot/zh-Hans.lproj/Localizable.strings
@@ -406,6 +406,8 @@
 "The recognized table is too large to create an Excel file." = "识别的表格过大，无法创建 Excel 文件。";
 "Could Not Create Excel File" = "无法创建 Excel 文件";
 "The Excel file could not be written. Please try again." = "无法写入 Excel 文件，请重试。";
+"Could Not Open Excel File" = "无法打开 Excel 文件";
+"No application is available to open Excel files." = "没有可用于打开 Excel 文件的应用。";
 
 /* Upload Toast */
 "URL copied to the clipboard" = "URL 已拷贝到剪贴板";

--- a/macshot/zh-Hans.lproj/Localizable.strings
+++ b/macshot/zh-Hans.lproj/Localizable.strings
@@ -391,6 +391,22 @@
 "Translation" = "翻译";
 "(No text detected in the selected area)" = "（未在选定区域中检测到文字）";
 
+/* Table Recognition Window */
+"Table Recognition" = "表格识别";
+"Table recognition succeeded" = "表格识别成功";
+"%d rows · %d columns" = "%d 行 · %d 列";
+"Open Excel File" = "打开 Excel 文件";
+"Copy Excel File" = "复制 Excel 文件";
+"Copy as TSV" = "复制为 Tab 分隔表格";
+"Save Recognized Table" = "存储识别的表格";
+"Recognized Table.xlsx" = "识别的表格.xlsx";
+"Table Recognition Failed" = "表格识别失败";
+"No text was detected in the selected area." = "未在选定区域中检测到文字。";
+"No table structure was detected. Select a table with at least two rows and two columns." = "未检测到表格结构。请选择至少包含两行两列的表格。";
+"The recognized table is too large to create an Excel file." = "识别的表格过大，无法创建 Excel 文件。";
+"Could Not Create Excel File" = "无法创建 Excel 文件";
+"The Excel file could not be written. Please try again." = "无法写入 Excel 文件，请重试。";
+
 /* Upload Toast */
 "URL copied to the clipboard" = "URL 已拷贝到剪贴板";
 "Uploading... %d%%" = "上传中... %d%%";

--- a/macshot/zh-Hant.lproj/Localizable.strings
+++ b/macshot/zh-Hant.lproj/Localizable.strings
@@ -421,6 +421,8 @@
 "The recognized table is too large to create an Excel file." = "辨識的表格過大，無法建立 Excel 檔案。";
 "Could Not Create Excel File" = "無法建立 Excel 檔案";
 "The Excel file could not be written. Please try again." = "無法寫入 Excel 檔案，請再試一次。";
+"Could Not Open Excel File" = "無法開啟 Excel 檔案";
+"No application is available to open Excel files." = "沒有可用來開啟 Excel 檔案的應用程式。";
 
 /* Upload Toast */
 "URL copied to the clipboard" = "URL 已拷貝至剪貼簿";

--- a/macshot/zh-Hant.lproj/Localizable.strings
+++ b/macshot/zh-Hant.lproj/Localizable.strings
@@ -406,6 +406,22 @@
 "Translation" = "翻譯";
 "(No text detected in the selected area)" = "（在選取區域中未偵測到文字）";
 
+/* Table Recognition Window */
+"Table Recognition" = "表格辨識";
+"Table recognition succeeded" = "表格辨識成功";
+"%d rows · %d columns" = "%d 列 · %d 欄";
+"Open Excel File" = "開啟 Excel 檔案";
+"Copy Excel File" = "拷貝 Excel 檔案";
+"Copy as TSV" = "拷貝為 Tab 分隔表格";
+"Save Recognized Table" = "儲存辨識的表格";
+"Recognized Table.xlsx" = "辨識的表格.xlsx";
+"Table Recognition Failed" = "表格辨識失敗";
+"No text was detected in the selected area." = "在所選區域中未偵測到文字。";
+"No table structure was detected. Select a table with at least two rows and two columns." = "未偵測到表格結構。請選取至少包含兩列兩欄的表格。";
+"The recognized table is too large to create an Excel file." = "辨識的表格過大，無法建立 Excel 檔案。";
+"Could Not Create Excel File" = "無法建立 Excel 檔案";
+"The Excel file could not be written. Please try again." = "無法寫入 Excel 檔案，請再試一次。";
+
 /* Upload Toast */
 "URL copied to the clipboard" = "URL 已拷貝至剪貼簿";
 "Uploading... %d%%" = "上傳中⋯ %d%%";


### PR DESCRIPTION
## Summary

- add a configurable Table Recognition action to the capture toolbar
- reconstruct rows and columns with Vision OCR, using detected table grid lines when available and geometry as a fallback
- preserve multiline cell contents and quote tabs, newlines, and quotes when copying TSV for direct Excel paste
- add a result preview with XLSX open, save, and copy actions
- localize the table-recognition UI across all 40 existing Localizable.strings files

## Current implementation

- uses Apple Vision OCR and a lightweight line detector; no OCR or spreadsheet dependency was added
- supports bordered, horizontal-line-only, and geometry-only tables, including left-, center-, and right-aligned columns
- generates a dependency-free XLSX workbook and also supports TSV copy
- keeps the AppKit result window available when file creation or external opening fails

## Validation

- Release xcodebuild succeeded for the universal arm64/x86_64 app
- the supplied multiline API table was reconstructed as 11 rows by 6 columns, with all four refundOutTradeNo description lines in one cell
- the existing score-table sample remained 8 rows by 5 columns
- focused regression coverage passed for mixed alignments, blank grid rows, multiline cells, horizontal-only grids, and TSV escaping
- a generated 10,000-row workbook passed ZIP archive integrity validation
- all 40 localization files passed syntax, key-coverage, and format-placeholder checks
- git diff --check passed

## Maintainer feedback welcome

I saw that CONTRIBUTING.md asks contributors to discuss new features before implementation. Since the implementation and PR already exist, I am presenting the current code as a concrete proposal for review rather than opening a duplicate implementation discussion now.

Would this direction and current implementation be acceptable for macshot? I am happy to change, simplify, or rework any part based on maintainer preferences. It is also completely fine to close or reject the PR if the feature does not fit the project direction.