### PR TITLE
Fix leaked SCStream when recording setup fails

### DIFF
--- a/macshot/Capture/RecordingEngine.swift
+++ b/macshot/Capture/RecordingEngine.swift
@@ -216,6 +216,15 @@ final class RecordingEngine: NSObject {
             self.streamOutput = output
 
             let stream = SCStream(filter: filter, configuration: config, delegate: output)
+            // Take ownership before the stream can go live. Everything below can
+            // throw, and the task can be cancelled — both `finalizeCapture()` and
+            // the `catch` need a handle to call `stopCapture()` on. Assigning only
+            // after `startCapture()` leaves a window where the local `stream`
+            // deallocates while the daemon is already capturing. replayd then
+            // pushes frames into a dead queue for the lifetime of the login
+            // session (err=-16665 "Client terminated the queue"), once per frame
+            // interval, with no way to stop it short of killing replayd.
+            self.stream = stream
             try stream.addStreamOutput(output, type: .screen, sampleHandlerQueue: recordingQueue)
             if #available(macOS 13.0, *) {
                 let recordAudio = UserDefaults.standard.bool(forKey: "recordSystemAudio")
@@ -224,7 +233,6 @@ final class RecordingEngine: NSObject {
                 }
             }
             try await stream.startCapture()
-            self.stream = stream
 
             // Start mic capture if enabled and authorized (permission resolved before capture started)
             if UserDefaults.standard.bool(forKey: "recordMicAudio") &&
@@ -242,6 +250,12 @@ final class RecordingEngine: NSObject {
             }
 
         } catch {
+            // Never leave a started stream running behind a failed setup.
+            if let stream = self.stream {
+                try? await stream.stopCapture()
+                self.stream = nil
+            }
+            self.streamOutput = nil
             await MainActor.run { self.fail(error) }
         }
     }


### PR DESCRIPTION
### What's broken

`RecordingEngine.beginCapture()` assigns `self.stream` only after the stream is already running:

```swift
try await stream.startCapture()
self.stream = stream
```

Between these two lines the stream is live on daemon side, but engine has no handle on it. If something throws there, or task gets cancelled, local `stream` goes out of scope and deallocates. `finalizeCapture()` is guarded by `if let stream = stream`, so teardown is skipped. `fail()` does not touch the stream either.

Client-side queue dies with the object, daemon keeps capturing. Nothing can stop it anymore.

### Evidence

Hit this on my machine, 4.2.1 on macOS 13.7.5, after 18 days uptime. From 20:00:46 until I power-cycled, replayd was doing this non stop:

```
replayd [ERROR] _SCRemoteQueue_Enqueue:206 remoteQueue=0x125404a10 err=-16665 opType=3 Client terminated the queue
replayd [ERROR] SCRemoteQueue_EnqueueSampleBuffer:236 Error occurred when sending the sample buffer. err=-16665
```

- ~50 events/sec, steady, 31 minutes, stopped only on reboot
- **two** distinct `remoteQueue` addresses — two leaked streams, not one
- 98679 log lines in 17 min sample = 42% of all system logging on the box
- macshot process itself never crashed, it was alive the whole time. So not an orphan-after-crash, app simply lost the handle

`killall replayd` was the only cure.

### Fix

Assign `self.stream` right after `SCStream(...)` init, before anything that can throw. Add teardown to the `catch`.

### Checklist — honest version

- [ ] **Builds without warnings — I could not build.** `objectVersion = 77` needs Xcode 16+, I am on macOS 13.7.5 / Xcode 14.3. `swiftc -parse` on the file is clean, but that is syntax only, no type check.
- [ ] **Tested manually — no**, same reason.
- [x] Does not break existing behaviour — assignment only moves earlier, `finalizeCapture()` untouched and still nils it.

So please treat as untested patch, reasoning is from source + logs. If you prefer different approach (e.g. explicit `defer`, or teardown helper shared with `finalizeCapture()`), lmk and I redo it.
