### PR TITLE
feat: add accessibility element snapping

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -3152,12 +3152,11 @@ extension AppDelegate: OverlayWindowControllerDelegate {
         return stitchCrossScreenCapture(primary: controller, others: others)
     }
 
-    func overlayDidChangeWindowSnapState(_ controller: OverlayWindowController) {
+    func overlayDidChangeSnapMode(_ controller: OverlayWindowController) {
         // Notify all other overlays to redraw (for multi-monitor setups)
-        // When window snap state changes via Tab key, all overlays need to update
-        // their helper text to show the new ON/OFF state
+        // When snap mode changes via Tab, all overlays need to update their helper text.
         for other in overlayControllers where other !== controller {
-            other.triggerRedraw()
+            other.refreshSnapMode()
         }
     }
 

--- a/macshot/UI/Editor/DetachedEditorWindowController.swift
+++ b/macshot/UI/Editor/DetachedEditorWindowController.swift
@@ -585,7 +585,7 @@ extension DetachedEditorWindowController: OverlayViewDelegate {
     func overlayViewDidRequestToggleAutoScroll() {}
     func overlayViewDidRequestAccessibilityPermission() {}
     func overlayViewDidRequestInputMonitoringPermission() {}
-    func overlayViewDidChangeWindowSnapState() {}  // Not applicable in editor mode
+    func overlayViewDidChangeSnapMode() {}  // Not applicable in editor mode
 
     func overlayViewDidRequestAddCapture() {
         guard let editorWindow = window else { return }
@@ -757,10 +757,10 @@ private class AddCaptureOverlayHandler: NSObject, OverlayWindowControllerDelegat
         return NSImage(cgImage: cgImage, size: globalRect.size)
     }
 
-    func overlayDidChangeWindowSnapState(_ controller: OverlayWindowController) {
+    func overlayDidChangeSnapMode(_ controller: OverlayWindowController) {
         // Notify all other overlays to redraw (for multi-monitor setups during "Add Capture" in editor)
         for other in overlayControllers where other !== controller {
-            other.triggerRedraw()
+            other.refreshSnapMode()
         }
     }
 }

--- a/macshot/UI/Overlay/OverlayView+WindowSnapping.swift
+++ b/macshot/UI/Overlay/OverlayView+WindowSnapping.swift
@@ -4,7 +4,13 @@ extension OverlayView {
 
     static let browserElementSnapEnabledKey = "browserElementSnapEnabled"
     private static let browserAccessibilityLock = NSLock()
-    private static var browserAccessibilityPreparedPIDs: Set<Int> = []
+    private static var browserAccessibilitySessionToken = 0
+    private static var browserAccessibilityPreviousValues: [Int: BrowserAccessibilityValues] = [:]
+
+    private struct BrowserAccessibilityValues {
+        let application: AXUIElement
+        let manualAccessibility: CFTypeRef?
+    }
 
     enum SnapMode: Int {
         case window
@@ -165,15 +171,19 @@ extension OverlayView {
         windowResult: WindowSnapResult,
         windowOrigin: NSPoint,
         viewBounds: NSRect,
-        screenH: CGFloat
-    ) -> WindowSnapResult {
-        guard AXIsProcessTrusted(), windowResult.ownerPID > 0 else { return windowResult }
+        screenH: CGFloat,
+        accessibilitySessionToken: Int
+    ) -> (result: WindowSnapResult, didPrepareBrowserAccessibility: Bool) {
+        guard AXIsProcessTrusted(), windowResult.ownerPID > 0 else {
+            return (windowResult, false)
+        }
 
         let application = AXUIElementCreateApplication(pid_t(windowResult.ownerPID))
         AXUIElementSetMessagingTimeout(application, 0.2)
-        prepareBrowserAccessibilityIfNeeded(
+        let didPrepareBrowserAccessibility = prepareBrowserAccessibilityIfNeeded(
             application: application,
-            ownerPID: windowResult.ownerPID)
+            ownerPID: windowResult.ownerPID,
+            sessionToken: accessibilitySessionToken)
 
         var hitElement: AXUIElement?
         let error = AXUIElementCopyElementAtPosition(
@@ -185,7 +195,7 @@ extension OverlayView {
               let axRect = deepestAccessibilityRect(
                 at: NSPoint(x: screenPoint.x, y: screenH - screenPoint.y),
                 from: hitElement)
-        else { return windowResult }
+        else { return (windowResult, didPrepareBrowserAccessibility) }
 
         let appKitRect = NSRect(
             x: axRect.origin.x,
@@ -199,16 +209,21 @@ extension OverlayView {
             height: appKitRect.height)
             .intersection(windowResult.rect)
             .intersection(viewBounds)
-        guard viewRect.width > 2, viewRect.height > 2 else { return windowResult }
+        guard viewRect.width > 2, viewRect.height > 2 else {
+            return (windowResult, didPrepareBrowserAccessibility)
+        }
 
-        return WindowSnapResult(
-            rect: viewRect,
-            windowID: windowResult.windowID,
-            ownerPID: windowResult.ownerPID)
+        return (
+            WindowSnapResult(
+                rect: viewRect,
+                windowID: windowResult.windowID,
+                ownerPID: windowResult.ownerPID),
+            didPrepareBrowserAccessibility)
     }
 
     private struct AccessibilityNodeInfo {
         let rect: NSRect?
+        let isHidden: Bool
         let children: [AXUIElement]
     }
 
@@ -229,10 +244,15 @@ extension OverlayView {
         var bestArea = CGFloat.greatestFiniteMagnitude
 
         while let current = pending.popLast(), visited.count < maxVisited {
-            if current.depth > 0 && CFAbsoluteTimeGetCurrent() >= deadline { break }
+            let remainingTime = deadline - CFAbsoluteTimeGetCurrent()
+            if current.depth > 0 && remainingTime <= 0 { break }
             let identity = CFHash(current.element)
             guard visited.insert(identity).inserted,
-                  let info = accessibilityNodeInfo(of: current.element)
+                  let info = accessibilityNodeInfo(
+                    of: current.element,
+                    messagingTimeout: Float(max(0.001, remainingTime)),
+                    maxChildren: maxChildrenPerNode),
+                  !info.isHidden
             else { continue }
 
             let containsPoint = info.rect?.contains(axPoint) ?? true
@@ -249,7 +269,7 @@ extension OverlayView {
                   CFAbsoluteTimeGetCurrent() < deadline
             else { continue }
 
-            for child in info.children.prefix(maxChildrenPerNode).reversed() {
+            for child in info.children.reversed() {
                 pending.append((child, current.depth + 1))
             }
         }
@@ -262,16 +282,28 @@ extension OverlayView {
     /// ignore the attributes. Attempt them once per target PID per capture session.
     private static func prepareBrowserAccessibilityIfNeeded(
         application: AXUIElement,
-        ownerPID: Int
-    ) {
+        ownerPID: Int,
+        sessionToken: Int
+    ) -> Bool {
         let defaults = UserDefaults.standard
         let enabled = defaults.object(forKey: browserElementSnapEnabledKey) as? Bool ?? true
-        guard enabled else { return }
+        guard enabled else { return false }
 
         browserAccessibilityLock.lock()
-        let shouldPrepare = browserAccessibilityPreparedPIDs.insert(ownerPID).inserted
-        browserAccessibilityLock.unlock()
-        guard shouldPrepare else { return }
+        guard sessionToken == browserAccessibilitySessionToken else {
+            browserAccessibilityLock.unlock()
+            return false
+        }
+        guard browserAccessibilityPreviousValues[ownerPID] == nil else {
+            browserAccessibilityLock.unlock()
+            return false
+        }
+
+        browserAccessibilityPreviousValues[ownerPID] = BrowserAccessibilityValues(
+            application: application,
+            manualAccessibility: accessibilityAttributeValue(
+                "AXManualAccessibility" as CFString,
+                of: application))
 
         // Chromium/Electron builds may report errors even when these values
         // successfully materialize the web-content accessibility tree.
@@ -283,20 +315,62 @@ extension OverlayView {
             application,
             "AXEnhancedUserInterface" as CFString,
             kCFBooleanTrue)
+        browserAccessibilityLock.unlock()
+        return true
+    }
+
+    static func currentBrowserAccessibilitySessionToken() -> Int {
+        browserAccessibilityLock.lock()
+        defer { browserAccessibilityLock.unlock() }
+        return browserAccessibilitySessionToken
     }
 
     static func resetBrowserAccessibilityPreparation() {
         browserAccessibilityLock.lock()
-        browserAccessibilityPreparedPIDs.removeAll()
+        browserAccessibilitySessionToken &+= 1
+        let previousValues = Array(browserAccessibilityPreviousValues.values)
+        browserAccessibilityPreviousValues.removeAll()
+
+        for values in previousValues {
+            AXUIElementSetAttributeValue(
+                values.application,
+                "AXManualAccessibility" as CFString,
+                values.manualAccessibility ?? kCFBooleanFalse)
+            // Chromium counts Enhanced UI enable/disable requests. A matching
+            // false removes only our request and preserves requests from other
+            // assistive clients; re-sending a previously observed true would
+            // add another request instead of restoring the prior state.
+            AXUIElementSetAttributeValue(
+                values.application,
+                "AXEnhancedUserInterface" as CFString,
+                kCFBooleanFalse)
+        }
         browserAccessibilityLock.unlock()
+    }
+
+    private static func accessibilityAttributeValue(
+        _ attribute: CFString,
+        of element: AXUIElement
+    ) -> CFTypeRef? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else {
+            return nil
+        }
+        return value
     }
 
     /// Fetch geometry and the common AX child collections in one IPC round trip.
     /// Some frameworks populate only one of these collections.
-    private static func accessibilityNodeInfo(of element: AXUIElement) -> AccessibilityNodeInfo? {
+    private static func accessibilityNodeInfo(
+        of element: AXUIElement,
+        messagingTimeout: Float,
+        maxChildren: Int
+    ) -> AccessibilityNodeInfo? {
+        AXUIElementSetMessagingTimeout(element, messagingTimeout)
         let attributes: [CFString] = [
             kAXPositionAttribute as CFString,
             kAXSizeAttribute as CFString,
+            kAXHiddenAttribute as CFString,
             kAXVisibleChildrenAttribute as CFString,
             "AXChildrenInNavigationOrder" as CFString,
             kAXChildrenAttribute as CFString,
@@ -309,14 +383,25 @@ extension OverlayView {
         else { return nil }
 
         let rect = accessibilityRect(positionValue: values[0], sizeValue: values[1])
+        let isHidden = values[2] as? Bool ?? false
+        let visibleChildren = values[3] as? [AXUIElement]
+        let childCollections: [[AXUIElement]]
+        if let visibleChildren, !visibleChildren.isEmpty {
+            childCollections = [visibleChildren]
+        } else {
+            childCollections = values.dropFirst(4).compactMap { $0 as? [AXUIElement] }
+        }
+
         var children: [AXUIElement] = []
-        for value in values.dropFirst(2) {
-            guard let elements = value as? [AXUIElement] else { continue }
-            for child in elements where !children.contains(where: { CFEqual($0, child) }) {
+        var childIdentities = Set<CFHashCode>()
+        collectionLoop: for elements in childCollections {
+            for child in elements.prefix(maxChildren) {
+                guard childIdentities.insert(CFHash(child)).inserted else { continue }
                 children.append(child)
+                if children.count == maxChildren { break collectionLoop }
             }
         }
-        return AccessibilityNodeInfo(rect: rect, children: children)
+        return AccessibilityNodeInfo(rect: rect, isHidden: isHidden, children: children)
     }
 
     private static func accessibilityRect(positionValue: Any, sizeValue: Any) -> NSRect? {

--- a/macshot/UI/Overlay/OverlayView+WindowSnapping.swift
+++ b/macshot/UI/Overlay/OverlayView+WindowSnapping.swift
@@ -2,10 +2,29 @@ import Cocoa
 
 extension OverlayView {
 
-    /// Result of window snap detection: the rect and optional window ID.
+    static let browserElementSnapEnabledKey = "browserElementSnapEnabled"
+    private static let browserAccessibilityLock = NSLock()
+    private static var browserAccessibilityPreparedPIDs: Set<Int> = []
+
+    enum SnapMode: Int {
+        case window
+        case element
+        case off
+
+        var next: SnapMode {
+            switch self {
+            case .window: return .element
+            case .element: return .off
+            case .off: return .window
+            }
+        }
+    }
+
+    /// Window metadata used by both window and accessibility-element snapping.
     struct WindowSnapResult {
         let rect: NSRect
         let windowID: CGWindowID
+        let ownerPID: Int
     }
 
     private struct WindowSnapCandidate {
@@ -132,11 +151,195 @@ extension OverlayView {
             best = frontmost
         }
 
-        return WindowSnapResult(rect: best.rect, windowID: best.windowID)
+        return WindowSnapResult(
+            rect: best.rect,
+            windowID: best.windowID,
+            ownerPID: best.ownerPID)
     }
 
-    func drawWindowSnapHighlight() {
-        guard state == .idle, windowSnapEnabled, let rect = hoveredWindowRect, !rect.isEmpty else {
+    /// Returns the accessibility element under the pointer, clipped to the
+    /// visible window and converted into overlay-view coordinates. Apps that
+    /// do not expose a usable element fall back to their window rect.
+    static func elementSnapResult(
+        screenPoint: NSPoint,
+        windowResult: WindowSnapResult,
+        windowOrigin: NSPoint,
+        viewBounds: NSRect,
+        screenH: CGFloat
+    ) -> WindowSnapResult {
+        guard AXIsProcessTrusted(), windowResult.ownerPID > 0 else { return windowResult }
+
+        let application = AXUIElementCreateApplication(pid_t(windowResult.ownerPID))
+        AXUIElementSetMessagingTimeout(application, 0.2)
+        prepareBrowserAccessibilityIfNeeded(
+            application: application,
+            ownerPID: windowResult.ownerPID)
+
+        var hitElement: AXUIElement?
+        let error = AXUIElementCopyElementAtPosition(
+            application,
+            Float(screenPoint.x),
+            Float(screenH - screenPoint.y),
+            &hitElement)
+        guard error == .success, let hitElement,
+              let axRect = deepestAccessibilityRect(
+                at: NSPoint(x: screenPoint.x, y: screenH - screenPoint.y),
+                from: hitElement)
+        else { return windowResult }
+
+        let appKitRect = NSRect(
+            x: axRect.origin.x,
+            y: screenH - axRect.origin.y - axRect.height,
+            width: axRect.width,
+            height: axRect.height)
+        let viewRect = NSRect(
+            x: appKitRect.origin.x - windowOrigin.x,
+            y: appKitRect.origin.y - windowOrigin.y,
+            width: appKitRect.width,
+            height: appKitRect.height)
+            .intersection(windowResult.rect)
+            .intersection(viewBounds)
+        guard viewRect.width > 2, viewRect.height > 2 else { return windowResult }
+
+        return WindowSnapResult(
+            rect: viewRect,
+            windowID: windowResult.windowID,
+            ownerPID: windowResult.ownerPID)
+    }
+
+    private struct AccessibilityNodeInfo {
+        let rect: NSRect?
+        let children: [AXUIElement]
+    }
+
+    /// Refine the direct AX hit by following only descendants whose frames
+    /// contain the pointer. The limits keep custom or malformed AX trees from
+    /// turning mouse movement into an unbounded traversal.
+    private static func deepestAccessibilityRect(
+        at axPoint: NSPoint,
+        from root: AXUIElement
+    ) -> NSRect? {
+        let deadline = CFAbsoluteTimeGetCurrent() + 0.035
+        let maxDepth = 8
+        let maxVisited = 48
+        let maxChildrenPerNode = 64
+        var pending: [(element: AXUIElement, depth: Int)] = [(root, 0)]
+        var visited = Set<CFHashCode>()
+        var bestRect: NSRect?
+        var bestArea = CGFloat.greatestFiniteMagnitude
+
+        while let current = pending.popLast(), visited.count < maxVisited {
+            if current.depth > 0 && CFAbsoluteTimeGetCurrent() >= deadline { break }
+            let identity = CFHash(current.element)
+            guard visited.insert(identity).inserted,
+                  let info = accessibilityNodeInfo(of: current.element)
+            else { continue }
+
+            let containsPoint = info.rect?.contains(axPoint) ?? true
+            if let rect = info.rect, containsPoint {
+                let area = rect.width * rect.height
+                if area < bestArea {
+                    bestRect = rect
+                    bestArea = area
+                }
+            }
+
+            guard containsPoint,
+                  current.depth < maxDepth,
+                  CFAbsoluteTimeGetCurrent() < deadline
+            else { continue }
+
+            for child in info.children.prefix(maxChildrenPerNode).reversed() {
+                pending.append((child, current.depth + 1))
+            }
+        }
+
+        return bestRect
+    }
+
+    /// Chromium/Electron may lazily omit web-content AX nodes until an assistive
+    /// client requests manual or enhanced accessibility. Unsupported native apps
+    /// ignore the attributes. Attempt them once per target PID per capture session.
+    private static func prepareBrowserAccessibilityIfNeeded(
+        application: AXUIElement,
+        ownerPID: Int
+    ) {
+        let defaults = UserDefaults.standard
+        let enabled = defaults.object(forKey: browserElementSnapEnabledKey) as? Bool ?? true
+        guard enabled else { return }
+
+        browserAccessibilityLock.lock()
+        let shouldPrepare = browserAccessibilityPreparedPIDs.insert(ownerPID).inserted
+        browserAccessibilityLock.unlock()
+        guard shouldPrepare else { return }
+
+        // Chromium/Electron builds may report errors even when these values
+        // successfully materialize the web-content accessibility tree.
+        AXUIElementSetAttributeValue(
+            application,
+            "AXManualAccessibility" as CFString,
+            kCFBooleanTrue)
+        AXUIElementSetAttributeValue(
+            application,
+            "AXEnhancedUserInterface" as CFString,
+            kCFBooleanTrue)
+    }
+
+    static func resetBrowserAccessibilityPreparation() {
+        browserAccessibilityLock.lock()
+        browserAccessibilityPreparedPIDs.removeAll()
+        browserAccessibilityLock.unlock()
+    }
+
+    /// Fetch geometry and the common AX child collections in one IPC round trip.
+    /// Some frameworks populate only one of these collections.
+    private static func accessibilityNodeInfo(of element: AXUIElement) -> AccessibilityNodeInfo? {
+        let attributes: [CFString] = [
+            kAXPositionAttribute as CFString,
+            kAXSizeAttribute as CFString,
+            kAXVisibleChildrenAttribute as CFString,
+            "AXChildrenInNavigationOrder" as CFString,
+            kAXChildrenAttribute as CFString,
+            kAXContentsAttribute as CFString,
+        ]
+        var copiedValues: CFArray?
+        guard AXUIElementCopyMultipleAttributeValues(
+                element, attributes as CFArray, [], &copiedValues) == .success,
+              let values = copiedValues as? [Any], values.count == attributes.count
+        else { return nil }
+
+        let rect = accessibilityRect(positionValue: values[0], sizeValue: values[1])
+        var children: [AXUIElement] = []
+        for value in values.dropFirst(2) {
+            guard let elements = value as? [AXUIElement] else { continue }
+            for child in elements where !children.contains(where: { CFEqual($0, child) }) {
+                children.append(child)
+            }
+        }
+        return AccessibilityNodeInfo(rect: rect, children: children)
+    }
+
+    private static func accessibilityRect(positionValue: Any, sizeValue: Any) -> NSRect? {
+        let positionRef = positionValue as CFTypeRef
+        let sizeRef = sizeValue as CFTypeRef
+        guard CFGetTypeID(positionRef) == AXValueGetTypeID(),
+              CFGetTypeID(sizeRef) == AXValueGetTypeID()
+        else { return nil }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(positionRef as! AXValue, .cgPoint, &position),
+              AXValueGetValue(sizeRef as! AXValue, .cgSize, &size),
+              position.x.isFinite, position.y.isFinite,
+              size.width.isFinite, size.height.isFinite,
+              size.width > 2, size.height > 2
+        else { return nil }
+
+        return NSRect(origin: position, size: size)
+    }
+
+    func drawSnapHighlight() {
+        guard state == .idle, snapMode != .off, let rect = hoveredSnapRect, !rect.isEmpty else {
             return
         }
 

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -30,7 +30,7 @@ protocol OverlayViewDelegate: AnyObject {
     func overlayViewDidRequestInputMonitoringPermission()
     func overlayViewDidBeginSelection()
     func overlayViewRemoteSelectionDidChange(_ rect: NSRect)
-    func overlayViewDidChangeWindowSnapState()
+    func overlayViewDidChangeSnapMode()
     func overlayViewRemoteSelectionDidFinish(_ rect: NSRect)
     func overlayViewDidRequestAddCapture()
 }
@@ -120,8 +120,8 @@ class OverlayView: NSView {
             if screenshotImage != nil && windowSnapCooldown {
                 windowSnapCooldown = false
                 if window?.isVisible == true,
-                   state == .idle && windowSnapEnabled && !windowSnapQueryInFlight {
-                    queryWindowSnap(at: NSEvent.mouseLocation)
+                   state == .idle && snapMode != .off && !snapQueryInFlight {
+                    querySnapTarget(at: NSEvent.mouseLocation)
                 }
             }
             // Build (or invalidate) the boundary-snap edge index off the main thread.
@@ -889,10 +889,21 @@ class OverlayView: NSView {
         }
     }
 
-    // Window snapping
-    var windowSnapEnabled: Bool {
-        get { UserDefaults.standard.object(forKey: "windowSnapEnabled") as? Bool ?? true }
-        set { UserDefaults.standard.set(newValue, forKey: "windowSnapEnabled") }
+    // Capture-target snapping. Preserve the old Boolean preference as a
+    // migration fallback for existing users.
+    var snapMode: SnapMode {
+        get {
+            let defaults = UserDefaults.standard
+            if defaults.object(forKey: "captureSnapMode") != nil,
+               let mode = SnapMode(rawValue: defaults.integer(forKey: "captureSnapMode")) {
+                return mode
+            }
+            return (defaults.object(forKey: "windowSnapEnabled") as? Bool ?? true) ? .window : .off
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: "captureSnapMode")
+            UserDefaults.standard.set(newValue != .off, forKey: "windowSnapEnabled")
+        }
     }
 
     // Boundary snapping — snap the selection's dragged edges to strong color
@@ -910,8 +921,8 @@ class OverlayView: NSView {
     /// line feedback. nil when not snapping that axis.
     private var boundarySnapGuideX: CGFloat?
     private var boundarySnapGuideY: CGFloat?
-    var hoveredWindowRect: NSRect? = nil
-    var hoveredWindowID: CGWindowID? = nil
+    var hoveredSnapRect: NSRect? = nil
+    var hoveredSnapWindowID: CGWindowID? = nil
     private var windowSnapCooldown: Bool = true  // true until overlay has rendered
     /// True when the current selection was made via window snap (click without drag).
     /// Cleared when the user manually resizes the selection.
@@ -948,36 +959,61 @@ class OverlayView: NSView {
     var snappedWindowID: CGWindowID? = nil
     /// Independently captured window image (with transparent corners) for beautify snap mode.
     var snappedWindowImage: NSImage? = nil
-    private var windowSnapQueryInFlight: Bool = false
+    private var snapQueryInFlight: Bool = false
+    private var pendingSnapQueryPoint: NSPoint?
 
-    /// Perform a window snap query at the given screen point (AppKit screen coordinates).
-    private func queryWindowSnap(at screenPoint: NSPoint) {
-        guard !windowSnapQueryInFlight,
-            state == .idle && windowSnapEnabled,
+    /// Find the window or accessibility element under the given AppKit screen point.
+    private func querySnapTarget(at screenPoint: NSPoint) {
+        let requestedMode = snapMode
+        guard state == .idle && requestedMode != .off,
             !(remoteSelectionRect.width >= 1 && remoteSelectionRect.height >= 1),
             let viewWindow = window
         else { return }
+        if snapQueryInFlight {
+            pendingSnapQueryPoint = screenPoint
+            return
+        }
         let overlayWindowNumber = viewWindow.windowNumber
         let windowOrigin = viewWindow.frame.origin
         let viewBounds = bounds
         let screenH = NSScreen.screens.first?.frame.height ?? NSScreen.main?.frame.height ?? 0
-        windowSnapQueryInFlight = true
+        snapQueryInFlight = true
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in
-            let result = Self.windowRectOnBackground(
+            let windowResult = Self.windowRectOnBackground(
                 screenPoint: screenPoint,
                 overlayWindowNumber: overlayWindowNumber,
                 windowOrigin: windowOrigin,
                 viewBounds: viewBounds,
                 screenH: screenH
             )
+            let result: WindowSnapResult?
+            if requestedMode == .element, let windowResult {
+                result = Self.elementSnapResult(
+                    screenPoint: screenPoint,
+                    windowResult: windowResult,
+                    windowOrigin: windowOrigin,
+                    viewBounds: viewBounds,
+                    screenH: screenH)
+            } else {
+                result = windowResult
+            }
             DispatchQueue.main.async {
                 guard let self = self else { return }
-                self.windowSnapQueryInFlight = false
-                let newRect = result?.rect
-                if newRect != self.hoveredWindowRect {
-                    self.hoveredWindowRect = newRect
-                    self.hoveredWindowID = result?.windowID
-                    self.needsDisplay = true
+                self.snapQueryInFlight = false
+                if self.snapMode == requestedMode {
+                    let newRect = result?.rect
+                    let newWindowID = result?.windowID
+                    if newRect != self.hoveredSnapRect || newWindowID != self.hoveredSnapWindowID {
+                        self.hoveredSnapRect = newRect
+                        self.hoveredSnapWindowID = newWindowID
+                        self.needsDisplay = true
+                    }
+                }
+                if let pendingPoint = self.pendingSnapQueryPoint {
+                    self.pendingSnapQueryPoint = nil
+                    self.querySnapTarget(at: pendingPoint)
+                } else if self.snapMode != requestedMode {
+                    self.querySnapTarget(at: NSEvent.mouseLocation)
                 }
             }
         }
@@ -1135,13 +1171,13 @@ class OverlayView: NSView {
             updateAutoMeasurePreview()
         }
 
-        // Window snap: highlight hovered window in idle state.
+        // Snap highlight for the hovered window or accessibility element.
         // CGWindowListCopyWindowInfo is expensive — run it on a background thread,
         // skipping new queries while one is already in flight.
         // Delay window snap queries briefly after overlay appears so the overlay
         // renders without competing with CGWindowListCopyWindowInfo for the window server
         if windowSnapCooldown { return }
-        if state == .idle && windowSnapEnabled && !windowSnapQueryInFlight
+        if state == .idle && snapMode != .off
             && !(remoteSelectionRect.width >= 1 && remoteSelectionRect.height >= 1)
         {
             guard
@@ -1149,7 +1185,7 @@ class OverlayView: NSView {
                     NSPoint(x: $0.frame.origin.x + point.x, y: $0.frame.origin.y + point.y)
                 })
             else { return }
-            queryWindowSnap(at: screenPoint)
+            querySnapTarget(at: screenPoint)
         }
 
         // Track cursor for loupe live preview (use canvas space for zoom correctness)
@@ -1651,8 +1687,8 @@ class OverlayView: NSView {
             }
         }
 
-        // Window snap highlight (drawn before helper text so text appears on top)
-        drawWindowSnapHighlight()
+        // Snap-target highlight (drawn before helper text so text appears on top)
+        drawSnapHighlight()
 
         // Helper text (capture instructions). Suppressed when the user has
         // enabled "Hide capture instructions" in Settings (issue #226).
@@ -2209,16 +2245,23 @@ class OverlayView: NSView {
     private static let helperDimColor = NSColor.white.withAlphaComponent(0.7)
 
     private func drawIdleHelperText() {
-        let line1 =
-            windowSnapEnabled
-            ? L("Click a window  ·  Drag for custom area  ·  F for full screen")
-            : L("Drag to select  ·  Click for full screen")
-        let snapOn = windowSnapEnabled
-        let line3prefix = L("Window snap: ")
-        let line3state = snapOn ? L("ON") : L("OFF")
-        let line3suffix = L("  (Tab to toggle)")
+        let line1: String
+        let line3state: String
+        switch snapMode {
+        case .window:
+            line1 = L("Click a window  ·  Drag for custom area  ·  F for full screen")
+            line3state = L("WINDOW")
+        case .element:
+            line1 = L("Click an element  ·  Drag for custom area  ·  F for full screen")
+            line3state = L("ELEMENT")
+        case .off:
+            line1 = L("Drag to select  ·  Click for full screen")
+            line3state = L("OFF")
+        }
+        let line3prefix = L("Snap mode: ")
+        let line3suffix = L("  (Tab to switch)")
 
-        let snapColor = snapOn ? NSColor.systemGreen : NSColor.systemOrange
+        let snapColor = snapMode == .off ? NSColor.systemOrange : NSColor.systemGreen
 
         let attrs1: [NSAttributedString.Key: Any] = [.font: Self.helperFont, .foregroundColor: NSColor.white]
         let attrs2prefix: [NSAttributedString.Key: Any] = [
@@ -6621,13 +6664,14 @@ class OverlayView: NSView {
             applyPreSelectionLockAfterSelection()
             if !autoOCRMode && !autoQuickSaveMode && !autoScrollCaptureMode && !autoConfirmMode { showToolbars = true }
             overlayDelegate?.overlayViewDidFinishSelection(selectionRect)
-        } else if windowSnapEnabled, let snapRect = hoveredWindowRect, !snapRect.isEmpty {
-            // Click (no drag) with snap on — snap to hovered window
+        } else if snapMode != .off, let snapRect = hoveredSnapRect, !snapRect.isEmpty {
+            // Click (no drag) with snap on — select the hovered target.
             selectionRect = snapRect
-            selectionIsWindowSnap = true
-            snappedWindowID = hoveredWindowID
-            // Capture the window independently for beautify (transparent corners)
-            if let wid = hoveredWindowID, let screen = window?.screen {
+            selectionIsWindowSnap = snapMode == .window
+            snappedWindowID = selectionIsWindowSnap ? hoveredSnapWindowID : nil
+            // Only whole-window snaps use the independent capture that preserves
+            // transparent corners. Element snaps are ordinary screen crops.
+            if selectionIsWindowSnap, let wid = hoveredSnapWindowID, let screen = window?.screen {
                 Task {
                     if let cgImage = await ScreenCaptureManager.captureWindow(windowID: wid, screen: screen) {
                         self.snappedWindowImage = NSImage(cgImage: cgImage,
@@ -6647,7 +6691,7 @@ class OverlayView: NSView {
             if !autoOCRMode && !autoQuickSaveMode && !autoScrollCaptureMode && !autoConfirmMode { showToolbars = true }
             overlayDelegate?.overlayViewDidFinishSelection(selectionRect)
         }
-        hoveredWindowRect = nil
+        hoveredSnapRect = nil
         // Update cursor to match the selected tool (replaces resize cursor from dragging)
         if let win = window {
             let point = convert(win.mouseLocationOutsideOfEventStream, from: nil)
@@ -6809,11 +6853,11 @@ class OverlayView: NSView {
                 showToolbars = true
             }
             overlayDelegate?.overlayViewDidFinishSelection(selectionRect)
-        } else if windowSnapEnabled, let snapRect = hoveredWindowRect, !snapRect.isEmpty {
+        } else if snapMode != .off, let snapRect = hoveredSnapRect, !snapRect.isEmpty {
             selectionRect = snapRect
-            selectionIsWindowSnap = true
-            snappedWindowID = hoveredWindowID
-            if let wid = hoveredWindowID, let screen = window?.screen {
+            selectionIsWindowSnap = snapMode == .window
+            snappedWindowID = selectionIsWindowSnap ? hoveredSnapWindowID : nil
+            if selectionIsWindowSnap, let wid = hoveredSnapWindowID, let screen = window?.screen {
                 Task {
                     if let cgImage = await ScreenCaptureManager.captureWindow(windowID: wid, screen: screen) {
                         self.snappedWindowImage = NSImage(
@@ -6838,7 +6882,7 @@ class OverlayView: NSView {
             }
             overlayDelegate?.overlayViewDidFinishSelection(selectionRect)
         }
-        hoveredWindowRect = nil
+        hoveredSnapRect = nil
         if let win = window {
             updateCursorForPoint(convert(win.mouseLocationOutsideOfEventStream, from: nil))
         }
@@ -9050,12 +9094,12 @@ class OverlayView: NSView {
         }
 
         // Character-based so the shortcut follows QWERTZ/AZERTY/Dvorak.
-        if state == .idle && windowSnapEnabled
+        if state == .idle && snapMode != .off
             && KeyboardShortcutMatcher.matches(event, character: "f", modifiers: [])
         {
             selectionRect = bounds
             state = .selected
-            hoveredWindowRect = nil
+            hoveredSnapRect = nil
             if autoQuickSaveMode {
                 autoQuickSaveMode = false
                 overlayDelegate?.overlayViewDidRequestQuickSave()
@@ -9151,12 +9195,21 @@ class OverlayView: NSView {
             }
         case 48:  // Tab
             if state == .idle {
-                // Toggle window snapping in idle state
-                windowSnapEnabled = !windowSnapEnabled
-                hoveredWindowRect = nil
+                // Cycle capture snapping: window -> element -> off.
+                snapMode = snapMode.next
+                hoveredSnapRect = nil
+                hoveredSnapWindowID = nil
+                if snapMode == .element && !AXIsProcessTrusted() {
+                    let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+                    AXIsProcessTrustedWithOptions(options)
+                    showOverlayError(L("Accessibility Access Required"))
+                }
                 needsDisplay = true
                 // Notify other overlays to redraw (for multi-monitor setups)
-                overlayDelegate?.overlayViewDidChangeWindowSnapState()
+                overlayDelegate?.overlayViewDidChangeSnapMode()
+                if snapMode != .off {
+                    querySnapTarget(at: NSEvent.mouseLocation)
+                }
             }
         case 36, 76:  // Return / numpad Enter — quick capture (respects quickCaptureMode setting)
             if textEditView == nil, state == .selected {
@@ -10068,7 +10121,9 @@ class OverlayView: NSView {
         overlayErrorTimer?.invalidate()
         overlayErrorTimer = nil
         overlayErrorMessage = nil
-        hoveredWindowRect = nil
+        hoveredSnapRect = nil
+        pendingSnapQueryPoint = nil
+        Self.resetBrowserAccessibilityPreparation()
         isRecording = false
         // Webcam setup preview (if any) — clear so a reused overlay doesn't
         // show a stale camera feed on the next session.

--- a/macshot/UI/Overlay/OverlayView.swift
+++ b/macshot/UI/Overlay/OverlayView.swift
@@ -961,6 +961,7 @@ class OverlayView: NSView {
     var snappedWindowImage: NSImage? = nil
     private var snapQueryInFlight: Bool = false
     private var pendingSnapQueryPoint: NSPoint?
+    private var browserAccessibilityRetryWorkItems: [DispatchWorkItem] = []
 
     /// Find the window or accessibility element under the given AppKit screen point.
     private func querySnapTarget(at screenPoint: NSPoint) {
@@ -977,6 +978,9 @@ class OverlayView: NSView {
         let windowOrigin = viewWindow.frame.origin
         let viewBounds = bounds
         let screenH = NSScreen.screens.first?.frame.height ?? NSScreen.main?.frame.height ?? 0
+        let accessibilitySessionToken = requestedMode == .element
+            ? Self.currentBrowserAccessibilitySessionToken()
+            : 0
         snapQueryInFlight = true
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in
             let windowResult = Self.windowRectOnBackground(
@@ -987,13 +991,17 @@ class OverlayView: NSView {
                 screenH: screenH
             )
             let result: WindowSnapResult?
+            var didPrepareBrowserAccessibility = false
             if requestedMode == .element, let windowResult {
-                result = Self.elementSnapResult(
+                let elementResult = Self.elementSnapResult(
                     screenPoint: screenPoint,
                     windowResult: windowResult,
                     windowOrigin: windowOrigin,
                     viewBounds: viewBounds,
-                    screenH: screenH)
+                    screenH: screenH,
+                    accessibilitySessionToken: accessibilitySessionToken)
+                result = elementResult.result
+                didPrepareBrowserAccessibility = elementResult.didPrepareBrowserAccessibility
             } else {
                 result = windowResult
             }
@@ -1009,6 +1017,9 @@ class OverlayView: NSView {
                         self.needsDisplay = true
                     }
                 }
+                if didPrepareBrowserAccessibility {
+                    self.scheduleBrowserAccessibilityRetry()
+                }
                 if let pendingPoint = self.pendingSnapQueryPoint {
                     self.pendingSnapQueryPoint = nil
                     self.querySnapTarget(at: pendingPoint)
@@ -1016,6 +1027,22 @@ class OverlayView: NSView {
                     self.querySnapTarget(at: NSEvent.mouseLocation)
                 }
             }
+        }
+    }
+
+    private func scheduleBrowserAccessibilityRetry() {
+        for workItem in browserAccessibilityRetryWorkItems {
+            workItem.cancel()
+        }
+        browserAccessibilityRetryWorkItems = [0.1, 0.5, 2.1].map { delay in
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self, self.state == .idle, self.snapMode == .element,
+                      self.window?.isVisible == true
+                else { return }
+                self.querySnapTarget(at: NSEvent.mouseLocation)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+            return workItem
         }
     }
 
@@ -10123,6 +10150,10 @@ class OverlayView: NSView {
         overlayErrorMessage = nil
         hoveredSnapRect = nil
         pendingSnapQueryPoint = nil
+        for workItem in browserAccessibilityRetryWorkItems {
+            workItem.cancel()
+        }
+        browserAccessibilityRetryWorkItems.removeAll()
         Self.resetBrowserAccessibilityPreparation()
         isRecording = false
         // Webcam setup preview (if any) — clear so a reused overlay doesn't

--- a/macshot/UI/Overlay/OverlayWindowController.swift
+++ b/macshot/UI/Overlay/OverlayWindowController.swift
@@ -82,7 +82,7 @@ protocol OverlayWindowControllerDelegate: AnyObject {
     func overlayDidRemoteResizeSelection(_ controller: OverlayWindowController, globalRect: NSRect)
     func overlayDidFinishRemoteResize(_ controller: OverlayWindowController, globalRect: NSRect)
     func overlayCrossScreenImage(_ controller: OverlayWindowController) -> NSImage?
-    func overlayDidChangeWindowSnapState(_ controller: OverlayWindowController)
+    func overlayDidChangeSnapMode(_ controller: OverlayWindowController)
 }
 
 /// Manages one fullscreen overlay per screen.
@@ -274,7 +274,9 @@ class OverlayWindowController {
         overlayView?.clearSelection()
     }
 
-    func triggerRedraw() {
+    func refreshSnapMode() {
+        overlayView?.hoveredSnapRect = nil
+        overlayView?.hoveredSnapWindowID = nil
         overlayView?.needsDisplay = true
     }
 
@@ -282,7 +284,7 @@ class OverlayWindowController {
         overlayView?.remoteSelectionRect = rect
         overlayView?.remoteSelectionFullRect = fullRect.width >= 1 ? fullRect : rect
         if rect.width >= 1 && rect.height >= 1 {
-            overlayView?.hoveredWindowRect = nil
+            overlayView?.hoveredSnapRect = nil
         }
         overlayView?.needsDisplay = true
     }
@@ -761,8 +763,8 @@ extension OverlayWindowController: OverlayViewDelegate {
         overlayDelegate?.overlayDidBeginSelection(self)
     }
 
-    func overlayViewDidChangeWindowSnapState() {
-        overlayDelegate?.overlayDidChangeWindowSnapState(self)
+    func overlayViewDidChangeSnapMode() {
+        overlayDelegate?.overlayDidChangeSnapMode(self)
     }
 
     func overlayViewDidRequestAddCapture() {}  // editor-only

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -84,6 +84,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     private var historySizeStepper: NSStepper!
     private var snapGuidesCheckbox: NSButton!
     private var boundarySnapCheckbox: NSButton!
+    private var browserElementSnapCheckbox: NSButton!
     private var captureCursorCheckbox: NSButton!
     private var doubleClickToCopyCheckbox: NSButton!
     private var hideCaptureInstructionsCheckbox: NSButton!
@@ -772,6 +773,10 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         thumbnailCheckbox = NSButton(checkboxWithTitle: L("Show floating thumbnail after capture"), target: self, action: #selector(thumbnailChanged(_:)))
         snapGuidesCheckbox = NSButton(checkboxWithTitle: L("Show snap alignment guides"), target: self, action: #selector(snapGuidesChanged(_:)))
         boundarySnapCheckbox = NSButton(checkboxWithTitle: L("Snap selection edges to image boundaries"), target: self, action: #selector(boundarySnapChanged(_:)))
+        browserElementSnapCheckbox = NSButton(
+            checkboxWithTitle: L("Enhance browser and Electron element snapping"),
+            target: self,
+            action: #selector(browserElementSnapChanged(_:)))
         captureCursorCheckbox = NSButton(checkboxWithTitle: L("Capture mouse cursor in screenshot"), target: self, action: #selector(captureCursorChanged(_:)))
         doubleClickToCopyCheckbox = NSButton(checkboxWithTitle: L("Double-click selection to copy"), target: self, action: #selector(doubleClickToCopyChanged(_:)))
         hideCaptureInstructionsCheckbox = NSButton(checkboxWithTitle: L("Hide capture instructions"), target: self, action: #selector(hideCaptureInstructionsChanged(_:)))
@@ -845,6 +850,14 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         stack.addArrangedSubview(indented(snapGuidesCheckbox))
         stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
         stack.addArrangedSubview(indented(boundarySnapCheckbox))
+        stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
+
+        stack.addArrangedSubview(indented(browserElementSnapCheckbox))
+        stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
+        let browserElementSnapNote = NSTextField(wrappingLabelWithString: L("Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues."))
+        browserElementSnapNote.font = NSFont.systemFont(ofSize: 10)
+        browserElementSnapNote.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(indented(browserElementSnapNote))
         stack.setCustomSpacing(6, after: stack.arrangedSubviews.last!)
 
         stack.addArrangedSubview(indented(captureCursorCheckbox))
@@ -2568,6 +2581,9 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         snapGuidesCheckbox.state = snapGuides ? .on : .off
         let boundarySnap = UserDefaults.standard.object(forKey: "boundarySnapEnabled") as? Bool ?? true
         boundarySnapCheckbox.state = boundarySnap ? .on : .off
+        let browserElementSnap = UserDefaults.standard.object(
+            forKey: OverlayView.browserElementSnapEnabledKey) as? Bool ?? true
+        browserElementSnapCheckbox.state = browserElementSnap ? .on : .off
         showToolShortcutsInTooltipsCheckbox.state = UserDefaults.standard.bool(forKey: "showToolShortcutsInTooltips") ? .on : .off
 
         captureCursorCheckbox.state = UserDefaults.standard.bool(forKey: "captureCursor") ? .on : .off
@@ -3011,6 +3027,11 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     }
     @objc private func boundarySnapChanged(_ sender: NSButton) {
         UserDefaults.standard.set(sender.state == .on, forKey: "boundarySnapEnabled")
+    }
+    @objc private func browserElementSnapChanged(_ sender: NSButton) {
+        UserDefaults.standard.set(
+            sender.state == .on,
+            forKey: OverlayView.browserElementSnapEnabledKey)
     }
     @objc private func captureCursorChanged(_ sender: NSButton) {
         UserDefaults.standard.set(sender.state == .on, forKey: "captureCursor")

--- a/macshot/ar.lproj/Localizable.strings
+++ b/macshot/ar.lproj/Localizable.strings
@@ -174,6 +174,13 @@
 "ON" = "تشغيل";
 "OFF" = "إيقاف";
 "  (Tab to toggle)" = "  (Tab للتبديل)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "انقر على عنصر  ·  اسحب لتحديد منطقة  ·  F لملء الشاشة";
+"Snap mode: " = "وضع التقاط: ";
+"WINDOW" = "نافذة";
+"ELEMENT" = "عنصر";
+"  (Tab to switch)" = "  (Tab للتبديل)";
+"Enhance browser and Electron element snapping" = "تحسين التقاط عناصر المتصفح وتطبيقات Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "يبني شجرة إمكانية الوصول لتطبيق الهدف في وضع العنصر. قم بإيقاف تشغيله إذا أصبح المتصفح أو تطبيق Electron بطيئًا أو كانت لديه مشاكل في الإدخال.";
 "Right-click to copy" = "انقر بزر الفأرة الأيمن للنسخ";
 "Copied %@" = "تم نسخ %@";
 "Set color %@" = "تعيين اللون %@";

--- a/macshot/bg.lproj/Localizable.strings
+++ b/macshot/bg.lproj/Localizable.strings
@@ -185,15 +185,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Щракнете върху прозорец  ·  Плъзнете за произволна област  ·  F за цял екран";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Щракнете върху елемент  ·  Плъзнете за произволна област  ·  F за цял екран";
 "Drag to select  ·  Click for full screen" = "Плъзнете за избиране  ·  Щракнете за цял екран";
 "Release to annotate and edit" = "Отпуснете за анотиране и редактиране";
 "Release to finish" = "Отпуснете за завършване";
 "Hold Space to move. Release to annotate and edit" = "Задръжте Интервал за преместване. Отпуснете за анотиране и редактиране";
 "Hold Space to move. Release to finish" = "Задръжте Интервал за преместване. Отпуснете за завършване";
 "Window snap: " = "Прилепване към прозорец: ";
+"Snap mode: " = "Режим на прилепване: ";
 "ON" = "ВКЛ.";
 "OFF" = "ИЗКЛ.";
+"WINDOW" = "ПРОЗОРЕЦ";
+"ELEMENT" = "ЕЛЕМЕНТ";
 "  (Tab to toggle)" = "  (Tab за превключване)";
+"  (Tab to switch)" = "  (Tab за превключване)";
 "Space" = "Интервал";
 "Right-click to copy" = "Десен бутон за копиране";
 "Copied %@" = "Копирано %@";
@@ -228,6 +233,8 @@
 "Launch at login" = "Стартиране при вход";
 "Show snap alignment guides" = "Показване на водачи за подравняване";
 "Snap selection edges to image boundaries" = "Прилепване на ръбовете на селекцията към границите на изображението";
+"Enhance browser and Electron element snapping" = "Подобряване на прилепването на елементи в браузър и Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Изгражда дървото на достъпност на целевото приложение в режим на елементи. Деактивирайте, ако браузър или Electron приложение се забави или има проблеми с въвеждането.";
 "Capture mouse cursor in screenshot" = "Заснемане на курсора в екранната снимка";
 "Double-click selection to copy" = "Копиране с двойно щракване върху селекцията";
 "Hide capture instructions" = "Скриване на указанията при заснемане";

--- a/macshot/bn.lproj/Localizable.strings
+++ b/macshot/bn.lproj/Localizable.strings
@@ -177,6 +177,13 @@
 "ON" = "চালু";
 "OFF" = "বন্ধ";
 "  (Tab to toggle)" = "  (Tab টগল করতে)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "একটি উপাদানে ক্লিক করুন  ·  কাস্টম এরিয়ার জন্য টানুন  ·  পূর্ণ স্ক্রিনের জন্য F";
+"Snap mode: " = "স্ন্যাপ মোড: ";
+"WINDOW" = "উইন্ডো";
+"ELEMENT" = "উপাদান";
+"  (Tab to switch)" = "  (Tab স্যুইচ করতে)";
+"Enhance browser and Electron element snapping" = "ব্রাউজার এবং ইলেক্ট্রন উপাদান স্ন্যাপিং বর্ধিত করুন";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "এলিমেন্ট মোডে টার্গেট অ্যাপের অ্যাক্সেসিবিলিটি ট্রি তৈরি করে। একটি ব্রাউজার বা ইলেক্ট্রন অ্যাপ ধীর হয়ে গেলে বা ইনপুট সমস্যা হলে এটি অক্ষম করুন।";
 "Right-click to copy" = "কপি করতে ডান-ক্লিক করুন";
 "Copied %@" = "%@ কপি হয়েছে";
 "Set color %@" = "রং সেট করুন %@";

--- a/macshot/ca.lproj/Localizable.strings
+++ b/macshot/ca.lproj/Localizable.strings
@@ -174,6 +174,13 @@
 "ON" = "ACTIVAT";
 "OFF" = "DESACTIVAT";
 "  (Tab to toggle)" = "  (Tab per canviar)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Clic a un element  ·  Arrossegar per a area personalitzada  ·  F per a pantalla completa";
+"Snap mode: " = "Mode d'ajust: ";
+"WINDOW" = "FINESTRA";
+"ELEMENT" = "ELEMENT";
+"  (Tab to switch)" = "  (Tab per canviar)";
+"Enhance browser and Electron element snapping" = "Millora l'ajust d'elements de navegador i aplicacions Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Construeix l'arbre d'accessibilitat de l'aplicació objectiu en mode Element. Desactiveu-ho si un navegador o aplicació Electron es torna lent o té problemes d'entrada.";
 "Right-click to copy" = "Clic dret per copiar";
 "Copied %@" = "Copiat %@";
 "Set color %@" = "Color establert %@";

--- a/macshot/cs.lproj/Localizable.strings
+++ b/macshot/cs.lproj/Localizable.strings
@@ -185,15 +185,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Klikněte na okno  ·  Tažením vyberte oblast  ·  F pro celou obrazovku";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Klikněte na prvek  ·  Tažením vyberte oblast  ·  F pro celou obrazovku";
 "Drag to select  ·  Click for full screen" = "Tažením vyberte  ·  Kliknutím celá obrazovka";
 "Release to annotate and edit" = "Uvolněte pro anotaci a úpravy";
 "Release to finish" = "Uvolněte pro dokončení";
 "Hold Space to move. Release to annotate and edit" = "Podržte Mezerník pro přesun. Uvolněte pro anotaci a úpravy";
 "Hold Space to move. Release to finish" = "Podržte Mezerník pro přesun. Uvolněte pro dokončení";
 "Window snap: " = "Přichycení k oknu: ";
+"Snap mode: " = "Režim přichycení: ";
 "ON" = "ZAP";
 "OFF" = "VYP";
+"WINDOW" = "OKNO";
+"ELEMENT" = "PRVEK";
 "  (Tab to toggle)" = "  (Tab pro přepnutí)";
+"  (Tab to switch)" = "  (Tab pro přepnutí)";
 "Space" = "Mezerník";
 "Right-click to copy" = "Pravým tlačítkem kopírovat";
 "Copied %@" = "Zkopírováno %@";
@@ -228,6 +233,8 @@
 "Launch at login" = "Spustit při přihlášení";
 "Show snap alignment guides" = "Zobrazit vodítka zarovnání";
 "Snap selection edges to image boundaries" = "Přichytit okraje výběru k hranicím obrázku";
+"Enhance browser and Electron element snapping" = "Zlepšit přichycování prvků v prohlížeči a Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Sestavuje strom usnadnění cílové aplikace v režimu prvků. Zakažte, pokud se prohlížeč nebo Electron aplikace stane pomalým nebo má problémy s vstupem.";
 "Capture mouse cursor in screenshot" = "Zachytit kurzor myši na snímku";
 "Double-click selection to copy" = "Kopírovat dvojklikem na výběr";
 "Hide capture instructions" = "Skrýt pokyny při snímání";

--- a/macshot/da.lproj/Localizable.strings
+++ b/macshot/da.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 
 /* Overlay / Canvas */
 "Click a window  \U00B7  Drag for custom area  \U00B7  F for full screen" = "Klik p\U00E5 et vindue  \U00B7  Tr\U00E6k for tilpasset omr\U00E5de  \U00B7  F for fuld sk\U00E6rm";
+"Click an element  \U00B7  Drag for custom area  \U00B7  F for full screen" = "Klik p\U00E5 et element  \U00B7  Tr\U00E6k for tilpasset omr\U00E5de  \U00B7  F for fuld sk\U00E6rm";
 "Drag to select  \U00B7  Click for full screen" = "Tr\U00E6k for at v\U00E6lge  \U00B7  Klik for fuld sk\U00E6rm";
 "Release to annotate and edit" = "Slip for at annotere og redigere";
 "Release to finish" = "Slip for at afslutte";
@@ -183,9 +184,13 @@
 "Hold Space to move. Release to finish" = "Hold mellemrum for at flytte. Slip for at afslutte";
 "Space" = "Mellemrum";
 "Window snap: " = "Vinduesfang: ";
+"Snap mode: " = "Snapp-tilstand: ";
 "ON" = "TIL";
 "OFF" = "FRA";
+"WINDOW" = "VINDUE";
+"ELEMENT" = "ELEMENT";
 "  (Tab to toggle)" = "  (Tab for at skifte)";
+"  (Tab to switch)" = "  (Tab for at skifte)";
 "Right-click to copy" = "H\U00F8jreklik for at kopiere";
 "Copied %@" = "Kopieret %@";
 "Set color %@" = "Indstil farve %@";
@@ -222,6 +227,8 @@
 "Launch at login" = "Start ved login";
 "Show snap alignment guides" = "Vis fastg\U00F8relses-hj\U00E6lpelinjer";
 "Snap selection edges to image boundaries" = "Fastg\U00F8r markeringskanter til billedgr\U00E6nser";
+"Enhance browser and Electron element snapping" = "Forbedr browser- og Electron-elementfangst";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Opbygger m\U00E5lappens tilg\U00E6ngelighedstr\U00E6 i Element-tilstand. Deaktiv\U00E9r dette, hvis en browser- eller Electron-app bliver langsom eller har input-problemer.";
 "Capture mouse cursor in screenshot" = "Inkluder musemark\U00F8r i sk\U00E6rmbillede";
 "Double-click selection to copy" = "Dobbeltklik p\U00E5 markeringen for at kopiere";
 "Hide capture instructions" = "Skjul vejledning ved optagelse";

--- a/macshot/de.lproj/Localizable.strings
+++ b/macshot/de.lproj/Localizable.strings
@@ -172,15 +172,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Fenster klicken  ·  Ziehen für eigenen Bereich  ·  F für Vollbild";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Element klicken  ·  Ziehen für eigenen Bereich  ·  F für Vollbild";
 "Drag to select  ·  Click for full screen" = "Ziehen zum Auswählen  ·  Klicken für Vollbild";
 "Release to annotate and edit" = "Loslassen zum Beschriften und Bearbeiten";
 "Release to finish" = "Loslassen zum Abschließen";
 "Hold Space to move. Release to annotate and edit" = "Leertaste halten zum Verschieben. Loslassen zum Beschriften und Bearbeiten";
 "Hold Space to move. Release to finish" = "Leertaste halten zum Verschieben. Loslassen zum Abschließen";
 "Window snap: " = "Fenster-Einrasten: ";
+"Snap mode: " = "Einrast-Modus: ";
 "ON" = "AN";
 "OFF" = "AUS";
+"WINDOW" = "FENSTER";
+"ELEMENT" = "ELEMENT";
 "  (Tab to toggle)" = "  (Tab zum Umschalten)";
+"  (Tab to switch)" = "  (Tab zum Wechseln)";
 "Right-click to copy" = "Rechtsklick zum Kopieren";
 "Copied %@" = "%@ kopiert";
 "Set color %@" = "Farbe %@ gesetzt";
@@ -214,6 +219,8 @@
 "Launch at login" = "Bei Anmeldung starten";
 "Show snap alignment guides" = "Ausrichtungshilfen anzeigen";
 "Snap selection edges to image boundaries" = "Auswahlkanten an Bildgrenzen ausrichten";
+"Enhance browser and Electron element snapping" = "Browser- und Electron-Element-Einrasten verbessern";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Baut den Accessibility-Baum der Ziel-App im Element-Modus auf. Deaktivieren Sie dies, wenn ein Browser oder eine Electron-App langsam wird oder Eingabeprobleme hat.";
 "Capture mouse cursor in screenshot" = "Mauszeiger im Screenshot aufnehmen";
 "Double-click selection to copy" = "Doppelklick auf Auswahl zum Kopieren";
 "Hide capture instructions" = "Aufnahmehinweise ausblenden";

--- a/macshot/el.lproj/Localizable.strings
+++ b/macshot/el.lproj/Localizable.strings
@@ -186,6 +186,13 @@
 "ON" = "ON";
 "OFF" = "OFF";
 "  (Tab to toggle)" = "  (Tab για εναλλαγή)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Κλικ σε στοιχείο  ·  Σύρσιμο για προσαρμοσμένη περιοχή  ·  F για πλήρη οθόνη";
+"Snap mode: " = "Λειτουργία κουμπώματος: ";
+"WINDOW" = "ΠΑΡΑΘΥΡΟ";
+"ELEMENT" = "ΣΤΟΙΧΕΙΟ";
+"  (Tab to switch)" = "  (Tab για εναλλαγή)";
+"Enhance browser and Electron element snapping" = "Βελτίωση της κούμπωσης στοιχείων σε προγράμματα περιήγησης και Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Κατασκευάζει το δέντρο προσβασιμότητας της εφαρμογής-στόχου στη λειτουργία Στοιχείο. Απενεργοποιήστε το αν ένα πρόγραμμα περιήγησης ή Electron γίνει αργό ή έχει προβλήματα εισαγωγής.";
 "Right-click to copy" = "Δεξί κλικ για αντιγραφή";
 "Copied %@" = "Αντιγράφηκε %@";
 "Set color %@" = "Ορισμός χρώματος %@";

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -177,15 +177,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Click a window  ·  Drag for custom area  ·  F for full screen";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Click an element  ·  Drag for custom area  ·  F for full screen";
 "Drag to select  ·  Click for full screen" = "Drag to select  ·  Click for full screen";
 "Release to annotate and edit" = "Release to annotate and edit";
 "Release to finish" = "Release to finish";
 "Space to move. Release to annotate and edit" = "Space to move. Release to annotate and edit";
 "Space to move. Release to finish" = "Space to move. Release to finish";
 "Window snap: " = "Window snap: ";
+"Snap mode: " = "Snap mode: ";
 "ON" = "ON";
 "OFF" = "OFF";
+"WINDOW" = "WINDOW";
+"ELEMENT" = "ELEMENT";
 "  (Tab to toggle)" = "  (Tab to toggle)";
+"  (Tab to switch)" = "  (Tab to switch)";
 "Right-click to copy" = "Right-click to copy";
 "Copied %@" = "Copied %@";
 "Set color %@" = "Set color %@";
@@ -218,6 +223,8 @@
 "Launch at login" = "Launch at login";
 "Show snap alignment guides" = "Show snap alignment guides";
 "Snap selection edges to image boundaries" = "Snap selection edges to image boundaries";
+"Enhance browser and Electron element snapping" = "Enhance browser and Electron element snapping";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues.";
 "Capture mouse cursor in screenshot" = "Capture mouse cursor in screenshot";
 "Double-click selection to copy" = "Double-click selection to copy";
 "Hide capture instructions" = "Hide capture instructions";

--- a/macshot/es.lproj/Localizable.strings
+++ b/macshot/es.lproj/Localizable.strings
@@ -172,15 +172,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Clic en una ventana  ·  Arrastra para area personalizada  ·  F para pantalla completa";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Clic en un elemento  ·  Arrastra para area personalizada  ·  F para pantalla completa";
 "Drag to select  ·  Click for full screen" = "Arrastra para seleccionar  ·  Clic para pantalla completa";
 "Release to annotate and edit" = "Suelta para anotar y editar";
 "Release to finish" = "Suelta para terminar";
 "Hold Space to move. Release to annotate and edit" = "Mantén Espacio para mover. Suelta para anotar y editar";
 "Hold Space to move. Release to finish" = "Mantén Espacio para mover. Suelta para terminar";
 "Window snap: " = "Ajuste a ventana: ";
+"Snap mode: " = "Modo de ajuste: ";
 "ON" = "SI";
 "OFF" = "NO";
+"WINDOW" = "VENTANA";
+"ELEMENT" = "ELEMENTO";
 "  (Tab to toggle)" = "  (Tab para alternar)";
+"  (Tab to switch)" = "  (Tab para cambiar)";
 "Right-click to copy" = "Clic derecho para copiar";
 "Copied %@" = "Copiado %@";
 "Set color %@" = "Color establecido %@";
@@ -214,6 +219,8 @@
 "Launch at login" = "Abrir al iniciar sesion";
 "Show snap alignment guides" = "Mostrar guias de alineacion";
 "Snap selection edges to image boundaries" = "Ajustar los bordes de la selección a los límites de la imagen";
+"Enhance browser and Electron element snapping" = "Mejorar el ajuste de elementos de navegador y Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Construye el árbol de accesibilidad de la app objetivo en modo Elemento. Desactívalo si un navegador o app de Electron se vuelve lento o tiene problemas de entrada.";
 "Capture mouse cursor in screenshot" = "Capturar cursor del mouse en la captura";
 "Double-click selection to copy" = "Doble clic en la seleccion para copiar";
 "Hide capture instructions" = "Ocultar instrucciones de captura";

--- a/macshot/fa.lproj/Localizable.strings
+++ b/macshot/fa.lproj/Localizable.strings
@@ -174,6 +174,13 @@
 "ON" = "روشن";
 "OFF" = "خاموش";
 "  (Tab to toggle)" = "  (Tab برای تغییر)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "روی یک عنصر کلیک کنید  ·  برای منطقه سفارشی بکشید  ·  F برای تمام صفحه";
+"Snap mode: " = "حالت چسبش: ";
+"WINDOW" = "پنجره";
+"ELEMENT" = "عنصر";
+"  (Tab to switch)" = "  (Tab برای تغییر)";
+"Enhance browser and Electron element snapping" = "بهبود چسبش عناصر مرورگر و الکترون";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "درخت دسترسی‌پذیری برنامه هدف را در حالت عنصر می‌سازد. اگر مرورگر یا برنامه الکترون کند می‌شود یا مشکلات ورودی دارد، این را غیرفعال کنید.";
 "Right-click to copy" = "کلیک راست برای کپی";
 "Copied %@" = "کپی شد %@";
 "Set color %@" = "تنظیم رنگ %@";

--- a/macshot/fi.lproj/Localizable.strings
+++ b/macshot/fi.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Napsauta ikkunaa  ·  Vedä valitaksesi alue  ·  F koko ruudulle";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Napsauta elementtiä  ·  Vedä valitaksesi alue  ·  F koko ruudulle";
 "Drag to select  ·  Click for full screen" = "Vedä valitaksesi  ·  Napsauta koko ruudulle";
 "Release to annotate and edit" = "Vapauta merkintoja ja muokkausta varten";
 "Release to finish" = "Vapauta lopettaaksesi";
@@ -183,9 +184,13 @@
 "Hold Space to move. Release to finish" = "Pida valilyontia siirtaaksesi. Vapauta lopettaaksesi";
 "Space" = "V\U00E4lily\U00F6nti";
 "Window snap: " = "Ikkunan tarttuminen: ";
+"Snap mode: " = "Tartuntitila: ";
 "ON" = "PAALLA";
 "OFF" = "POIS";
+"WINDOW" = "IKKUNA";
+"ELEMENT" = "ELEMENTTI";
 "  (Tab to toggle)" = "  (Tab vaihtaaksesi)";
+"  (Tab to switch)" = "  (Tab vaihtaaksesi)";
 "Right-click to copy" = "Kopioi oikealla napsautuksella";
 "Copied %@" = "Kopioitu %@";
 "Set color %@" = "Aseta vari %@";
@@ -222,6 +227,8 @@
 "Launch at login" = "Kaynnista kirjautumisen yhteydessa";
 "Show snap alignment guides" = "Nayta kohdistusoppaat";
 "Snap selection edges to image boundaries" = "Kohdista valinnan reunat kuvan rajoihin";
+"Enhance browser and Electron element snapping" = "Paranna selaimen ja Electronin elementt tartuntaa";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Rakentaa kohdeohjelman saavutettavuuspuun Element-tilassa. Poista tämä käytöstä, jos selain tai Electron-sovellus hidastuu tai sillä on input-ongelmia.";
 "Capture mouse cursor in screenshot" = "Kaappaa hiiren osoitin kuvakaappaukseen";
 "Double-click selection to copy" = "Kopioi kaksoisnapsauttamalla valintaa";
 "Hide capture instructions" = "Piilota kuvakaappausohjeet";

--- a/macshot/fil.lproj/Localizable.strings
+++ b/macshot/fil.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "I-click ang window  ·  I-drag para sa custom na lugar  ·  F para sa buong screen";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "I-click ang elemento  ·  I-drag para sa custom na lugar  ·  F para sa buong screen";
 "Drag to select  ·  Click for full screen" = "I-drag upang pumili  ·  I-click para sa buong screen";
 "Release to annotate and edit" = "Bitawan upang mag-annotate at mag-edit";
 "Release to finish" = "Bitawan upang tapusin";
@@ -179,9 +180,13 @@
 "Hold Space to move. Release to finish" = "Pindutin ang Space upang ilipat. Bitawan upang tapusin";
 "Space" = "Space";
 "Window snap: " = "Window snap: ";
+"Snap mode: " = "Snap mode: ";
 "ON" = "ON";
 "OFF" = "OFF";
+"WINDOW" = "WINDOW";
+"ELEMENT" = "ELEMENT";
 "  (Tab to toggle)" = "  (Tab upang i-toggle)";
+"  (Tab to switch)" = "  (Tab upang magpalit)";
 "Right-click to copy" = "I-right-click upang kopyahin";
 "Copied %@" = "Nakopya ang %@";
 "Set color %@" = "Itakda ang kulay %@";
@@ -226,6 +231,8 @@
 "Launch at login" = "Buksan kapag nag-login";
 "Show snap alignment guides" = "Ipakita ang mga gabay sa pagkakahanay";
 "Snap selection edges to image boundaries" = "I-snap ang mga gilid ng seleksiyon sa hangganan ng imahe";
+"Enhance browser and Electron element snapping" = "Pahusayin ang element snapping ng browser at Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Gumagawa ng accessibility tree ng target app sa Element mode. I-disable ito kung mabagal ang browser o Electron app o may mga problema sa input.";
 "Capture mouse cursor in screenshot" = "Isama ang cursor ng mouse sa screenshot";
 "Double-click selection to copy" = "I-double-click ang pinili upang kopyahin";
 "Hide capture instructions" = "Itago ang mga tagubilin sa pagkuha ng screenshot";

--- a/macshot/fr.lproj/Localizable.strings
+++ b/macshot/fr.lproj/Localizable.strings
@@ -172,15 +172,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Cliquer sur une fenêtre  ·  Glisser pour une zone  ·  F pour plein écran";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Cliquer sur un élément  ·  Glisser pour une zone  ·  F pour plein écran";
 "Drag to select  ·  Click for full screen" = "Glisser pour sélectionner  ·  Cliquer pour plein écran";
 "Release to annotate and edit" = "Relâcher pour annoter et modifier";
 "Release to finish" = "Relâcher pour terminer";
 "Hold Space to move. Release to annotate and edit" = "Maintenir Espace pour déplacer. Relâcher pour annoter et modifier";
 "Hold Space to move. Release to finish" = "Maintenir Espace pour déplacer. Relâcher pour terminer";
 "Window snap: " = "Accrochage fenêtre : ";
+"Snap mode: " = "Mode d'accrochage : ";
 "ON" = "OUI";
 "OFF" = "NON";
+"WINDOW" = "FENÊTRE";
+"ELEMENT" = "ÉLÉMENT";
 "  (Tab to toggle)" = "  (Tab pour basculer)";
+"  (Tab to switch)" = "  (Tab pour changer)";
 "Right-click to copy" = "Clic droit pour copier";
 "Aspect ratio & resolution presets" = "Préréglages de ratio et de résolution";
 "Aspect ratio" = "Ratio d'aspect";
@@ -221,6 +226,8 @@
 "Launch at login" = "Lancer au démarrage";
 "Show snap alignment guides" = "Afficher les guides d'alignement";
 "Snap selection edges to image boundaries" = "Aligner les bords de la sélection sur les limites de l'image";
+"Enhance browser and Electron element snapping" = "Améliorer l'accrochage des éléments des navigateurs et apps Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Construit l'arbre d'accessibilité de l'app cible en mode Élément. Désactivez si un navigateur ou une app Electron devient lent ou a des problèmes de saisie.";
 "Capture mouse cursor in screenshot" = "Capturer le curseur dans la capture d'écran";
 "Double-click selection to copy" = "Double-cliquer sur la sélection pour copier";
 "Hide capture instructions" = "Masquer les instructions de capture";

--- a/macshot/he.lproj/Localizable.strings
+++ b/macshot/he.lproj/Localizable.strings
@@ -174,6 +174,13 @@
 "ON" = "פעיל";
 "OFF" = "כבוי";
 "  (Tab to toggle)" = "  (Tab להחלפה)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "לחץ על אלמנט  ·  גרור לאזור מותאם אישית  ·  F למסך מלא";
+"Snap mode: " = "מצב הצמדה: ";
+"WINDOW" = "חלון";
+"ELEMENT" = "אלמנט";
+"  (Tab to switch)" = "  (Tab להחלפה)";
+"Enhance browser and Electron element snapping" = "שיפור הצמדת אלמנטים בדפדפן ובאפליקציות Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "בונה את עץ הנגישות של האפליקצייה היעד במצב אלמנט. השבת זאת אם דפדפן או אפליקציית Electron הופכים איטיים או יש להם בעיות קלט.";
 "Right-click to copy" = "לחץ ימני להעתקה";
 "Copied %@" = "הועתק %@";
 "Set color %@" = "הגדר צבע %@";

--- a/macshot/hi.lproj/Localizable.strings
+++ b/macshot/hi.lproj/Localizable.strings
@@ -174,6 +174,13 @@
 "ON" = "चालू";
 "OFF" = "बंद";
 "  (Tab to toggle)" = "  (टॉगल के लिए Tab)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "किसी तत्व पर क्लिक करें  ·  कस्टम क्षेत्र के लिए खींचें  ·  पूर्ण स्क्रीन के लिए F";
+"Snap mode: " = "स्नैप मोड: ";
+"WINDOW" = "विंडो";
+"ELEMENT" = "तत्व";
+"  (Tab to switch)" = "  (स्विच करने के लिए Tab)";
+"Enhance browser and Electron element snapping" = "ब्राउज़र और इलेक्ट्रॉन तत्व स्नैपिंग को बेहतर करें";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "तत्व मोड में लक्ष्य ऐप की ऐक्सेसिबिलिटी ट्री बनाता है। यदि कोई ब्राउज़र या इलेक्ट्रॉन ऐप धीमा हो जाता है या इनपुट समस्याएं होती हैं, तो इसे अक्षम करें।";
 "Right-click to copy" = "कॉपी करने के लिए राइट-क्लिक करें";
 "Copied %@" = "%@ कॉपी किया";
 "Set color %@" = "रंग सेट किया %@";

--- a/macshot/hr.lproj/Localizable.strings
+++ b/macshot/hr.lproj/Localizable.strings
@@ -185,15 +185,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Klikni prozor  ·  Povuci za podrucje  ·  F za cijeli zaslon";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Klikni element  ·  Povuci za podrucje  ·  F za cijeli zaslon";
 "Drag to select  ·  Click for full screen" = "Povuci za odabir  ·  Klikni za cijeli zaslon";
 "Release to annotate and edit" = "Pusti za oznacavanje i uredivanje";
 "Release to finish" = "Pusti za završetak";
 "Hold Space to move. Release to annotate and edit" = "Držite Razmaknicu za pomicanje. Pustite za označavanje i uređivanje";
 "Hold Space to move. Release to finish" = "Držite Razmaknicu za pomicanje. Pustite za završetak";
 "Window snap: " = "Hvatanje prozora: ";
+"Snap mode: " = "Režim hvatanja: ";
 "ON" = "UKLJ.";
 "OFF" = "ISKLJ.";
+"WINDOW" = "PROZOR";
+"ELEMENT" = "ELEMENT";
 "  (Tab to toggle)" = "  (Tab za prebacivanje)";
+"  (Tab to switch)" = "  (Tab za prebacivanje)";
 "Space" = "Razmaknica";
 "Right-click to copy" = "Desni klik za kopiranje";
 "Copied %@" = "Kopirano %@";
@@ -228,6 +233,8 @@
 "Launch at login" = "Pokreni pri prijavi";
 "Show snap alignment guides" = "Prikazi vodilice za poravnanje";
 "Snap selection edges to image boundaries" = "Privezi rubove odabira uz granice slike";
+"Enhance browser and Electron element snapping" = "Poboljšaj hvatanje elemenata u pregledniku i Electron-u";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Izgrađuje stablo pristupačnosti ciljne aplikacije u načinu elemenata. Onemogućite ako preglednik ili Electron aplikacija postane spora ili ima problema s unosom.";
 "Capture mouse cursor in screenshot" = "Snimi kursor misa na snimci zaslona";
 "Double-click selection to copy" = "Kopiraj dvostrukim klikom na odabir";
 "Hide capture instructions" = "Sakrij upute pri snimanju";

--- a/macshot/hu.lproj/Localizable.strings
+++ b/macshot/hu.lproj/Localizable.strings
@@ -178,6 +178,13 @@
 "ON" = "BE";
 "OFF" = "KI";
 "  (Tab to toggle)" = "  (Tab a váltáshoz)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Kattintson egy elemre  ·  Húzzon egyéni területhez  ·  F a teljes képernyőhöz";
+"Snap mode: " = "Illesztés mód: ";
+"WINDOW" = "ABLAK";
+"ELEMENT" = "ELEM";
+"  (Tab to switch)" = "  (Tab a váltáshoz)";
+"Enhance browser and Electron element snapping" = "Böngésző és Electron elem illesztésének javítása";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Építi a célalkalmazás akadálymentesítési fastruktúráját Elem módban. Tiltsa le, ha egy böngésző vagy Electron alkalmazás lassúvá válik vagy bemeneti problémái vannak.";
 "Right-click to copy" = "Jobb kattintás a másoláshoz";
 "Copied %@" = "%@ másolva";
 "Set color %@" = "Szín beállítva: %@";

--- a/macshot/id.lproj/Localizable.strings
+++ b/macshot/id.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Klik jendela  ·  Seret untuk area kustom  ·  F untuk layar penuh";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Klik elemen  ·  Seret untuk area kustom  ·  F untuk layar penuh";
 "Drag to select  ·  Click for full screen" = "Seret untuk memilih  ·  Klik untuk layar penuh";
 "Release to annotate and edit" = "Lepaskan untuk menganotasi dan mengedit";
 "Release to finish" = "Lepaskan untuk menyelesaikan";
@@ -179,9 +180,13 @@
 "Hold Space to move. Release to finish" = "Tahan Spasi untuk memindahkan. Lepaskan untuk menyelesaikan";
 "Space" = "Spasi";
 "Window snap: " = "Jepret jendela: ";
+"Snap mode: " = "Mode jepret: ";
 "ON" = "AKTIF";
 "OFF" = "NONAKTIF";
+"WINDOW" = "JENDELA";
+"ELEMENT" = "ELEMEN";
 "  (Tab to toggle)" = "  (Tab untuk beralih)";
+"  (Tab to switch)" = "  (Tab untuk berpindah)";
 "Right-click to copy" = "Klik kanan untuk menyalin";
 "Copied %@" = "Disalin %@";
 "Set color %@" = "Atur warna %@";
@@ -226,6 +231,8 @@
 "Launch at login" = "Jalankan saat masuk";
 "Show snap alignment guides" = "Tampilkan panduan perataan jepret";
 "Snap selection edges to image boundaries" = "Jepretkan tepi pilihan ke batas gambar";
+"Enhance browser and Electron element snapping" = "Tingkatkan penjepretan elemen browser dan Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Membangun pohon aksesibilitas aplikasi target dalam Mode Elemen. Nonaktifkan ini jika browser atau aplikasi Electron menjadi lambat atau memiliki masalah input.";
 "Capture mouse cursor in screenshot" = "Tangkap kursor mouse di tangkapan layar";
 "Double-click selection to copy" = "Klik dua kali pilihan untuk menyalin";
 "Hide capture instructions" = "Sembunyikan petunjuk pengambilan tangkapan layar";

--- a/macshot/it.lproj/Localizable.strings
+++ b/macshot/it.lproj/Localizable.strings
@@ -158,6 +158,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Clicca una finestra  ·  Trascina per area personalizzata  ·  F per schermo intero";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Clicca un elemento  ·  Trascina per area personalizzata  ·  F per schermo intero";
 "Drag to select  ·  Click for full screen" = "Trascina per selezionare  ·  Clicca per schermo intero";
 "Release to annotate and edit" = "Rilascia per annotare e modificare";
 "Release to finish" = "Rilascia per completare";
@@ -171,9 +172,13 @@
 "Units" = "Unità";
 "Keep ratio for next captures" = "Mantieni le proporzioni per le prossime catture";
 "Window snap: " = "Aggancio finestra: ";
+"Snap mode: " = "Modalità aggancio: ";
 "ON" = "ON";
 "OFF" = "OFF";
+"WINDOW" = "FINESTRA";
+"ELEMENT" = "ELEMENTO";
 "  (Tab to toggle)" = "  (Tab per alternare)";
+"  (Tab to switch)" = "  (Tab per cambiare)";
 "Right-click to copy" = "Clic destro per copiare";
 "Copied %@" = "Copiato %@";
 "Set color %@" = "Imposta colore %@";
@@ -207,6 +212,8 @@
 "Launch at login" = "Avvia al login";
 "Show snap alignment guides" = "Mostra guide di allineamento";
 "Snap selection edges to image boundaries" = "Allinea i bordi della selezione ai contorni dell’immagine";
+"Enhance browser and Electron element snapping" = "Migliora lo scatto degli elementi di browser ed Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Costruisce l’albero di accessibilità dell’app target in modalità Elemento. Disabilita se un browser o un’app Electron diventa lento o ha problemi di input.";
 "Capture mouse cursor in screenshot" = "Cattura il cursore del mouse nello screenshot";
 "Double-click selection to copy" = "Doppio clic sulla selezione per copiare";
 "Hide capture instructions" = "Nascondi istruzioni di cattura";

--- a/macshot/ja.lproj/Localizable.strings
+++ b/macshot/ja.lproj/Localizable.strings
@@ -165,6 +165,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "ウインドウをクリック · ドラッグで範囲選択 · F でフルスクリーン";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "要素をクリック · ドラッグで範囲選択 · F でフルスクリーン";
 "Drag to select  ·  Click for full screen" = "ドラッグで選択 · クリックでフルスクリーン";
 "Release to annotate and edit" = "離して注釈・編集";
 "Release to finish" = "離して完了";
@@ -172,9 +173,13 @@
 "Hold Space to move. Release to finish" = "スペースキー長押しで移動。離して完了";
 "Space" = "スペース";
 "Window snap: " = "ウインドウスナップ: ";
+"Snap mode: " = "スナップモード: ";
 "ON" = "オン";
 "OFF" = "オフ";
+"WINDOW" = "ウインドウ";
+"ELEMENT" = "要素";
 "  (Tab to toggle)" = "  (Tab で切替)";
+"  (Tab to switch)" = "  (Tab で切り替え)";
 "Right-click to copy" = "右クリックでコピー";
 "Copied %@" = "%@ をコピーしました";
 "Set color %@" = "カラーを %@ に設定";
@@ -208,6 +213,8 @@
 "Launch at login" = "ログイン時に起動";
 "Show snap alignment guides" = "スナップ整列ガイドを表示";
 "Snap selection edges to image boundaries" = "選択範囲の端を画像の境界にスナップ";
+"Enhance browser and Electron element snapping" = "ブラウザと Electron の要素スナップを強化";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "要素モードで対象アプリのアクセシビリティツリーを構築します。ブラウザまたは Electron アプリが動作中に遅くなる場合や入力に問題がある場合は無効にしてください。";
 "Capture mouse cursor in screenshot" = "スクリーンショットにマウスカーソルを含める";
 "Double-click selection to copy" = "選択範囲をダブルクリックでコピー";
 "Hide capture instructions" = "撮影時の操作説明を非表示";

--- a/macshot/ko.lproj/Localizable.strings
+++ b/macshot/ko.lproj/Localizable.strings
@@ -165,6 +165,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "윈도우 클릭  ·  드래그하여 영역 선택  ·  F 전체 화면";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "요소 클릭  ·  드래그하여 영역 선택  ·  F 전체 화면";
 "Drag to select  ·  Click for full screen" = "드래그하여 선택  ·  클릭하여 전체 화면";
 "Release to annotate and edit" = "놓으면 주석 및 편집";
 "Release to finish" = "놓으면 완료";
@@ -172,9 +173,13 @@
 "Hold Space to move. Release to finish" = "스페이스바를 누른 채로 이동. 놓으면 완료";
 "Space" = "스페이스";
 "Window snap: " = "윈도우 스냅: ";
+"Snap mode: " = "스냅 모드: ";
 "ON" = "켜짐";
 "OFF" = "꺼짐";
+"WINDOW" = "창";
+"ELEMENT" = "요소";
 "  (Tab to toggle)" = "  (Tab으로 전환)";
+"  (Tab to switch)" = "  (Tab으로 전환)";
 "Right-click to copy" = "우클릭하여 복사";
 "Copied %@" = "%@ 복사됨";
 "Set color %@" = "색상 %@ 설정됨";
@@ -208,6 +213,8 @@
 "Launch at login" = "로그인 시 실행";
 "Show snap alignment guides" = "스냅 정렬 가이드 표시";
 "Snap selection edges to image boundaries" = "선택 영역 가장자리를 이미지 경계에 스냅";
+"Enhance browser and Electron element snapping" = "브라우저 및 Electron 요소 스냅 향상";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "요소 모드에서 대상 앱의 접근성 트리를 구축합니다. 브라우저 또는 Electron 앱이 느려지거나 입력 문제가 있는 경우 비활성화하세요.";
 "Capture mouse cursor in screenshot" = "스크린샷에 마우스 커서 포함";
 "Double-click selection to copy" = "선택 영역 더블 클릭으로 복사";
 "Hide capture instructions" = "캡처 안내 숨기기";

--- a/macshot/macshot.entitlements
+++ b/macshot/macshot.entitlements
@@ -16,8 +16,13 @@
 	<true/>
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 	<array>
+		<string>com.apple.axserver</string>
 		<string>com.sw33tlie.macshot.macshot-spks</string>
 		<string>com.sw33tlie.macshot.macshot-spki</string>
+	</array>
+	<key>com.apple.security.temporary-exception.mach-lookup.local-name</key>
+	<array>
+		<string>com.apple.axserver</string>
 	</array>
 </dict>
 </plist>

--- a/macshot/ms.lproj/Localizable.strings
+++ b/macshot/ms.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Klik tetingkap  ·  Seret untuk kawasan tersuai  ·  F untuk skrin penuh";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Klik elemen  ·  Seret untuk kawasan tersuai  ·  F untuk skrin penuh";
 "Drag to select  ·  Click for full screen" = "Seret untuk memilih  ·  Klik untuk skrin penuh";
 "Release to annotate and edit" = "Lepaskan untuk anotasi dan sunting";
 "Release to finish" = "Lepaskan untuk selesai";
@@ -179,9 +180,13 @@
 "Hold Space to move. Release to finish" = "Tahan Space untuk alih. Lepaskan untuk selesai";
 "Space" = "Space";
 "Window snap: " = "Lekat tetingkap: ";
+"Snap mode: " = "Mod lekat: ";
 "ON" = "HIDUP";
 "OFF" = "MATI";
+"WINDOW" = "TINGKAP";
+"ELEMENT" = "ELEMEN";
 "  (Tab to toggle)" = "  (Tab untuk togol)";
+"  (Tab to switch)" = "  (Tab untuk tukar)";
 "Right-click to copy" = "Klik kanan untuk salin";
 "Copied %@" = "Disalin %@";
 "Set color %@" = "Tetapkan warna %@";
@@ -226,6 +231,8 @@
 "Launch at login" = "Lancar semasa log masuk";
 "Show snap alignment guides" = "Tunjuk panduan penjajaran lekat";
 "Snap selection edges to image boundaries" = "Lekatkan tepi pilihan pada sempadan imej";
+"Enhance browser and Electron element snapping" = "Tingkatkan penjerapan elemen penyegerak dan Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Membina pokok aksesibilitas aplikasi sasaran dalam Mod Elemen. Lumpuhkan ini jika penyegerak atau aplikasi Electron menjadi perlahan atau mempunyai masukan input.";
 "Capture mouse cursor in screenshot" = "Tangkap kursor tetikus dalam tangkapan skrin";
 "Double-click selection to copy" = "Dwiklik pilihan untuk menyalin";
 "Hide capture instructions" = "Sembunyikan arahan tangkapan skrin";

--- a/macshot/nb.lproj/Localizable.strings
+++ b/macshot/nb.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 
 /* Overlay / Canvas */
 "Click a window  \U00B7  Drag for custom area  \U00B7  F for full screen" = "Klikk et vindu  \U00B7  Dra for egendefinert omr\U00E5de  \U00B7  F for fullskjerm";
+"Click an element  \U00B7  Drag for custom area  \U00B7  F for full screen" = "Klikk et element  \U00B7  Dra for egendefinert omr\U00E5de  \U00B7  F for fullskjerm";
 "Drag to select  \U00B7  Click for full screen" = "Dra for \U00E5 velge  \U00B7  Klikk for fullskjerm";
 "Release to annotate and edit" = "Slipp for \U00E5 kommentere og redigere";
 "Release to finish" = "Slipp for \U00E5 fullf\U00F8re";
@@ -183,9 +184,13 @@
 "Hold Space to move. Release to finish" = "Hold mellomrom for \U00E5 flytte. Slipp for \U00E5 fullf\U00F8re";
 "Space" = "Mellomrom";
 "Window snap: " = "Vindussnapping: ";
+"Snap mode: " = "Snappemodus: ";
 "ON" = "P\U00C5";
 "OFF" = "AV";
+"WINDOW" = "VINDU";
+"ELEMENT" = "ELEMENT";
 "  (Tab to toggle)" = "  (Tab for \U00E5 veksle)";
+"  (Tab to switch)" = "  (Tab for \U00E5 bytte)";
 "Right-click to copy" = "H\U00F8yreklikk for \U00E5 kopiere";
 "Copied %@" = "Kopierte %@";
 "Set color %@" = "Sett farge %@";
@@ -222,6 +227,8 @@
 "Launch at login" = "Start ved innlogging";
 "Show snap alignment guides" = "Vis hjelpelinje for justering";
 "Snap selection edges to image boundaries" = "Fest markeringskanter til bildegrenser";
+"Enhance browser and Electron element snapping" = "Forbedre elementfangst for nettleser og Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Bygger tilgangstr\U00E6t i m\U00E5lappen i Element-modus. Deaktiver dette hvis en nettleser eller Electron-app blir treg eller har innproblemer.";
 "Capture mouse cursor in screenshot" = "Ta med musepeker i skjermbilde";
 "Double-click selection to copy" = "Dobbeltklikk p\U00E5 utvalget for \U00E5 kopiere";
 "Hide capture instructions" = "Skjul instruksjoner ved skjermbilde";

--- a/macshot/nl.lproj/Localizable.strings
+++ b/macshot/nl.lproj/Localizable.strings
@@ -171,15 +171,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Klik op een venster  ·  Sleep voor aangepast gebied  ·  F voor volledig scherm";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Klik op een element  ·  Sleep voor aangepast gebied  ·  F voor volledig scherm";
 "Drag to select  ·  Click for full screen" = "Sleep om te selecteren  ·  Klik voor volledig scherm";
 "Release to annotate and edit" = "Laat los om te annoteren en bewerken";
 "Release to finish" = "Laat los om te voltooien";
 "Hold Space to move. Release to annotate and edit" = "Houd Spatie ingedrukt om te verplaatsen. Laat los om te annoteren en bewerken";
 "Hold Space to move. Release to finish" = "Houd Spatie ingedrukt om te verplaatsen. Laat los om te voltooien";
 "Window snap: " = "Venster-snap: ";
+"Snap mode: " = "Snap-modus: ";
 "ON" = "AAN";
 "OFF" = "UIT";
+"WINDOW" = "VENSTER";
+"ELEMENT" = "ELEMENT";
 "  (Tab to toggle)" = "  (Tab om te wisselen)";
+"  (Tab to switch)" = "  (Tab om te schakelen)";
 "Right-click to copy" = "Rechtsklik om te kopieren";
 "Copied %@" = "%@ gekopieerd";
 "Set color %@" = "Kleur %@ ingesteld";
@@ -213,6 +218,8 @@
 "Launch at login" = "Open bij inloggen";
 "Show snap alignment guides" = "Uitlijnhulplijnen tonen";
 "Snap selection edges to image boundaries" = "Selectieranden uitlijnen op afbeeldingsgrenzen";
+"Enhance browser and Electron element snapping" = "Verbeter browser- en Electron-element-snap";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Bouwt de toegankelijkheidsboom van de doel-app op in Element-modus. Schakel dit uit als een browser of Electron-app traag wordt of invoerproblemen heeft.";
 "Capture mouse cursor in screenshot" = "Muiscursor vastleggen in schermafbeelding";
 "Double-click selection to copy" = "Dubbelklik op selectie om te kopiëren";
 "Hide capture instructions" = "Opname-instructies verbergen";

--- a/macshot/pl.lproj/Localizable.strings
+++ b/macshot/pl.lproj/Localizable.strings
@@ -172,15 +172,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Kliknij okno  ·  Przeciągnij, aby wybrać obszar  ·  F — pełny ekran";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Kliknij element  ·  Przeciągnij, aby wybrać obszar  ·  F — pełny ekran";
 "Drag to select  ·  Click for full screen" = "Przeciągnij, aby zaznaczyć  ·  Kliknij — pełny ekran";
 "Release to annotate and edit" = "Puść, aby opisać i edytować";
 "Release to finish" = "Puść, aby zakończyć";
 "Hold Space to move. Release to annotate and edit" = "Przytrzymaj Spację, aby przesunąć. Puść, aby opisać i edytować";
 "Hold Space to move. Release to finish" = "Przytrzymaj Spację, aby przesunąć. Puść, aby zakończyć";
 "Window snap: " = "Przyciąganie do okien: ";
+"Snap mode: " = "Tryb przyciągania: ";
 "ON" = "WŁ.";
 "OFF" = "WYŁ.";
+"WINDOW" = "OKNO";
+"ELEMENT" = "ELEMENT";
 "  (Tab to toggle)" = "  (Tab, aby przełączyć)";
+"  (Tab to switch)" = "  (Tab, aby zmienić)";
 "Right-click to copy" = "Kliknij prawym, aby skopiować";
 "Copied %@" = "Skopiowano %@";
 "Set color %@" = "Ustaw kolor %@";
@@ -214,6 +219,8 @@
 "Launch at login" = "Uruchamiaj przy logowaniu";
 "Show snap alignment guides" = "Pokaż linie wyrównywania";
 "Snap selection edges to image boundaries" = "Przyciągaj krawędzie zaznaczenia do granic obrazu";
+"Enhance browser and Electron element snapping" = "Ulepsz przyciąganie elementów przeglądarki i Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Buduje drzewo dostępności aplikacji docelowej w trybie Element. Wyłączaj, jeśli przeglądarka lub aplikacja Electron zwalnia lub ma problemy z wprowadzaniem.";
 "Capture mouse cursor in screenshot" = "Uwzględnij kursor myszy na zrzucie";
 "Double-click selection to copy" = "Kliknij dwukrotnie zaznaczenie, aby skopiować";
 "Hide capture instructions" = "Ukryj instrukcje przechwytywania";

--- a/macshot/pt-BR.lproj/Localizable.strings
+++ b/macshot/pt-BR.lproj/Localizable.strings
@@ -172,15 +172,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Clique em uma janela  ·  Arraste para área personalizada  ·  F para tela cheia";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Clique em um elemento  ·  Arraste para área personalizada  ·  F para tela cheia";
 "Drag to select  ·  Click for full screen" = "Arraste para selecionar  ·  Clique para tela cheia";
 "Release to annotate and edit" = "Solte para anotar e editar";
 "Release to finish" = "Solte para concluir";
 "Hold Space to move. Release to annotate and edit" = "Segure Espaço para mover. Solte para anotar e editar";
 "Hold Space to move. Release to finish" = "Segure Espaço para mover. Solte para concluir";
 "Window snap: " = "Encaixe de janela: ";
+"Snap mode: " = "Modo de encaixe: ";
 "ON" = "LIGADO";
 "OFF" = "DESLIGADO";
+"WINDOW" = "JANELA";
+"ELEMENT" = "ELEMENTO";
 "  (Tab to toggle)" = "  (Tab para alternar)";
+"  (Tab to switch)" = "  (Tab para mudar)";
 "Right-click to copy" = "Clique com o botão direito para copiar";
 "Copied %@" = "Copiado %@";
 "Set color %@" = "Cor definida %@";
@@ -214,6 +219,8 @@
 "Launch at login" = "Abrir ao iniciar sessão";
 "Show snap alignment guides" = "Mostrar guias de alinhamento";
 "Snap selection edges to image boundaries" = "Ajustar as bordas da seleção aos limites da imagem";
+"Enhance browser and Electron element snapping" = "Aprimorar encaixe de elementos de navegador e Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Constrói a árvore de acessibilidade do app alvo no modo Elemento. Desative se um navegador ou app Electron ficar lento ou tiver problemas de entrada.";
 "Capture mouse cursor in screenshot" = "Capturar cursor do mouse na captura de tela";
 "Double-click selection to copy" = "Clique duplo na seleção para copiar";
 "Hide capture instructions" = "Ocultar instruções de captura";

--- a/macshot/pt.lproj/Localizable.strings
+++ b/macshot/pt.lproj/Localizable.strings
@@ -172,15 +172,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Clicar numa janela  ·  Arrastar para area personalizada  ·  F para ecra inteiro";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Clicar num elemento  ·  Arrastar para area personalizada  ·  F para ecra inteiro";
 "Drag to select  ·  Click for full screen" = "Arrastar para selecionar  ·  Clicar para ecra inteiro";
 "Release to annotate and edit" = "Soltar para anotar e editar";
 "Release to finish" = "Soltar para concluir";
 "Hold Space to move. Release to annotate and edit" = "Mantenha Espaco para mover. Solte para anotar e editar";
 "Hold Space to move. Release to finish" = "Mantenha Espaco para mover. Solte para concluir";
 "Window snap: " = "Ajuste a janela: ";
+"Snap mode: " = "Modo de ajuste: ";
 "ON" = "LIGADO";
 "OFF" = "DESLIGADO";
+"WINDOW" = "JANELA";
+"ELEMENT" = "ELEMENTO";
 "  (Tab to toggle)" = "  (Tab para alternar)";
+"  (Tab to switch)" = "  (Tab para mudar)";
 "Right-click to copy" = "Clique direito para copiar";
 "Copied %@" = "Copiado %@";
 "Set color %@" = "Definir cor %@";
@@ -215,6 +220,8 @@
 "Launch at login" = "Iniciar ao arrancar";
 "Show snap alignment guides" = "Mostrar guias de alinhamento";
 "Snap selection edges to image boundaries" = "Ajustar as margens da seleção aos limites da imagem";
+"Enhance browser and Electron element snapping" = "Melhorar ajuste de elementos de navegador e Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Constrói a árvore de acessibilidade da aplicação alvo no modo Elemento. Desative se um navegador ou aplicação Electron ficar lento ou tiver problemas de entrada.";
 "Capture mouse cursor in screenshot" = "Capturar cursor do rato na captura de ecra";
 "Double-click selection to copy" = "Duplo clique na selecao para copiar";
 "Hide capture instructions" = "Ocultar instrucoes de captura";

--- a/macshot/ro.lproj/Localizable.strings
+++ b/macshot/ro.lproj/Localizable.strings
@@ -174,6 +174,13 @@
 "ON" = "ACTIVAT";
 "OFF" = "DEZACTIVAT";
 "  (Tab to toggle)" = "  (Tab pentru comutare)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Clic pe un element  ·  Trage pentru zona personalizată  ·  F pentru ecran complet";
+"Snap mode: " = "Mod fixare: ";
+"WINDOW" = "FEREASTRĂ";
+"ELEMENT" = "ELEMENT";
+"  (Tab to switch)" = "  (Tab pentru comutare)";
+"Enhance browser and Electron element snapping" = "Îmbunătățește fixarea elementelor de browser și Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Construiește arborele de accesibilitate al aplicației țintă în modul Element. Dezactivează dacă un browser sau aplicație Electron devine lentă sau are probleme de intrare.";
 "Right-click to copy" = "Clic dreapta pentru copiere";
 "Copied %@" = "Copiat %@";
 "Set color %@" = "Seteaza culoarea %@";

--- a/macshot/ru.lproj/Localizable.strings
+++ b/macshot/ru.lproj/Localizable.strings
@@ -185,15 +185,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Нажмите на окно  ·  Выделите область  ·  F для полного экрана";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Нажмите на элемент  ·  Выделите область  ·  F для полного экрана";
 "Drag to select  ·  Click for full screen" = "Выделите область  ·  Нажмите для полного экрана";
 "Release to annotate and edit" = "Отпустите для аннотации и редактирования";
 "Release to finish" = "Отпустите для завершения";
 "Hold Space to move. Release to annotate and edit" = "Удерживайте Пробел для перемещения. Отпустите для аннотации и редактирования";
 "Hold Space to move. Release to finish" = "Удерживайте Пробел для перемещения. Отпустите для завершения";
 "Window snap: " = "Привязка к окнам: ";
+"Snap mode: " = "Режим привязки: ";
 "ON" = "ВКЛ";
 "OFF" = "ВЫКЛ";
+"WINDOW" = "ОКНО";
+"ELEMENT" = "ЭЛЕМЕНТ";
 "  (Tab to toggle)" = "  (Tab для переключения)";
+"  (Tab to switch)" = "  (Tab для переключения)";
 "Space" = "Пробел";
 "Right-click to copy" = "Нажмите правой кнопкой, чтобы скопировать";
 "Copied %@" = "Скопировано: %@";
@@ -228,6 +233,8 @@
 "Launch at login" = "Запускать при входе в систему";
 "Show snap alignment guides" = "Показывать направляющие привязки";
 "Snap selection edges to image boundaries" = "Привязывать края выделения к границам изображения";
+"Enhance browser and Electron element snapping" = "Улучшить привязку элементов в браузере и Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Строит дерево доступности целевого приложения в режиме элементов. Отключите, если браузер или Electron-приложение начинает медленно работать или возникают проблемы с вводом.";
 "Capture mouse cursor in screenshot" = "Захватывать курсор мыши на снимке экрана";
 "Double-click selection to copy" = "Копировать двойным щелчком по выделению";
 "Hide capture instructions" = "Скрывать подсказки при захвате";

--- a/macshot/sk.lproj/Localizable.strings
+++ b/macshot/sk.lproj/Localizable.strings
@@ -185,15 +185,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Kliknite na okno  ·  Potiahnite pre vlastnu oblast  ·  F pre celu obrazovku";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Kliknite na prvok  ·  Potiahnite pre vlastnu oblast  ·  F pre celu obrazovku";
 "Drag to select  ·  Click for full screen" = "Potiahnite pre vyber  ·  Kliknite pre celu obrazovku";
 "Release to annotate and edit" = "Pustite pre anotaciu a upravu";
 "Release to finish" = "Pustite pre dokončenie";
 "Hold Space to move. Release to annotate and edit" = "Podržte Medzerník pre presun. Pustite pre anotáciu a úpravu";
 "Hold Space to move. Release to finish" = "Podržte Medzerník pre presun. Pustite pre dokončenie";
 "Window snap: " = "Prichytenie okna: ";
+"Snap mode: " = "Režim prichytenia: ";
 "ON" = "ZAP";
 "OFF" = "VYP";
+"WINDOW" = "OKNO";
+"ELEMENT" = "PRVOK";
 "  (Tab to toggle)" = "  (Tab pre prepnutie)";
+"  (Tab to switch)" = "  (Tab pre prepnutie)";
 "Space" = "Medzerník";
 "Right-click to copy" = "Kliknite pravym tlacidlom pre kopirovanie";
 "Copied %@" = "Skopirovane %@";
@@ -228,6 +233,8 @@
 "Launch at login" = "Spustit pri prihlaseni";
 "Show snap alignment guides" = "Zobrazit vodiace ciary zarovnania";
 "Snap selection edges to image boundaries" = "Prichytit okraje vyberu k hraniciam obrazka";
+"Enhance browser and Electron element snapping" = "Zlepšiť prichytenie prvkov v prehliadači a Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Vytvára strom dostupnosti cieľovej aplikácie v režime prvkov. Zakážte, ak sa prehliadač alebo Electron aplikácia stane pomalým alebo má problémy s vstupom.";
 "Capture mouse cursor in screenshot" = "Zachytit kurzor mysi na snimke obrazovky";
 "Double-click selection to copy" = "Kopirovat dvojklikom na vyber";
 "Hide capture instructions" = "Skryt pokyny pri snimani";

--- a/macshot/sr.lproj/Localizable.strings
+++ b/macshot/sr.lproj/Localizable.strings
@@ -185,15 +185,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Кликни на прозор  ·  Превуци за произвољну област  ·  F за цео екран";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Кликни на елемент  ·  Превуци за произвољну област  ·  F за цео екран";
 "Drag to select  ·  Click for full screen" = "Превуци за селекцију  ·  Кликни за цео екран";
 "Release to annotate and edit" = "Отпусти за означавање и уређивање";
 "Release to finish" = "Отпусти за завршетак";
 "Hold Space to move. Release to annotate and edit" = "Држи Размак за померање. Отпусти за означавање и уређивање";
 "Hold Space to move. Release to finish" = "Држи Размак за померање. Отпусти за завршетак";
 "Window snap: " = "Прилепљивање на прозор: ";
+"Snap mode: " = "Режим прилепљивања: ";
 "ON" = "УКЉУЧЕНО";
 "OFF" = "ИСКЉУЧЕНО";
+"WINDOW" = "ПРОЗОР";
+"ELEMENT" = "ЕЛЕМЕНТ";
 "  (Tab to toggle)" = "  (Tab за пребацивање)";
+"  (Tab to switch)" = "  (Tab за пребацивање)";
 "Space" = "Размак";
 "Right-click to copy" = "Десни клик за копирање";
 "Copied %@" = "Копирано %@";
@@ -228,6 +233,8 @@
 "Launch at login" = "Покрени при пријављивању";
 "Show snap alignment guides" = "Прикажи водиље за поравнање";
 "Snap selection edges to image boundaries" = "Привежи ивице избора уз границе слике";
+"Enhance browser and Electron element snapping" = "Побољшај лепљење елемената у прегледачу и Electron-у";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Гради стабло доступности циљне апликације у режиму елемената. Онемогућите ако прегледач или Electron апликација постане спора или има проблема са уносом.";
 "Capture mouse cursor in screenshot" = "Сними курсор миша на снимку екрана";
 "Double-click selection to copy" = "Копирај двокликом на селекцију";
 "Hide capture instructions" = "Сакриј упутства при снимању";

--- a/macshot/sv.lproj/Localizable.strings
+++ b/macshot/sv.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 
 /* Overlay / Canvas */
 "Click a window  \U00B7  Drag for custom area  \U00B7  F for full screen" = "Klicka p\U00E5 ett f\U00F6nster  \U00B7  Dra f\U00F6r eget omr\U00E5de  \U00B7  F f\U00F6r helsk\U00E4rm";
+"Click an element  \U00B7  Drag for custom area  \U00B7  F for full screen" = "Klicka p\U00E5 ett element  \U00B7  Dra f\U00F6r eget omr\U00E5de  \U00B7  F f\U00F6r helsk\U00E4rm";
 "Drag to select  \U00B7  Click for full screen" = "Dra f\U00F6r att markera  \U00B7  Klicka f\U00F6r helsk\U00E4rm";
 "Release to annotate and edit" = "Sl\U00E4pp f\U00F6r att anteckna och redigera";
 "Release to finish" = "Sl\U00E4pp f\U00F6r att avsluta";
@@ -183,9 +184,13 @@
 "Hold Space to move. Release to finish" = "H\U00E5ll mellanslag f\U00F6r att flytta. Sl\U00E4pp f\U00F6r att avsluta";
 "Space" = "Blanksteg";
 "Window snap: " = "F\U00F6nsterf\U00E5ngst: ";
+"Snap mode: " = "F\U00E5ngstl\U00E4ge: ";
 "ON" = "P\U00C5";
 "OFF" = "AV";
+"WINDOW" = "F\U00D6NSTER";
+"ELEMENT" = "ELEMENT";
 "  (Tab to toggle)" = "  (Tab f\U00F6r att v\U00E4xla)";
+"  (Tab to switch)" = "  (Tab f\U00F6r att v\U00E4xla)";
 "Right-click to copy" = "H\U00F6gerklicka f\U00F6r att kopiera";
 "Copied %@" = "Kopierade %@";
 "Set color %@" = "Valde f\U00E4rg %@";
@@ -222,6 +227,8 @@
 "Launch at login" = "Starta vid inloggning";
 "Show snap alignment guides" = "Visa f\U00E4stlinjer";
 "Snap selection edges to image boundaries" = "F\U00E4st markeringskanter mot bildgr\U00E4nser";
+"Enhance browser and Electron element snapping" = "F\U00F6rb\U00E4ttra elementf\U00E5ngst f\U00F6r webbl\U00E4sare och Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Bygger m\U00E5lappens tr\U00E4d f\U00F6r hj\U00E4lpmedel i Element-l\U00E4ge. Inaktivera detta om en webbl\U00E4sare eller Electron-app blir långsam eller har inmatningsproblem.";
 "Capture mouse cursor in screenshot" = "F\U00E5nga muspekaren i sk\U00E4rmbild";
 "Double-click selection to copy" = "Dubbelklicka p\U00E5 markeringen f\U00F6r att kopiera";
 "Hide capture instructions" = "D\U00F6lj instruktioner vid sk\U00E4rmbild";

--- a/macshot/ta.lproj/Localizable.strings
+++ b/macshot/ta.lproj/Localizable.strings
@@ -178,6 +178,13 @@
 "ON" = "இயக்கு";
 "OFF" = "நிறுத்து";
 "  (Tab to toggle)" = "  (மாற்ற Tab)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "ஒரு உறுப்பொருளைக் கிளிக் செய்  ·  தனிப்பயன் பகுதிக்கு இழு  ·  முழுத்திரைக்கு F";
+"Snap mode: " = "ஒட்டு முறை: ";
+"WINDOW" = "சாளரம்";
+"ELEMENT" = "உறுப்பொருள்";
+"  (Tab to switch)" = "  (மாற்ற Tab)";
+"Enhance browser and Electron element snapping" = "உலாவி மற்றும் எலக்ட்ரான் உறுப்பொருள் ஒட்டுதலை மேம்படுத்து";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "உறுப்பொருள் பயன்முறையில் இலக்கு செயலியின் அணுகல்தன்மை மரத்தை உருவாக்குகிறது. உலாவி அல்லது எலக்ட்ரான் செயலி மெதுவாகும் அல்லது உள்ளீட்டுச் சிக்கல்கள் இருந்தால் இதை முடக்கவும்.";
 "Right-click to copy" = "நகலெடுக்க வலது கிளிக் செய்";
 "Copied %@" = "%@ நகலெடுக்கப்பட்டது";
 "Set color %@" = "நிறம் %@ அமைக்கப்பட்டது";

--- a/macshot/th.lproj/Localizable.strings
+++ b/macshot/th.lproj/Localizable.strings
@@ -171,6 +171,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "คลิกที่หน้าต่าง  ·  ลากเพื่อเลือกพื้นที่  ·  F เพื่อเต็มจอ";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "คลิกที่องค์ประกอบ  ·  ลากเพื่อเลือกพื้นที่  ·  F เพื่อเต็มจอ";
 "Drag to select  ·  Click for full screen" = "ลากเพื่อเลือก  ·  คลิกเพื่อเต็มจอ";
 "Release to annotate and edit" = "ปล่อยเพื่อใส่คำอธิบายและแก้ไข";
 "Release to finish" = "ปล่อยเพื่อเสร็จสิ้น";
@@ -178,9 +179,13 @@
 "Hold Space to move. Release to finish" = "กด Space ค้างเพื่อย้าย ปล่อยเพื่อเสร็จสิ้น";
 "Space" = "Space";
 "Window snap: " = "จับหน้าต่าง: ";
+"Snap mode: " = "โหมดจับ: ";
 "ON" = "เปิด";
 "OFF" = "ปิด";
+"WINDOW" = "หน้าต่าง";
+"ELEMENT" = "องค์ประกอบ";
 "  (Tab to toggle)" = "  (Tab เพื่อสลับ)";
+"  (Tab to switch)" = "  (Tab เพื่อสลับ)";
 "Right-click to copy" = "คลิกขวาเพื่อคัดลอก";
 "Copied %@" = "คัดลอก %@ แล้ว";
 "Set color %@" = "ตั้งสี %@";
@@ -225,6 +230,8 @@
 "Launch at login" = "เปิดเมื่อเข้าสู่ระบบ";
 "Show snap alignment guides" = "แสดงเส้นจัดแนว";
 "Snap selection edges to image boundaries" = "ดูดขอบพื้นที่เลือกเข้ากับขอบเขตของภาพ";
+"Enhance browser and Electron element snapping" = "เพิ่มการจับองค์ประกอบของเบราว์เซอร์และ Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "สร้าง accessibility tree ของแอปเป้าหมายในโหมดองค์ประกอบ ปิดการใช้งานนี้หากเบราว์เซอร์หรือแอป Electron ทำงานช้ากว่าปกติหรือมีปัญหาในการรับข้อมูล";
 "Capture mouse cursor in screenshot" = "จับภาพเคอร์เซอร์เมาส์ในภาพหน้าจอ";
 "Double-click selection to copy" = "ดับเบิลคลิกที่พื้นที่ที่เลือกเพื่อคัดลอก";
 "Hide capture instructions" = "ซ่อนคำแนะนำการจับภาพหน้าจอ";

--- a/macshot/tr.lproj/Localizable.strings
+++ b/macshot/tr.lproj/Localizable.strings
@@ -174,6 +174,13 @@
 "ON" = "AÇIK";
 "OFF" = "KAPALI";
 "  (Tab to toggle)" = "  (Değiştirmek için Tab)";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Bir öğeye tıklayın  ·  Özel alan için sürükleyin  ·  Tam ekran için F";
+"Snap mode: " = "Yakalama modu: ";
+"WINDOW" = "PENCERE";
+"ELEMENT" = "ÖĞE";
+"  (Tab to switch)" = "  (Değiştirmek için Tab)";
+"Enhance browser and Electron element snapping" = "Tarayıcı ve Electron öğe yakalamasını geliştir";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Hedef uygulamanın erişilebilirlik ağacını Öğe modunda oluşturur. Bir tarayıcı veya Electron uygulaması yavaşlarsa veya giriş sorunları yaşarsa bunu devre dışı bırakın.";
 "Right-click to copy" = "Kopyalamak için sağ tıklayın";
 "Copied %@" = "%@ kopyalandı";
 "Set color %@" = "Renk ayarlandı %@";

--- a/macshot/uk.lproj/Localizable.strings
+++ b/macshot/uk.lproj/Localizable.strings
@@ -185,15 +185,20 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Клацніть вікно  ·  Перетягніть для довільної області  ·  F для повного екрана";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Клацніть елемент  ·  Перетягніть для довільної області  ·  F для повного екрана";
 "Drag to select  ·  Click for full screen" = "Перетягніть для вибору  ·  Клацніть для повного екрана";
 "Release to annotate and edit" = "Відпустіть для анотації та редагування";
 "Release to finish" = "Відпустіть для завершення";
 "Hold Space to move. Release to annotate and edit" = "Утримуйте Пробіл для переміщення. Відпустіть для анотації та редагування";
 "Hold Space to move. Release to finish" = "Утримуйте Пробіл для переміщення. Відпустіть для завершення";
 "Window snap: " = "Прилипання до вікна: ";
+"Snap mode: " = "Режим прилипання: ";
 "ON" = "УВІМК.";
 "OFF" = "ВИМК.";
+"WINDOW" = "ВІКНО";
+"ELEMENT" = "ЕЛЕМЕНТ";
 "  (Tab to toggle)" = "  (Tab для перемикання)";
+"  (Tab to switch)" = "  (Tab для перемикання)";
 "Space" = "Пробіл";
 "Right-click to copy" = "Клацніть правою кнопкою, щоб копіювати";
 "Copied %@" = "Скопійовано %@";
@@ -228,6 +233,8 @@
 "Launch at login" = "Запускати при вході в систему";
 "Show snap alignment guides" = "Показувати напрямні вирівнювання";
 "Snap selection edges to image boundaries" = "Прив'язувати краї виділення до меж зображення";
+"Enhance browser and Electron element snapping" = "Покращення прилипання елементів у браузері та Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Будує дерево доступності цільової програми в режимі елементів. Вимкніть, якщо браузер або Electron-програма працює повільно або має проблеми з введенням.";
 "Capture mouse cursor in screenshot" = "Захоплювати курсор миші на знімку екрана";
 "Double-click selection to copy" = "Копіювати подвійним клацанням по виділенню";
 "Hide capture instructions" = "Приховувати підказки під час захоплення";

--- a/macshot/vi.lproj/Localizable.strings
+++ b/macshot/vi.lproj/Localizable.strings
@@ -171,6 +171,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "Nhấp vào cửa sổ  ·  Kéo để chọn vùng  ·  F để toàn màn hình";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "Nhấp vào phần tử  ·  Kéo để chọn vùng  ·  F để toàn màn hình";
 "Drag to select  ·  Click for full screen" = "Kéo để chọn  ·  Nhấp để toàn màn hình";
 "Release to annotate and edit" = "Thả chuột để chú thích và chỉnh sửa";
 "Release to finish" = "Thả chuột để hoàn tất";
@@ -178,9 +179,13 @@
 "Hold Space to move. Release to finish" = "Giữ Space để di chuyển. Thả chuột để hoàn tất";
 "Space" = "Space";
 "Window snap: " = "Bắt cửa sổ: ";
+"Snap mode: " = "Chế độ bắt: ";
 "ON" = "BẬT";
 "OFF" = "TẮT";
+"WINDOW" = "CỬA SỔ";
+"ELEMENT" = "PHẦN TỬ";
 "  (Tab to toggle)" = "  (Tab để chuyển)";
+"  (Tab to switch)" = "  (Tab để chuyển đổi)";
 "Right-click to copy" = "Nhấp chuột phải để sao chép";
 "Copied %@" = "Đã sao chép %@";
 "Set color %@" = "Đặt màu %@";
@@ -225,6 +230,8 @@
 "Launch at login" = "Khởi chạy khi đăng nhập";
 "Show snap alignment guides" = "Hiển thị đường căn chỉnh bắt dính";
 "Snap selection edges to image boundaries" = "Bắt dính cạnh vùng chọn vào ranh giới ảnh";
+"Enhance browser and Electron element snapping" = "Nâng cao bắt dính phần tử trình duyệt và Electron";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "Xây dựng cây khả năng truy cập của ứng dụng đích trong Chế độ phần tử. Tắt tính năng này nếu trình duyệt hoặc ứng dụng Electron trở nên chậm hoặc gặp sự cố nhập liệu.";
 "Capture mouse cursor in screenshot" = "Chụp con trỏ chuột trong ảnh";
 "Double-click selection to copy" = "Nhấp đúp vào vùng chọn để sao chép";
 "Hide capture instructions" = "Ẩn hướng dẫn chụp màn hình";

--- a/macshot/zh-Hans.lproj/Localizable.strings
+++ b/macshot/zh-Hans.lproj/Localizable.strings
@@ -165,6 +165,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "点按窗口  ·  拖拽自定义区域  ·  F 全屏";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "点按元素  ·  拖拽自定义区域  ·  F 全屏";
 "Drag to select  ·  Click for full screen" = "拖拽选择  ·  点按全屏捕获";
 "Release to annotate and edit" = "松开以标注和编辑";
 "Release to finish" = "松开以完成";
@@ -172,9 +173,13 @@
 "Hold Space to move. Release to finish" = "按住空格键移动。松开以完成";
 "Space" = "空格";
 "Window snap: " = "窗口吸附: ";
+"Snap mode: " = "吸附模式: ";
 "ON" = "开";
 "OFF" = "关";
+"WINDOW" = "窗口";
+"ELEMENT" = "元素";
 "  (Tab to toggle)" = "  (Tab 切换)";
+"  (Tab to switch)" = "  (Tab 切换)";
 "Right-click to copy" = "右键点按拷贝";
 "Copied %@" = "已拷贝 %@";
 "Set color %@" = "设置颜色 %@";
@@ -208,6 +213,8 @@
 "Launch at login" = "登录时启动";
 "Show snap alignment guides" = "显示对齐辅助线";
 "Snap selection edges to image boundaries" = "将选区边缘吸附到图像边界";
+"Enhance browser and Electron element snapping" = "增强浏览器和 Electron 元素吸附";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "在元素模式下构建目标应用的辅助功能树。如果浏览器或 Electron 应用变慢或出现输入问题，请关闭此选项。";
 "Capture mouse cursor in screenshot" = "在截图中捕获鼠标指针";
 "Double-click selection to copy" = "双击选区以复制";
 "Hide capture instructions" = "隐藏截图操作提示";

--- a/macshot/zh-Hant.lproj/Localizable.strings
+++ b/macshot/zh-Hant.lproj/Localizable.strings
@@ -171,6 +171,7 @@
 
 /* Overlay / Canvas */
 "Click a window  ·  Drag for custom area  ·  F for full screen" = "點按視窗  ·  拖移以自訂區域  ·  F 全螢幕";
+"Click an element  ·  Drag for custom area  ·  F for full screen" = "點按元素  ·  拖移以自訂區域  ·  F 全螢幕";
 "Drag to select  ·  Click for full screen" = "拖移以選取  ·  點按以全螢幕";
 "Release to annotate and edit" = "放開以標註與編輯";
 "Release to finish" = "放開以完成";
@@ -178,9 +179,13 @@
 "Hold Space to move. Release to finish" = "按住空白鍵以移動。放開以完成";
 "Space" = "空白鍵";
 "Window snap: " = "視窗吸附：";
+"Snap mode: " = "吸附模式：";
 "ON" = "開";
 "OFF" = "關";
+"WINDOW" = "視窗";
+"ELEMENT" = "元素";
 "  (Tab to toggle)" = "  （Tab 切換）";
+"  (Tab to switch)" = "  （Tab 切換）";
 "Right-click to copy" = "右鍵點按以拷貝";
 "Copied %@" = "已拷貝 %@";
 "Set color %@" = "設定顏色 %@";
@@ -225,6 +230,8 @@
 "Launch at login" = "登入時啟動";
 "Show snap alignment guides" = "顯示對齊輔助線";
 "Snap selection edges to image boundaries" = "將選取範圍邊緣貼齊影像邊界";
+"Enhance browser and Electron element snapping" = "增強瀏覽器與 Electron 元素吸附";
+"Builds the target app's accessibility tree in Element mode. Disable this if a browser or Electron app becomes slow or has input issues." = "在元素模式下建立目標應用程式的輔助使用樹狀結構。如果瀏覽器或 Electron 應用程式變慢或出現輸入問題，請關閉此選項。";
 "Capture mouse cursor in screenshot" = "在螢幕截圖中擷取滑鼠游標";
 "Double-click selection to copy" = "雙擊選取範圍以複製";
 "Hide capture instructions" = "隱藏截圖操作提示";


### PR DESCRIPTION
## Summary

- cycle capture snapping through Window, Element, and Off with Tab while preserving the legacy preference as a migration fallback
- add small-control snapping for native apps through bounded Accessibility element traversal
- improve Chromium and Electron element exposure behind a default-on setting that users can disable if an app becomes slow or develops input issues

## Current implementation

- uses AppKit and Apple Accessibility APIs only, with no new dependency
- performs bounded deep traversal on a background queue and coalesces pointer updates to keep capture interaction responsive
- keeps whole-window snaps on the independent transparent-window capture path while element snaps use ordinary screen crops
- requests manual and enhanced accessibility once per target process per capture session and adds narrowly scoped sandbox access to com.apple.axserver
- localizes the new mode and browser enhancement UI text across all 39 supported locales

## Review follow-ups

- restores each target app's prior AXManualAccessibility/AXEnhancedUserInterface values when the capture session ends, so browser enhancement no longer outlives the capture
- retries element queries on a short bounded schedule (0.1s/0.5s/2.1s) after first-time Chromium/Electron accessibility activation, so the highlight settles on the element without requiring pointer movement
- applies AX messaging timeouts to each traversed element instead of only the application object, keeping traversal responsive with slow targets
- skips nodes reporting kAXHiddenAttribute during descendant traversal so hidden elements cannot win over the visible hit

## Validation

- Release xcodebuild succeeded on a clean branch based on origin/main
- isolated Chrome runtime probe changed the same point from AXScrollArea to the AXButton titled Tiny button, and macshot returned the expected 90 x 26 element rectangle
- with browser enhancement disabled, the same isolated probe remained AXScrollArea
- native application element snapping was manually verified, including small controls
- the signed Release deployment reported AXIsProcessTrusted as true
- localization and entitlement plists passed plutil validation, and git diff --check passed
- all 39 Localizable.strings files pass `plutil -lint` and the 7 new keys match the Swift call sites byte-for-byte
- the build still reports pre-existing repository Swift concurrency and unused-variable warnings; this change introduces no build failure
- cross-process Accessibility and multi-monitor behavior do not have an automated test seam; multi-monitor hardware validation was not performed in this environment

## Maintainer feedback welcome

I saw that CONTRIBUTING.md asks contributors to discuss new features before implementation. Since the implementation and PR already exist, I am presenting the current code as a concrete proposal for review rather than opening a duplicate implementation discussion now.

Would this snapping behavior and current implementation be acceptable for macshot? I am happy to change, simplify, or rework any part based on maintainer preferences. It is also completely fine to close or reject the PR if the feature does not fit the project direction.
