### PR TITLE
Add File menu with Close Window (⌘W)

### DIFF
--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -590,6 +590,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         appMenu.addItem(withTitle: "Quit macshot", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
         appMenuItem.submenu = appMenu
 
+        let fileMenuItem = NSMenuItem()
+        mainMenu.addItem(fileMenuItem)
+
+        let fileMenu = NSMenu(title: "File")
+        // Standard Close Window (Cmd+W) — routes to NSWindow.performClose(_:) via the
+        // responder chain, so it closes whichever window is key (editor, settings, etc.)
+        // without any window-specific handling.
+        fileMenu.addItem(withTitle: "Close Window", action: #selector(NSWindow.performClose(_:)), keyEquivalent: "w")
+        fileMenuItem.submenu = fileMenu
+
         let editMenuItem = NSMenuItem()
         mainMenu.addItem(editMenuItem)
 


### PR DESCRIPTION
## What

Adds a standard **File** menu with a **Close Window (⌘W)** item, wired to `NSWindow.performClose(_:)`.

## Why

The video editor / preview window doesn't respond to ⌘W — there's no `File` menu in `setupMainMenu()`
and no `Close Window` menu item anywhere in the app, so the keyboard shortcut has nothing to route to.
`performClose:` is the standard AppKit action; routing it through the responder chain means it closes
whichever window is currently key, not just the editor.

## Testing

I don't have a full Xcode install on this machine, so I could not build and run the app to confirm
⌘W closes the window end-to-end. I did verify the change parses cleanly with `swiftc -parse` and that
`NSWindow.performClose(_:)` / the `#selector` usage match the existing patterns already in this file
(e.g. `NSApplication.terminate(_:)` a few lines above). Happy to test properly if someone can confirm
it builds, or if a maintainer wants to verify before merging.


Note: #363 concerns remembered video export defaults and is unrelated to this change.