### PR TITLE
feat: restore last capture area with R

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -2301,6 +2301,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 // MARK: - OverlayWindowControllerDelegate
 
 extension AppDelegate: OverlayWindowControllerDelegate {
+    func overlayDidRequestRestoreLastSelection(_ controller: OverlayWindowController) {
+        restoreLastSelection(controllers: overlayControllers)
+    }
+
     func overlayDidCancel(_ controller: OverlayWindowController) {
         // If the user cancels while in recording setup (before capture started),
         // just dismiss. If recording is actively capturing, stop it.

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -33,6 +33,11 @@ protocol OverlayViewDelegate: AnyObject {
     func overlayViewDidChangeWindowSnapState()
     func overlayViewRemoteSelectionDidFinish(_ rect: NSRect)
     func overlayViewDidRequestAddCapture()
+    func overlayViewDidRequestRestoreLastSelection()
+}
+
+extension OverlayViewDelegate {
+    func overlayViewDidRequestRestoreLastSelection() {}
 }
 
 /// An entry in the undo/redo history.
@@ -9064,6 +9069,15 @@ class OverlayView: NSView {
                 overlayDelegate?.overlayViewDidFinishSelection(selectionRect)
                 needsDisplay = true
             }
+            return
+        }
+
+        // R restores the previous capture region while the overlay is still
+        // waiting for a selection. Once selected, R keeps its normal Rectangle
+        // tool shortcut behavior.
+        if state == .idle, !isEditorMode, textEditView == nil,
+           KeyboardShortcutMatcher.matches(event, character: "r", modifiers: []) {
+            overlayDelegate?.overlayViewDidRequestRestoreLastSelection()
             return
         }
 

--- a/macshot/UI/Overlay/OverlayWindowController.swift
+++ b/macshot/UI/Overlay/OverlayWindowController.swift
@@ -83,6 +83,11 @@ protocol OverlayWindowControllerDelegate: AnyObject {
     func overlayDidFinishRemoteResize(_ controller: OverlayWindowController, globalRect: NSRect)
     func overlayCrossScreenImage(_ controller: OverlayWindowController) -> NSImage?
     func overlayDidChangeWindowSnapState(_ controller: OverlayWindowController)
+    func overlayDidRequestRestoreLastSelection(_ controller: OverlayWindowController)
+}
+
+extension OverlayWindowControllerDelegate {
+    func overlayDidRequestRestoreLastSelection(_ controller: OverlayWindowController) {}
 }
 
 /// Manages one fullscreen overlay per screen.
@@ -526,6 +531,10 @@ class OverlayWindowController {
 // MARK: - OverlayViewDelegate
 
 extension OverlayWindowController: OverlayViewDelegate {
+    func overlayViewDidRequestRestoreLastSelection() {
+        overlayDelegate?.overlayDidRequestRestoreLastSelection(self)
+    }
+
     func overlayViewDidFinishSelection(_ rect: NSRect) {
         // No-op: window is already key (.nonactivatingPanel + makeKeyAndOrderFront).
     }


### PR DESCRIPTION
## Summary

- restore the last saved capture region by pressing R while the capture overlay is idle
- preserve the existing Rectangle shortcut after a selection is active
- reuse the existing multi-display restoration path and leave the overlay unchanged when no matching saved region exists

## Current implementation

- handles R only while the overlay is idle, outside editor and text-editing modes, and without Command, Option, or Control modifiers
- forwards the request through the existing overlay delegates to AppDelegate
- reuses the existing restoreLastSelection path instead of adding separate selection persistence or display-matching logic
- keeps the existing Rectangle tool shortcut unchanged once a selection is active

## Validation

- xcodebuild Debug build succeeded
- git diff --check passed

## Maintainer feedback welcome

I saw that CONTRIBUTING.md asks contributors to discuss new features before implementation. Since the implementation and PR already exist, I am presenting the current code as a concrete proposal for review rather than opening a duplicate implementation discussion now.

Would this shortcut behavior and current implementation be acceptable for macshot? I am happy to change the key behavior, simplify the implementation, or rework any part based on maintainer preferences. It is also completely fine to close or reject the PR if it does not fit the project direction.