### PR TITLE
feat: add letterbox thumbnail preview option

### DIFF
--- a/macshot/UI/Windows/FloatingThumbnailController.swift
+++ b/macshot/UI/Windows/FloatingThumbnailController.swift
@@ -708,6 +708,7 @@ private class ThumbnailView: NSView {
 
     private var image: NSImage
     private let thumbSize: NSSize
+    private let fitsImageInPreview = UserDefaults.standard.bool(forKey: "thumbnailLetterbox")
     private var dragStartScreenPoint: NSPoint?
     private var dragMode: DragMode = .idle
     private var dismissDragOffset: CGFloat = 0
@@ -845,24 +846,15 @@ private class ThumbnailView: NSView {
         let path = NSBezierPath(roundedRect: r, xRadius: cr, yRadius: cr)
         path.addClip()
 
-        // Dark background (visible as letterbox bars for extreme aspect ratios)
+        // Dark background doubles as the letterbox surface when fitting the image.
         NSColor(white: 0.12, alpha: 1.0).setFill()
         NSBezierPath(roundedRect: r, xRadius: cr, yRadius: cr).fill()
 
-        // Draw image with aspect fill (cropped to fill, no letterboxing)
-        let imgAspect = image.size.width / image.size.height
-        let viewAspect = r.width / r.height
-        var drawW: CGFloat
-        var drawH: CGFloat
-        if imgAspect > viewAspect {
-            // Image is wider than view — fill height, crop sides
-            drawH = r.height
-            drawW = drawH * imgAspect
-        } else {
-            // Image is taller than view — fill width, crop top/bottom
-            drawW = r.width
-            drawH = drawW / imgAspect
-        }
+        let scale = fitsImageInPreview
+            ? min(r.width / image.size.width, r.height / image.size.height)
+            : max(r.width / image.size.width, r.height / image.size.height)
+        let drawW = image.size.width * scale
+        let drawH = image.size.height * scale
         let drawRect = NSRect(
             x: r.midX - drawW / 2,
             y: r.midY - drawH / 2,

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -62,6 +62,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     private var thumbnailAutoDismissField: NSTextField!
     private var thumbnailStackingPopup: NSPopUpButton!
     private var thumbnailCornerPopup: NSPopUpButton!
+    private var thumbnailLetterboxCheckbox: NSButton!
     private var historyUnlimitedCheckbox: NSButton!
     private var historyOrderByLastEditCheckbox: NSButton!
     private var thumbnailScaleLabel: NSTextField!
@@ -835,6 +836,14 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         thumbnailScaleLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
         thumbnailScaleLabel.textColor = .secondaryLabelColor
         stack.addArrangedSubview(indented(labeledRow(L("  Preview size:"), controls: [sizeSlider, thumbnailScaleLabel])))
+        stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
+
+        thumbnailLetterboxCheckbox = NSButton(
+            checkboxWithTitle: L("Fit image in preview (letterbox)"),
+            target: self,
+            action: #selector(thumbnailLetterboxChanged(_:))
+        )
+        stack.addArrangedSubview(indented(thumbnailLetterboxCheckbox))
         stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
 
         stack.addArrangedSubview(indented(snapGuidesCheckbox))
@@ -2394,6 +2403,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
 
         let thumbnail = UserDefaults.standard.object(forKey: "showFloatingThumbnail") as? Bool ?? true
         thumbnailCheckbox.state = thumbnail ? .on : .off
+        thumbnailLetterboxCheckbox.state = UserDefaults.standard.bool(forKey: "thumbnailLetterbox") ? .on : .off
 
         let autoDismiss = UserDefaults.standard.object(forKey: "thumbnailAutoDismiss") as? Int ?? 5
         thumbnailAutoDismissField.integerValue = autoDismiss
@@ -2597,6 +2607,9 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     @objc private func thumbnailScaleChanged(_ sender: NSSlider) {
         UserDefaults.standard.set(sender.doubleValue, forKey: "thumbnailScale")
         thumbnailScaleLabel?.stringValue = scalePercentString(sender.doubleValue)
+    }
+    @objc private func thumbnailLetterboxChanged(_ sender: NSButton) {
+        UserDefaults.standard.set(sender.state == .on, forKey: "thumbnailLetterbox")
     }
 
     private func scalePercentString(_ scale: Double) -> String {

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -543,6 +543,7 @@
 "Shape:" = "Shape:";
 "Same as screenshots" = "Same as screenshots";
 "  Preview size:" = "  Preview size:";
+"Fit image in preview (letterbox)" = "Fit image in preview (letterbox)";
 "(0 = off)" = "(0 = off)";
 "Clear All" = "Clear All";
 "Clear History?" = "Clear History?";


### PR DESCRIPTION
Very wide and tall captures are heavily cropped in the fixed-size floating thumbnail, which makes the preview less useful. This adds an opt-in **Fit image in preview (letterbox)** setting while keeping the current aspect-fill behavior as the default.

## Test plan

- [x] Built Debug and Release configurations with `xcodebuild`; installed the Release app and confirmed it launches.
