### PR TITLE
Add sandboxed App Shot capture with OCR context

### DIFF
--- a/Tests/AppShotCaptureCoordinatorTests.swift
+++ b/Tests/AppShotCaptureCoordinatorTests.swift
@@ -3,10 +3,53 @@ import Foundation
 @main
 struct AppShotCaptureCoordinatorTests {
     static func main() async {
+        await presentsImageBeforeRecognitionCompletes()
         await publishesCompletedCapture()
         await reportsClipboardPublicationFailure()
         await resetsAdmissionAfterCaptureFailure()
         await rejectsOverlappingCapture()
+    }
+
+    @MainActor
+    private static func presentsImageBeforeRecognitionCompletes() async {
+        let recognitionGate = AsyncGate()
+        var events: [String] = []
+        let coordinator = AppShotCaptureCoordinator<Int, String>(
+            captureImage: { _ in
+                events.append("captured")
+                return "pixels"
+            },
+            onImageCaptured: { target, image in
+                precondition(target == 42)
+                precondition(image == "pixels")
+                events.append("presented")
+            },
+            recognizeText: { _ in
+                events.append("recognition started")
+                await recognitionGate.wait()
+                events.append("recognition finished")
+                return "visible text"
+            },
+            publish: { _ in
+                events.append("published")
+                return true
+            }
+        )
+
+        let capture = Task { await coordinator.capture(target: 42) }
+        await Task.yield()
+
+        precondition(events == ["captured", "presented", "recognition started"])
+        await recognitionGate.open()
+        let result = await capture.value
+        precondition(result == .completed)
+        precondition(events == [
+            "captured",
+            "presented",
+            "recognition started",
+            "recognition finished",
+            "published",
+        ])
     }
 
     @MainActor

--- a/Tests/AppShotCaptureCoordinatorTests.swift
+++ b/Tests/AppShotCaptureCoordinatorTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+@main
+struct AppShotCaptureCoordinatorTests {
+    static func main() async {
+        await publishesCompletedCapture()
+        await reportsClipboardPublicationFailure()
+        await resetsAdmissionAfterCaptureFailure()
+        await rejectsOverlappingCapture()
+    }
+
+    @MainActor
+    private static func publishesCompletedCapture() async {
+        var published: AppShotCaptureCoordinator<Int, String>.Content?
+        let coordinator = AppShotCaptureCoordinator<Int, String>(
+            captureImage: { _ in "pixels" },
+            recognizeText: { _ in "visible text" },
+            publish: {
+                published = $0
+                return true
+            }
+        )
+
+        let result = await coordinator.capture(
+            target: 42,
+            capturedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        precondition(result == .completed)
+        precondition(published?.target == 42)
+        precondition(published?.image == "pixels")
+        precondition(published?.recognizedText == "visible text")
+        precondition(published?.capturedAt == Date(timeIntervalSince1970: 0))
+        precondition(!coordinator.isCapturing)
+    }
+
+    @MainActor
+    private static func reportsClipboardPublicationFailure() async {
+        var publicationFinished = false
+        let coordinator = AppShotCaptureCoordinator<Int, String>(
+            captureImage: { _ in "pixels" },
+            recognizeText: { _ in "visible text" },
+            publish: { _ in
+                await Task.yield()
+                publicationFinished = true
+                return false
+            }
+        )
+
+        let result = await coordinator.capture(target: 42)
+
+        precondition(publicationFinished)
+        precondition(result == .clipboardPublicationFailed)
+        precondition(!coordinator.isCapturing)
+    }
+
+    @MainActor
+    private static func resetsAdmissionAfterCaptureFailure() async {
+        var attempts = 0
+        let coordinator = AppShotCaptureCoordinator<Int, String>(
+            captureImage: { _ in
+                attempts += 1
+                return attempts == 1 ? nil : "pixels"
+            },
+            recognizeText: { _ in "visible text" },
+            publish: { _ in true }
+        )
+
+        let failed = await coordinator.capture(target: 42)
+        precondition(failed == .imageCaptureFailed)
+        precondition(!coordinator.isCapturing)
+        let retried = await coordinator.capture(target: 42)
+        precondition(retried == .completed)
+    }
+
+    @MainActor
+    private static func rejectsOverlappingCapture() async {
+        let gate = AsyncGate()
+        let coordinator = AppShotCaptureCoordinator<Int, String>(
+            captureImage: { _ in
+                await gate.wait()
+                return "pixels"
+            },
+            recognizeText: { _ in "visible text" },
+            publish: { _ in true }
+        )
+
+        let first = Task { await coordinator.capture(target: 42) }
+        await Task.yield()
+        precondition(coordinator.isCapturing)
+        let overlapping = await coordinator.capture(target: 42)
+        precondition(overlapping == .captureInProgress)
+        await gate.open()
+        let firstResult = await first.value
+        precondition(firstResult == .completed)
+        precondition(!coordinator.isCapturing)
+    }
+}
+
+private actor AsyncGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func open() {
+        continuation?.resume()
+        continuation = nil
+    }
+}

--- a/Tests/AppShotClipboardPublisherTests.swift
+++ b/Tests/AppShotClipboardPublisherTests.swift
@@ -1,0 +1,165 @@
+import Cocoa
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    guard condition() else {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+@main
+struct AppShotClipboardPublisherTests {
+    @MainActor
+    static func main() async throws {
+        try await publishesImageThenContextDocumentAsSeparateClipboardStates()
+        await publishesContextAfterClipboardHistoryEnrichesTheImageState()
+        await doesNotOverwriteAClipboardChangedBeforeContextPublication()
+        await newerAppShotGenerationRejectsOlderContextPublication()
+        await reportsContextDocumentWriteFailure()
+        await productionPublicationUsesTheHistorySeparationDelay()
+    }
+
+    @MainActor
+    private static func publishesContextAfterClipboardHistoryEnrichesTheImageState() async {
+        let pasteboard = NSPasteboard.withUniqueName()
+        let historyMetadataType = NSPasteboard.PasteboardType("com.example.clipboard-history-metadata")
+        let generation = AppShotClipboardPublisher.beginPublication()
+
+        let result = await AppShotClipboardPublisher.publish(
+            to: pasteboard,
+            generation: generation,
+            backingURL: nil,
+            pngData: Data([0x01]),
+            tiffData: nil,
+            markdown: "# App Shot",
+            wait: {
+                pasteboard.clearContents()
+                pasteboard.declareTypes([.png, historyMetadataType], owner: nil)
+                pasteboard.setData(Data([0x01]), forType: .png)
+                pasteboard.setString("history metadata", forType: historyMetadataType)
+            }
+        )
+
+        expect(result, "clipboard-history metadata must not cancel Context Document publication")
+        expect(
+            pasteboard.string(forType: .string) == "# App Shot",
+            "Context Document must become current after clipboard-history enrichment"
+        )
+    }
+
+    @MainActor
+    private static func publishesImageThenContextDocumentAsSeparateClipboardStates() async throws {
+        let pasteboard = NSPasteboard.withUniqueName()
+        let backingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macshot-appshot-clipboard-\(UUID()).png")
+        try Data([0x03]).write(to: backingURL)
+        defer { try? FileManager.default.removeItem(at: backingURL) }
+        let generation = AppShotClipboardPublisher.beginPublication()
+
+        let result = await AppShotClipboardPublisher.publish(
+            to: pasteboard,
+            generation: generation,
+            backingURL: backingURL,
+            pngData: Data([0x01]),
+            tiffData: Data([0x02]),
+            markdown: "# App Shot",
+            wait: {
+                expect(pasteboard.data(forType: .png) == Data([0x01]), "first state must contain the Window Image")
+                expect(pasteboard.data(forType: .tiff) == Data([0x02]), "first state must contain TIFF when available")
+                expect(pasteboard.string(forType: .fileURL) != nil, "first state must retain its backing file URL")
+                expect(pasteboard.string(forType: .string) == nil, "first state must not contain Context Document text")
+            }
+        )
+
+        expect(result, "publication must report success after the Context Document is current")
+        expect(pasteboard.string(forType: .string) == "# App Shot", "current state must contain plain text")
+        expect(
+            pasteboard.string(forType: ImagePasteboardWriter.markdownType) == "# App Shot",
+            "current state must contain Markdown"
+        )
+        expect(pasteboard.data(forType: .png) == nil, "current state must be text-only")
+    }
+
+    @MainActor
+    private static func doesNotOverwriteAClipboardChangedBeforeContextPublication() async {
+        let pasteboard = NSPasteboard.withUniqueName()
+        let generation = AppShotClipboardPublisher.beginPublication()
+
+        let result = await AppShotClipboardPublisher.publish(
+            to: pasteboard,
+            generation: generation,
+            backingURL: nil,
+            pngData: Data([0x01]),
+            tiffData: nil,
+            markdown: "# App Shot",
+            wait: {
+                pasteboard.clearContents()
+                pasteboard.setString("newer clipboard content", forType: .string)
+            }
+        )
+
+        expect(!result, "stale Context Document publication must be rejected")
+        expect(
+            pasteboard.string(forType: .string) == "newer clipboard content",
+            "stale publication must preserve newer clipboard content"
+        )
+    }
+
+    @MainActor
+    private static func newerAppShotGenerationRejectsOlderContextPublication() async {
+        let pasteboard = NSPasteboard.withUniqueName()
+        let olderGeneration = AppShotClipboardPublisher.beginPublication()
+
+        let result = await AppShotClipboardPublisher.publish(
+            to: pasteboard,
+            generation: olderGeneration,
+            backingURL: nil,
+            pngData: Data([0x01]),
+            tiffData: nil,
+            markdown: "older context",
+            wait: {
+                _ = AppShotClipboardPublisher.beginPublication()
+            }
+        )
+
+        expect(!result, "a newer App Shot generation must reject older Context Document publication")
+        expect(pasteboard.string(forType: .string) == nil, "older Context Document must not become current")
+    }
+
+    @MainActor
+    private static func reportsContextDocumentWriteFailure() async {
+        let pasteboard = NSPasteboard.withUniqueName()
+        let generation = AppShotClipboardPublisher.beginPublication()
+
+        let result = await AppShotClipboardPublisher.publish(
+            to: pasteboard,
+            generation: generation,
+            backingURL: nil,
+            pngData: Data([0x01]),
+            tiffData: nil,
+            markdown: "# App Shot",
+            wait: {},
+            writeContext: { _, _ in false }
+        )
+
+        expect(!result, "publication must report a failed Context Document write")
+    }
+
+    @MainActor
+    private static func productionPublicationUsesTheHistorySeparationDelay() async {
+        let pasteboard = NSPasteboard.withUniqueName()
+        let generation = AppShotClipboardPublisher.beginPublication()
+        let startedAt = Date()
+
+        let result = await AppShotClipboardPublisher.publish(
+            to: pasteboard,
+            generation: generation,
+            backingURL: nil,
+            pngData: Data([0x01]),
+            tiffData: nil,
+            markdown: "# App Shot"
+        )
+
+        expect(result, "production publication must succeed")
+        expect(Date().timeIntervalSince(startedAt) >= 0.9, "production publication must preserve clipboard-history separation")
+    }
+}

--- a/Tests/ContextCapturePayloadTests.swift
+++ b/Tests/ContextCapturePayloadTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+@main
+struct ContextCapturePayloadTests {
+    static func main() {
+        let date = Date(timeIntervalSince1970: 0)
+        let payload = ContextCapturePayload(
+            applicationName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            windowTitle: "Project > Plan",
+            capturedAt: date,
+            recognizedText: "First line\nSecond line"
+        )
+
+        let expected = """
+        # App Shot
+
+        - Application: Notes
+        - Bundle ID: com.apple.Notes
+        - Window: Project > Plan
+        - Captured: 1970-01-01T00:00:00Z
+
+        ## Recognized Text
+
+        First line
+        Second line
+        """
+
+        precondition(payload.markdown == expected, "Unexpected Markdown:\n\(payload.markdown)")
+
+        let empty = ContextCapturePayload(
+            applicationName: "Finder",
+            bundleIdentifier: nil,
+            windowTitle: nil,
+            capturedAt: date,
+            recognizedText: "  \n"
+        )
+        precondition(empty.markdown.contains("- Bundle ID: Unavailable"))
+        precondition(empty.markdown.contains("- Window: Untitled"))
+        precondition(empty.markdown.hasSuffix("No text was recognized."))
+
+        let multilineMetadata = ContextCapturePayload(
+            applicationName: "Example\nApplication",
+            bundleIdentifier: " com.example.app ",
+            windowTitle: "First\nSecond",
+            capturedAt: date,
+            recognizedText: "Visible"
+        )
+        precondition(multilineMetadata.markdown.contains("- Application: Example Application"))
+        precondition(multilineMetadata.markdown.contains("- Bundle ID: com.example.app"))
+        precondition(multilineMetadata.markdown.contains("- Window: First Second"))
+    }
+}

--- a/Tests/FrontmostWindowSelectionTests.swift
+++ b/Tests/FrontmostWindowSelectionTests.swift
@@ -1,0 +1,142 @@
+import CoreGraphics
+import Foundation
+
+@main
+struct FrontmostWindowSelectionTests {
+    static func main() {
+        prefersFrontmostApplicationAndFrontmostWindow()
+        skipsTinyGenericAuxiliaryWindowWhenNormalWindowFollows()
+        keepsLegitimateCompactWindowsEligible()
+        fallsBackToTopNonSelfWindowWhenMenuOwnsFocus()
+        rejectsIneligibleAndOffscreenWindows()
+        choosesDisplayWithLargestIntersection()
+    }
+
+    private static func skipsTinyGenericAuxiliaryWindowWhenNormalWindowFollows() {
+        let windows = [
+            candidate(id: 50, pid: 200, x: 402, y: 109, width: 66, height: 20, title: "Window"),
+            candidate(id: 51, pid: 200, x: 396, y: 103, width: 720, height: 672, title: "Mac Appshot Source Fixture"),
+        ]
+        let selection = FrontmostWindowSelection.select(
+            windows: windows,
+            displays: [display(id: 1, x: 0)],
+            ownPID: 100,
+            preferredPID: 200
+        )
+        precondition(selection?.window.id == 51)
+    }
+
+    private static func keepsLegitimateCompactWindowsEligible() {
+        let onlyCompactWindow = FrontmostWindowSelection.select(
+            windows: [candidate(id: 52, pid: 200, x: 20, width: 66, height: 20, title: "Window")],
+            displays: [display(id: 1, x: 0)],
+            ownPID: 100,
+            preferredPID: 200
+        )
+        precondition(onlyCompactWindow?.window.id == 52)
+
+        let titledCompactWindow = FrontmostWindowSelection.select(
+            windows: [
+                candidate(id: 53, pid: 200, x: 20, width: 66, height: 20, title: "Inspector"),
+                candidate(id: 54, pid: 200, x: 20, width: 720, height: 672, title: "Document"),
+            ],
+            displays: [display(id: 1, x: 0)],
+            ownPID: 100,
+            preferredPID: 200
+        )
+        precondition(titledCompactWindow?.window.id == 53)
+
+        let genericCompactWindow = FrontmostWindowSelection.select(
+            windows: [
+                candidate(id: 55, pid: 200, x: 300, y: 300, width: 66, height: 20, title: "Window"),
+                candidate(id: 56, pid: 200, x: 20, y: 10, width: 720, height: 672, title: "Document"),
+            ],
+            displays: [display(id: 1, x: 0)],
+            ownPID: 100,
+            preferredPID: 200
+        )
+        precondition(genericCompactWindow?.window.id == 55)
+    }
+
+    private static func prefersFrontmostApplicationAndFrontmostWindow() {
+        let windows = [
+            candidate(id: 10, pid: 300, x: 10),
+            candidate(id: 11, pid: 200, x: 20),
+            candidate(id: 12, pid: 200, x: 30),
+        ]
+        let selection = FrontmostWindowSelection.select(
+            windows: windows,
+            displays: [display(id: 1, x: 0)],
+            ownPID: 100,
+            preferredPID: 200
+        )
+        precondition(selection?.window.id == 11)
+    }
+
+    private static func fallsBackToTopNonSelfWindowWhenMenuOwnsFocus() {
+        let windows = [
+            candidate(id: 20, pid: 100, x: 10),
+            candidate(id: 21, pid: 300, x: 20),
+            candidate(id: 22, pid: 200, x: 30),
+        ]
+        let selection = FrontmostWindowSelection.select(
+            windows: windows,
+            displays: [display(id: 1, x: 0)],
+            ownPID: 100,
+            preferredPID: nil
+        )
+        precondition(selection?.window.id == 21)
+    }
+
+    private static func rejectsIneligibleAndOffscreenWindows() {
+        let windows = [
+            candidate(id: 30, pid: 200, layer: 1, x: 10),
+            candidate(id: 31, pid: 200, x: 10, width: 1),
+            candidate(id: 32, pid: 200, x: 2_000),
+        ]
+        let selection = FrontmostWindowSelection.select(
+            windows: windows,
+            displays: [display(id: 1, x: 0)],
+            ownPID: 100,
+            preferredPID: 200
+        )
+        precondition(selection == nil)
+    }
+
+    private static func choosesDisplayWithLargestIntersection() {
+        let window = candidate(id: 40, pid: 200, x: 900, width: 400)
+        let selection = FrontmostWindowSelection.select(
+            windows: [window],
+            displays: [display(id: 1, x: 0), display(id: 2, x: 1_000)],
+            ownPID: 100,
+            preferredPID: 200
+        )
+        precondition(selection?.displayID == 2)
+    }
+
+    private static func candidate(
+        id: UInt32,
+        pid: Int32,
+        layer: Int = 0,
+        x: CGFloat,
+        y: CGFloat = 10,
+        width: CGFloat = 300,
+        height: CGFloat = 200,
+        title: String? = nil
+    ) -> WindowSelectionCandidate {
+        WindowSelectionCandidate(
+            id: id,
+            ownerPID: pid,
+            layer: layer,
+            bounds: CGRect(x: x, y: y, width: width, height: height),
+            title: title ?? "Window \(id)"
+        )
+    }
+
+    private static func display(id: UInt32, x: CGFloat) -> DisplaySelectionCandidate {
+        DisplaySelectionCandidate(
+            id: id,
+            bounds: CGRect(x: x, y: 0, width: 1_000, height: 800)
+        )
+    }
+}

--- a/Tests/ImagePasteboardWriterTests.swift
+++ b/Tests/ImagePasteboardWriterTests.swift
@@ -1,0 +1,61 @@
+import Cocoa
+
+@main
+struct ImagePasteboardWriterTests {
+    static func main() throws {
+        try writesRetainedFileImageAndContextRepresentations()
+        writesImageOnlyFallbackWithoutAFile()
+    }
+
+    private static func writesRetainedFileImageAndContextRepresentations() throws {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("macshot-context-test-\(UUID())"))
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macshot-context-test-\(UUID()).png")
+        try Data([0x01]).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        ImagePasteboardWriter.write(
+            to: pasteboard,
+            backingURL: fileURL,
+            pngData: Data([0x02]),
+            tiffData: Data([0x03]),
+            text: "# Context"
+        )
+
+        let types = Set(pasteboard.types ?? [])
+        precondition(pasteboard.pasteboardItems?.count == 1)
+        let itemTypes = Set(pasteboard.pasteboardItems?.first?.types ?? [])
+        precondition(types.contains(.fileURL))
+        precondition(types.contains(.png))
+        precondition(types.contains(.tiff))
+        precondition(types.contains(.string))
+        precondition(types.contains(ImagePasteboardWriter.markdownType))
+        precondition(itemTypes.isSuperset(of: [
+            .fileURL,
+            .png,
+            .tiff,
+            .string,
+            ImagePasteboardWriter.markdownType,
+        ]))
+        precondition(pasteboard.string(forType: .string) == "# Context")
+        precondition(pasteboard.string(forType: ImagePasteboardWriter.markdownType) == "# Context")
+    }
+
+    private static func writesImageOnlyFallbackWithoutAFile() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("macshot-image-test-\(UUID())"))
+        ImagePasteboardWriter.write(
+            to: pasteboard,
+            backingURL: nil,
+            pngData: Data([0x04]),
+            tiffData: nil,
+            text: nil
+        )
+
+        let types = Set(pasteboard.types ?? [])
+        precondition(types.contains(.png))
+        precondition(!types.contains(.fileURL))
+        precondition(!types.contains(.string))
+        precondition(!types.contains(ImagePasteboardWriter.markdownType))
+        precondition(pasteboard.data(forType: .png) == Data([0x04]))
+    }
+}

--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -14,6 +14,7 @@ enum CaptureMenuItemID: String, CaseIterable {
     case quickCapture = "quickCapture"
     case captureLastArea = "captureLastArea"
     case scrollCapture = "scrollCapture"
+    case contextCapture = "contextCapture"
 
     static let userDefaultsKey = "captureMenuItemOrder"
     static let defaultOrder: [CaptureMenuItemID] = [
@@ -23,6 +24,7 @@ enum CaptureMenuItemID: String, CaseIterable {
         .quickCapture,
         .captureLastArea,
         .scrollCapture,
+        .contextCapture,
     ]
 
     var title: String {
@@ -33,6 +35,7 @@ enum CaptureMenuItemID: String, CaseIterable {
         case .quickCapture: return L("Quick Capture")
         case .captureLastArea: return L("Capture Last Area")
         case .scrollCapture: return L("Scroll Capture")
+        case .contextCapture: return L("App Shot")
         }
     }
 
@@ -44,6 +47,7 @@ enum CaptureMenuItemID: String, CaseIterable {
         case .quickCapture: return "square.and.arrow.down"
         case .captureLastArea: return "arrow.counterclockwise.circle"
         case .scrollCapture: return "scroll"
+        case .contextCapture: return "doc.text.viewfinder"
         }
     }
 
@@ -55,6 +59,7 @@ enum CaptureMenuItemID: String, CaseIterable {
         case .quickCapture: return .quickCapture
         case .captureLastArea: return .captureLastArea
         case .scrollCapture: return .scrollCapture
+        case .contextCapture: return .contextCapture
         }
     }
 
@@ -843,6 +848,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         case .quickCapture: action = #selector(quickCapture)
         case .captureLastArea: action = #selector(captureLastArea)
         case .scrollCapture: action = #selector(scrollCapture)
+        case .contextCapture: action = #selector(contextCapture)
         }
 
         let item = NSMenuItem(title: itemID.title, action: action, keyEquivalent: "")
@@ -906,6 +912,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             },
             clearHistory: { [weak self] in
                 DispatchQueue.main.async { self?.clearHistorySilently() }
+            },
+            contextCapture: { [weak self] in
+                self?.perform(#selector(AppDelegate.contextCaptureFromHotkey))
             }
         )
     }
@@ -919,6 +928,53 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     private var pendingTranslateOverlayLang: String?
     private var pendingQuickCaptureMode: Bool = false
     private var pendingScrollCaptureMode: Bool = false
+    private lazy var appShotCaptureCoordinator = AppShotCaptureCoordinator<FrontmostWindowTarget, CGImage>(
+        captureImage: { target in
+            await ScreenCaptureManager.captureWindow(
+                windowID: target.windowID,
+                screen: target.screen
+            )
+        },
+        recognizeText: { image in
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    VisionOCR.performTextRecognition(cgImage: image) { request, _ in
+                        continuation.resume(returning: VisionOCR.recognizedText(from: request))
+                    }
+                }
+            }
+        },
+        publish: { [weak self] content in
+            guard let self else { return false }
+            let scale = content.target.screen.backingScaleFactor
+            let image = NSImage(
+                cgImage: content.image,
+                size: NSSize(
+                    width: CGFloat(content.image.width) / scale,
+                    height: CGFloat(content.image.height) / scale
+                )
+            )
+            let payload = ContextCapturePayload(
+                applicationName: content.target.applicationName,
+                bundleIdentifier: content.target.bundleIdentifier,
+                windowTitle: content.target.windowTitle,
+                capturedAt: content.capturedAt,
+                recognizedText: content.recognizedText
+            )
+
+            let entryID = ScreenshotHistory.shared.add(
+                image: image,
+                pixelWidth: content.image.width,
+                pixelHeight: content.image.height
+            )
+            self.showFloatingThumbnail(image: image, historyEntryID: entryID)
+            self.playCopySound()
+            return await ImageEncoder.copyContextCaptureToClipboard(
+                image,
+                markdown: payload.markdown
+            )
+        }
+    )
     private var capturedWindowTitle: String?
     /// The app that was active before the overlay appeared — re-activated on dismiss.
     /// The app that was active before macshot showed its overlay.
@@ -995,6 +1051,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
 
     private func beginCaptureArea(fromMenu: Bool) {
+        guard canStartCapture else { return }
         startCapture(fromMenu: fromMenu)
     }
 
@@ -1062,6 +1119,41 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         guard canStartCapture else { return }
         pendingQuickCaptureMode = true
         startCapture(fromMenu: fromMenu)
+    }
+
+    @objc private func contextCapture() {
+        beginContextCapture()
+    }
+
+    @objc private func contextCaptureFromHotkey() {
+        beginContextCapture()
+    }
+
+    /// Captures the frontmost window directly, enriches it with local OCR, and
+    /// publishes the image plus Markdown context without showing the overlay.
+    private func beginContextCapture() {
+        guard canStartCapture else { return }
+        guard CGPreflightScreenCaptureAccess() else {
+            showOnboarding()
+            return
+        }
+        guard let target = FrontmostWindowResolver.resolve() else {
+            NSSound.beep()
+            return
+        }
+        let capturedAt = Date()
+        Task { [weak self] in
+            guard let self else { return }
+            switch await self.appShotCaptureCoordinator.capture(
+                target: target,
+                capturedAt: capturedAt
+            ) {
+            case .completed, .captureInProgress:
+                break
+            case .imageCaptureFailed, .clipboardPublicationFailed:
+                NSSound.beep()
+            }
+        }
     }
 
     @objc private func scrollCapture() {
@@ -1147,13 +1239,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     /// delay-capture countdown `isCapturing` is already true and the pending mode
     /// belongs to that accepted (not-yet-consumed) capture.
     private var canStartCapture: Bool {
-        !isCapturing && recordingEngine == nil
+        !isCapturing && recordingEngine == nil && !appShotCaptureCoordinator.isCapturing
     }
 
     private func startCapture(fromMenu: Bool = false) {
         guard !isCapturing else { return }
         // Don't allow captures while recording
         guard recordingEngine == nil else { return }
+        guard !appShotCaptureCoordinator.isCapturing else { return }
         let trace = makeCaptureTimingTrace()
         captureTimingTrace = trace
         trace?.mark("startCapture entered fromMenu=\(fromMenu)")

--- a/macshot/AppDelegate.swift
+++ b/macshot/AppDelegate.swift
@@ -935,6 +935,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
                 screen: target.screen
             )
         },
+        onImageCaptured: { [weak self] target, capturedImage in
+            guard let self else { return }
+            let image = self.appShotImage(from: capturedImage, target: target)
+            let entryID = ScreenshotHistory.shared.add(
+                image: image,
+                pixelWidth: capturedImage.width,
+                pixelHeight: capturedImage.height
+            )
+            self.showFloatingThumbnail(image: image, historyEntryID: entryID)
+            self.playCopySound()
+        },
         recognizeText: { image in
             await withCheckedContinuation { continuation in
                 DispatchQueue.global(qos: .userInitiated).async {
@@ -946,14 +957,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         },
         publish: { [weak self] content in
             guard let self else { return false }
-            let scale = content.target.screen.backingScaleFactor
-            let image = NSImage(
-                cgImage: content.image,
-                size: NSSize(
-                    width: CGFloat(content.image.width) / scale,
-                    height: CGFloat(content.image.height) / scale
-                )
-            )
+            let image = self.appShotImage(from: content.image, target: content.target)
             let payload = ContextCapturePayload(
                 applicationName: content.target.applicationName,
                 bundleIdentifier: content.target.bundleIdentifier,
@@ -962,19 +966,26 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
                 recognizedText: content.recognizedText
             )
 
-            let entryID = ScreenshotHistory.shared.add(
-                image: image,
-                pixelWidth: content.image.width,
-                pixelHeight: content.image.height
-            )
-            self.showFloatingThumbnail(image: image, historyEntryID: entryID)
-            self.playCopySound()
             return await ImageEncoder.copyContextCaptureToClipboard(
                 image,
                 markdown: payload.markdown
             )
         }
     )
+
+    private func appShotImage(
+        from capturedImage: CGImage,
+        target: FrontmostWindowTarget
+    ) -> NSImage {
+        let scale = target.screen.backingScaleFactor
+        return NSImage(
+            cgImage: capturedImage,
+            size: NSSize(
+                width: CGFloat(capturedImage.width) / scale,
+                height: CGFloat(capturedImage.height) / scale
+            )
+        )
+    }
     private var capturedWindowTitle: String?
     /// The app that was active before the overlay appeared — re-activated on dismiss.
     /// The app that was active before macshot showed its overlay.

--- a/macshot/Capture/AppShotCaptureCoordinator.swift
+++ b/macshot/Capture/AppShotCaptureCoordinator.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// Owns admission and the asynchronous steps for one no-overlay App Shot.
-/// UI side effects stay behind `publish`, which keeps the capture path testable.
+/// Early image feedback and completed publication stay behind injected callbacks,
+/// which keeps their ordering testable without coupling this type to AppKit.
 @MainActor
 final class AppShotCaptureCoordinator<Target, Image> {
     struct Content {
@@ -19,6 +20,7 @@ final class AppShotCaptureCoordinator<Target, Image> {
     }
 
     private let captureImage: (Target) async -> Image?
+    private let onImageCaptured: (Target, Image) async -> Void
     private let recognizeText: (Image) async -> String
     private let publish: (Content) async -> Bool
 
@@ -26,10 +28,12 @@ final class AppShotCaptureCoordinator<Target, Image> {
 
     init(
         captureImage: @escaping (Target) async -> Image?,
+        onImageCaptured: @escaping (Target, Image) async -> Void = { _, _ in },
         recognizeText: @escaping (Image) async -> String,
         publish: @escaping (Content) async -> Bool
     ) {
         self.captureImage = captureImage
+        self.onImageCaptured = onImageCaptured
         self.recognizeText = recognizeText
         self.publish = publish
     }
@@ -48,6 +52,7 @@ final class AppShotCaptureCoordinator<Target, Image> {
         guard let image = await captureImage(target) else {
             return .imageCaptureFailed
         }
+        await onImageCaptured(target, image)
         let recognizedText = await recognizeText(image)
         guard await publish(Content(
             target: target,

--- a/macshot/Capture/AppShotCaptureCoordinator.swift
+++ b/macshot/Capture/AppShotCaptureCoordinator.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Owns admission and the asynchronous steps for one no-overlay App Shot.
+/// UI side effects stay behind `publish`, which keeps the capture path testable.
+@MainActor
+final class AppShotCaptureCoordinator<Target, Image> {
+    struct Content {
+        let target: Target
+        let image: Image
+        let recognizedText: String
+        let capturedAt: Date
+    }
+
+    enum Outcome: Equatable {
+        case completed
+        case captureInProgress
+        case imageCaptureFailed
+        case clipboardPublicationFailed
+    }
+
+    private let captureImage: (Target) async -> Image?
+    private let recognizeText: (Image) async -> String
+    private let publish: (Content) async -> Bool
+
+    private(set) var isCapturing = false
+
+    init(
+        captureImage: @escaping (Target) async -> Image?,
+        recognizeText: @escaping (Image) async -> String,
+        publish: @escaping (Content) async -> Bool
+    ) {
+        self.captureImage = captureImage
+        self.recognizeText = recognizeText
+        self.publish = publish
+    }
+
+    // Keep closure destruction out of the optimizer's early inliner. Xcode 26.5's
+    // x86_64 Swift frontend crashes while optimizing the synthesized deinitializer.
+    @inline(never)
+    deinit {}
+
+    func capture(target: Target, capturedAt: Date = Date()) async -> Outcome {
+        guard !isCapturing else { return .captureInProgress }
+
+        isCapturing = true
+        defer { isCapturing = false }
+
+        guard let image = await captureImage(target) else {
+            return .imageCaptureFailed
+        }
+        let recognizedText = await recognizeText(image)
+        guard await publish(Content(
+            target: target,
+            image: image,
+            recognizedText: recognizedText,
+            capturedAt: capturedAt
+        )) else {
+            return .clipboardPublicationFailed
+        }
+        return .completed
+    }
+}

--- a/macshot/Capture/FrontmostWindowResolver.swift
+++ b/macshot/Capture/FrontmostWindowResolver.swift
@@ -1,0 +1,71 @@
+import Cocoa
+import CoreGraphics
+
+struct FrontmostWindowTarget {
+    let windowID: CGWindowID
+    let applicationName: String
+    let bundleIdentifier: String?
+    let windowTitle: String?
+    let screen: NSScreen
+}
+
+enum FrontmostWindowResolver {
+    /// Resolves the frontmost app's first normal, on-screen window in Quartz
+    /// z-order. Call this synchronously at trigger time so later activation or
+    /// capture work cannot change the selected source window.
+    static func resolve() -> FrontmostWindowTarget? {
+        guard let windowInfo = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else { return nil }
+
+        let ownPID = NSRunningApplication.current.processIdentifier
+        let frontmost = NSWorkspace.shared.frontmostApplication
+        let preferredPID = frontmost?.processIdentifier == ownPID
+            ? nil
+            : frontmost?.processIdentifier
+
+        let windows = windowInfo.compactMap { info -> WindowSelectionCandidate? in
+            guard let layer = info[kCGWindowLayer as String] as? Int,
+                  let ownerPID = info[kCGWindowOwnerPID as String] as? pid_t,
+                  let number = info[kCGWindowNumber as String] as? Int,
+                  let boundsDictionary = info[kCGWindowBounds as String] as? [String: CGFloat],
+                  let x = boundsDictionary["X"],
+                  let y = boundsDictionary["Y"],
+                  let width = boundsDictionary["Width"],
+                  let height = boundsDictionary["Height"] else { return nil }
+            return WindowSelectionCandidate(
+                id: UInt32(number),
+                ownerPID: ownerPID,
+                layer: layer,
+                bounds: CGRect(x: x, y: y, width: width, height: height),
+                title: info[kCGWindowName as String] as? String
+            )
+        }
+        let screenPairs: [(CGDirectDisplayID, NSScreen)] = NSScreen.screens.compactMap { screen in
+            guard let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
+                    as? CGDirectDisplayID else { return nil }
+            return (displayID, screen)
+        }
+        let screensByID = Dictionary(screenPairs, uniquingKeysWith: { first, _ in first })
+        let displays = screenPairs.map { id, _ in
+            DisplaySelectionCandidate(id: id, bounds: CGDisplayBounds(id))
+        }
+        guard let selection = FrontmostWindowSelection.select(
+            windows: windows,
+            displays: displays,
+            ownPID: ownPID,
+            preferredPID: preferredPID
+        ), let screen = screensByID[selection.displayID],
+           let application = NSRunningApplication(processIdentifier: selection.window.ownerPID)
+        else { return nil }
+
+        return FrontmostWindowTarget(
+            windowID: CGWindowID(selection.window.id),
+            applicationName: application.localizedName ?? "Unknown Application",
+            bundleIdentifier: application.bundleIdentifier,
+            windowTitle: selection.window.title,
+            screen: screen
+        )
+    }
+}

--- a/macshot/Capture/FrontmostWindowSelection.swift
+++ b/macshot/Capture/FrontmostWindowSelection.swift
@@ -1,0 +1,99 @@
+import CoreGraphics
+import Foundation
+
+struct WindowSelectionCandidate: Equatable {
+    let id: UInt32
+    let ownerPID: Int32
+    let layer: Int
+    let bounds: CGRect
+    let title: String?
+}
+
+struct DisplaySelectionCandidate: Equatable {
+    let id: UInt32
+    let bounds: CGRect
+}
+
+struct FrontmostWindowSelectionResult: Equatable {
+    let window: WindowSelectionCandidate
+    let displayID: UInt32
+}
+
+enum FrontmostWindowSelection {
+    /// Selects from windows already ordered front-to-back by Quartz.
+    static func select(
+        windows: [WindowSelectionCandidate],
+        displays: [DisplaySelectionCandidate],
+        ownPID: Int32,
+        preferredPID: Int32?
+    ) -> FrontmostWindowSelectionResult? {
+        for (index, window) in windows.enumerated() {
+            guard window.layer == 0,
+                  window.ownerPID != ownPID,
+                  preferredPID == nil || window.ownerPID == preferredPID,
+                  window.bounds.width > 1,
+                  window.bounds.height > 1,
+                  let displayID = displayContainingMost(of: window.bounds, displays: displays),
+                  !isTinyGenericAuxiliary(
+                    window,
+                    windowsBehind: windows.dropFirst(index + 1),
+                    displays: displays
+                  )
+            else { continue }
+
+            return FrontmostWindowSelectionResult(window: window, displayID: displayID)
+        }
+        return nil
+    }
+
+    /// AppKit can expose a field-editor window as a layer-zero Quartz window
+    /// immediately above the application's normal window. Reject only a
+    /// generic-titled candidate that is dramatically smaller in both
+    /// dimensions than a usable same-process window behind it.
+    private static func isTinyGenericAuxiliary(
+        _ candidate: WindowSelectionCandidate,
+        windowsBehind: ArraySlice<WindowSelectionCandidate>,
+        displays: [DisplaySelectionCandidate]
+    ) -> Bool {
+        let title = candidate.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard title.isEmpty || title.caseInsensitiveCompare("Window") == .orderedSame else {
+            return false
+        }
+
+        let minimumDimensionRatio: CGFloat = 4
+        let maximumOriginInset: CGFloat = 16
+        return windowsBehind.contains { window in
+            let leadingInset = candidate.bounds.minX - window.bounds.minX
+            let topInset = candidate.bounds.minY - window.bounds.minY
+            return window.ownerPID == candidate.ownerPID
+                && window.layer == 0
+                && window.bounds.contains(candidate.bounds)
+                && leadingInset >= 0
+                && topInset >= 0
+                && leadingInset <= maximumOriginInset
+                && topInset <= maximumOriginInset
+                && window.bounds.width >= candidate.bounds.width * minimumDimensionRatio
+                && window.bounds.height >= candidate.bounds.height * minimumDimensionRatio
+                && displayContainingMost(of: window.bounds, displays: displays) != nil
+        }
+    }
+
+    private static func displayContainingMost(
+        of windowBounds: CGRect,
+        displays: [DisplaySelectionCandidate]
+    ) -> UInt32? {
+        var best: (id: UInt32, area: CGFloat)?
+        for display in displays {
+            let intersection = display.bounds.intersection(windowBounds)
+            guard !intersection.isNull else { continue }
+            let area = intersection.width * intersection.height
+            if let current = best {
+                if area > current.area { best = (display.id, area) }
+            } else {
+                best = (display.id, area)
+            }
+        }
+        guard let best, best.area > 0 else { return nil }
+        return best.id
+    }
+}

--- a/macshot/Model/ContextCapturePayload.swift
+++ b/macshot/Model/ContextCapturePayload.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct ContextCapturePayload {
+    let applicationName: String
+    let bundleIdentifier: String?
+    let windowTitle: String?
+    let capturedAt: Date
+    let recognizedText: String
+
+    var markdown: String {
+        let application = singleLine(applicationName) ?? "Unknown Application"
+        let bundleID = singleLine(bundleIdentifier) ?? "Unavailable"
+        let title = singleLine(windowTitle) ?? "Untitled"
+        let text = nonempty(recognizedText) ?? "No text was recognized."
+
+        return """
+        # App Shot
+
+        - Application: \(application)
+        - Bundle ID: \(bundleID)
+        - Window: \(title)
+        - Captured: \(Self.timestampFormatter.string(from: capturedAt))
+
+        ## Recognized Text
+
+        \(text)
+        """
+    }
+
+    private func nonempty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private func singleLine(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let components = value.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+        guard !components.isEmpty else { return nil }
+        return components.joined(separator: " ")
+    }
+
+    private static let timestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}

--- a/macshot/Services/AppShotClipboardPublisher.swift
+++ b/macshot/Services/AppShotClipboardPublisher.swift
@@ -1,0 +1,62 @@
+import Cocoa
+
+enum AppShotClipboardPublisher {
+    struct Generation: Equatable {
+        fileprivate let value: Int
+    }
+
+    private static let historySeparationDelay: TimeInterval = 1.0
+    private static let generationLock = NSLock()
+    private static var generation = 0
+
+    static func beginPublication() -> Generation {
+        generationLock.lock()
+        defer { generationLock.unlock() }
+        generation += 1
+        return Generation(value: generation)
+    }
+
+    static func isCurrent(_ expected: Generation) -> Bool {
+        generationLock.lock()
+        defer { generationLock.unlock() }
+        return generation == expected.value
+    }
+
+    @MainActor
+    static func publish(
+        to pasteboard: NSPasteboard = .general,
+        generation: Generation,
+        backingURL: URL?,
+        pngData: Data,
+        tiffData: Data?,
+        markdown: String,
+        wait: () async -> Void = {
+            try? await Task.sleep(
+                nanoseconds: UInt64(historySeparationDelay * 1_000_000_000)
+            )
+        },
+        writeContext: ((NSPasteboard, String) -> Bool)? = nil
+    ) async -> Bool {
+        guard isCurrent(generation),
+              ImagePasteboardWriter.write(
+            to: pasteboard,
+            backingURL: backingURL,
+            pngData: pngData,
+            tiffData: tiffData,
+            text: nil
+        ) else {
+            return false
+        }
+
+        await wait()
+
+        guard isCurrent(generation),
+              pasteboard.data(forType: .png) == pngData else {
+            return false
+        }
+        if let writeContext {
+            return writeContext(pasteboard, markdown)
+        }
+        return ImagePasteboardWriter.writeText(to: pasteboard, markdown: markdown)
+    }
+}

--- a/macshot/Services/HotkeyManager.swift
+++ b/macshot/Services/HotkeyManager.swift
@@ -22,6 +22,7 @@ class HotkeyManager {
         case captureLastArea = 10
         case pinFromClipboard = 11
         case clearHistory = 12
+        case contextCapture = 13
 
         var keyCodeKey: String {
             switch self {
@@ -37,6 +38,7 @@ class HotkeyManager {
             case .captureLastArea: return "hotkeyCaptureLastAreaKeyCode"
             case .pinFromClipboard: return "hotkeyPinClipboardKeyCode"
             case .clearHistory: return "hotkeyClearHistoryKeyCode"
+            case .contextCapture: return "hotkeyContextCaptureKeyCode"
             }
         }
 
@@ -54,6 +56,7 @@ class HotkeyManager {
             case .captureLastArea: return "hotkeyCaptureLastAreaModifiers"
             case .pinFromClipboard: return "hotkeyPinClipboardModifiers"
             case .clearHistory: return "hotkeyClearHistoryModifiers"
+            case .contextCapture: return "hotkeyContextCaptureModifiers"
             }
         }
 
@@ -75,6 +78,7 @@ class HotkeyManager {
             case .captureLastArea: return L("Capture Last Area")
             case .pinFromClipboard: return L("Pin from Clipboard")
             case .clearHistory: return L("Clear History")
+            case .contextCapture: return L("App Shot")
             }
         }
 
@@ -92,12 +96,13 @@ class HotkeyManager {
             case .captureLastArea: return 0    // no default hotkey
             case .pinFromClipboard: return 0    // no default hotkey
             case .clearHistory: return 0        // no default hotkey
+            case .contextCapture: return 0       // no default hotkey
             }
         }
 
         var defaultModifiers: UInt32 {
             switch self {
-            case .recordScreen, .scrollCapture, .openFromClipboard, .captureLastArea, .pinFromClipboard, .clearHistory: return 0
+            case .recordScreen, .scrollCapture, .openFromClipboard, .captureLastArea, .pinFromClipboard, .clearHistory, .contextCapture: return 0
             default: return UInt32(cmdKey | shiftKey)
             }
         }
@@ -136,7 +141,7 @@ class HotkeyManager {
     }
 
     /// Register all hotkeys with their callbacks.
-    func registerAll(captureArea: @escaping () -> Void, captureFullScreen: @escaping () -> Void, recordArea: @escaping () -> Void, recordScreen: @escaping () -> Void, historyOverlay: @escaping () -> Void, captureOCR: @escaping () -> Void, quickCapture: @escaping () -> Void, scrollCapture: @escaping () -> Void, openFromClipboard: @escaping () -> Void, captureLastArea: @escaping () -> Void, pinFromClipboard: @escaping () -> Void, clearHistory: @escaping () -> Void) {
+    func registerAll(captureArea: @escaping () -> Void, captureFullScreen: @escaping () -> Void, recordArea: @escaping () -> Void, recordScreen: @escaping () -> Void, historyOverlay: @escaping () -> Void, captureOCR: @escaping () -> Void, quickCapture: @escaping () -> Void, scrollCapture: @escaping () -> Void, openFromClipboard: @escaping () -> Void, captureLastArea: @escaping () -> Void, pinFromClipboard: @escaping () -> Void, clearHistory: @escaping () -> Void, contextCapture: @escaping () -> Void) {
         unregisterAll()
         register(slot: .captureArea, callback: captureArea)
         register(slot: .captureFullScreen, callback: captureFullScreen)
@@ -150,6 +155,7 @@ class HotkeyManager {
         register(slot: .captureLastArea, callback: captureLastArea)
         register(slot: .pinFromClipboard, callback: pinFromClipboard)
         register(slot: .clearHistory, callback: clearHistory)
+        register(slot: .contextCapture, callback: contextCapture)
     }
 
     private func installEventHandler() {

--- a/macshot/Services/ImageEncoder.swift
+++ b/macshot/Services/ImageEncoder.swift
@@ -221,17 +221,52 @@ enum ImageEncoder {
 
     // MARK: - Clipboard
 
-    private static let clipboardGenerationLock = NSLock()
-    private static var clipboardGeneration = 0
-
     /// Copy image to pasteboard as PNG.
     /// Explicitly sets PNG data so receiving apps (browsers, editors) get
     /// a lossless PNG instead of the TIFF that NSImage.writeObjects provides.
     /// Also writes a retained backing file so Finder paste works and clipboard
     /// history tools do not keep references to deleted `/tmp` files.
     static func copyToClipboard(_ image: NSImage, sourceFileURL: URL? = nil) {
+        copyToClipboard(image, sourceFileURL: sourceFileURL, text: nil)
+    }
+
+    /// Publishes an App Shot as an image history state followed by the
+    /// Markdown/plain-text Context Document as the current clipboard state.
+    static func copyContextCaptureToClipboard(_ image: NSImage, markdown: String) async -> Bool {
         let pasteboard = NSPasteboard.general
-        let generation = beginClipboardCopy()
+        let generation = AppShotClipboardPublisher.beginPublication()
+        let representations: (backingURL: URL?, pngData: Data, tiffData: Data?)? =
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    guard let bitmap = makeBitmap(image),
+                          let pngData = bitmap.representation(using: .png, properties: [:]) else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+
+                    let backingURL = ClipboardBackingStore.writeImageData(pngData)
+                    let tiffData = bitmap.representation(using: .tiff, properties: [:])
+                    continuation.resume(returning: (backingURL, pngData, tiffData))
+                }
+            }
+
+        guard let representations,
+              AppShotClipboardPublisher.isCurrent(generation) else {
+            return false
+        }
+        return await AppShotClipboardPublisher.publish(
+            to: pasteboard,
+            generation: generation,
+            backingURL: representations.backingURL,
+            pngData: representations.pngData,
+            tiffData: representations.tiffData,
+            markdown: markdown
+        )
+    }
+
+    private static func copyToClipboard(_ image: NSImage, sourceFileURL: URL?, text: String?) {
+        let pasteboard = NSPasteboard.general
+        let generation = AppShotClipboardPublisher.beginPublication()
 
         DispatchQueue.global(qos: .userInitiated).async {
             let validSourceURL = reusableSourceURL(sourceFileURL)
@@ -239,7 +274,7 @@ enum ImageEncoder {
                   let pngData = bitmap.representation(using: .png, properties: [:]) else {
                 if let validSourceURL {
                     DispatchQueue.main.async {
-                        guard isCurrentClipboardCopy(generation) else { return }
+                        guard AppShotClipboardPublisher.isCurrent(generation) else { return }
                         pasteboard.clearContents()
                         pasteboard.writeObjects([validSourceURL as NSURL])
                     }
@@ -251,28 +286,16 @@ enum ImageEncoder {
             let tiffData = bitmap.representation(using: .tiff, properties: [:])
 
             DispatchQueue.main.async {
-                guard isCurrentClipboardCopy(generation) else { return }
-                writeImagePasteboard(
-                    pasteboard,
+                guard AppShotClipboardPublisher.isCurrent(generation) else { return }
+                ImagePasteboardWriter.write(
+                    to: pasteboard,
                     backingURL: backingURL,
                     pngData: pngData,
-                    tiffData: tiffData
+                    tiffData: tiffData,
+                    text: text
                 )
             }
         }
-    }
-
-    private static func beginClipboardCopy() -> Int {
-        clipboardGenerationLock.lock()
-        defer { clipboardGenerationLock.unlock() }
-        clipboardGeneration += 1
-        return clipboardGeneration
-    }
-
-    private static func isCurrentClipboardCopy(_ generation: Int) -> Bool {
-        clipboardGenerationLock.lock()
-        defer { clipboardGenerationLock.unlock() }
-        return generation == clipboardGeneration
     }
 
     private static func reusableSourceURL(_ url: URL?) -> URL? {
@@ -283,35 +306,4 @@ enum ImageEncoder {
         return url
     }
 
-    private static func writeImagePasteboard(
-        _ pasteboard: NSPasteboard,
-        backingURL: URL?,
-        pngData: Data,
-        tiffData: Data?
-    ) {
-        pasteboard.clearContents()
-
-        if let backingURL, pasteboard.writeObjects([backingURL as NSURL]) {
-            var extraTypes: [NSPasteboard.PasteboardType] = [.png]
-            if tiffData != nil {
-                extraTypes.append(.tiff)
-            }
-            pasteboard.addTypes(extraTypes, owner: nil)
-            pasteboard.setData(pngData, forType: .png)
-            if let tiffData {
-                pasteboard.setData(tiffData, forType: .tiff)
-            }
-            return
-        }
-
-        var types: [NSPasteboard.PasteboardType] = [.png]
-        if tiffData != nil {
-            types.append(.tiff)
-        }
-        pasteboard.declareTypes(types, owner: nil)
-        pasteboard.setData(pngData, forType: .png)
-        if let tiffData {
-            pasteboard.setData(tiffData, forType: .tiff)
-        }
-    }
 }

--- a/macshot/Services/ImagePasteboardWriter.swift
+++ b/macshot/Services/ImagePasteboardWriter.swift
@@ -1,0 +1,39 @@
+import Cocoa
+
+enum ImagePasteboardWriter {
+    static let markdownType = NSPasteboard.PasteboardType("net.daringfireball.markdown")
+
+    @discardableResult
+    static func write(
+        to pasteboard: NSPasteboard,
+        backingURL: URL?,
+        pngData: Data,
+        tiffData: Data?,
+        text: String?
+    ) -> Bool {
+        let item = NSPasteboardItem()
+        var success = item.setData(pngData, forType: .png)
+        if let backingURL {
+            success = item.setString(backingURL.absoluteString, forType: .fileURL) && success
+        }
+        if let tiffData {
+            success = item.setData(tiffData, forType: .tiff) && success
+        }
+        if let text {
+            success = item.setString(text, forType: .string) && success
+            success = item.setString(text, forType: markdownType) && success
+        }
+
+        pasteboard.clearContents()
+        return success && pasteboard.writeObjects([item])
+    }
+
+    @discardableResult
+    static func writeText(to pasteboard: NSPasteboard, markdown: String) -> Bool {
+        let item = NSPasteboardItem()
+        let representationsSucceeded = item.setString(markdown, forType: .string)
+            && item.setString(markdown, forType: markdownType)
+        pasteboard.clearContents()
+        return representationsSucceeded && pasteboard.writeObjects([item])
+    }
+}

--- a/macshot/Services/ScreenshotHistory.swift
+++ b/macshot/Services/ScreenshotHistory.swift
@@ -95,9 +95,17 @@ class ScreenshotHistory {
     ///   - rawImage: The raw screenshot without annotations (optional — for editable history).
     ///   - annotations: Live annotation objects (optional — serialized to JSON for editable history).
     ///   - editState: Live post-processing settings (optional — serialized for non-destructive editing).
-    func add(image: NSImage, rawImage: NSImage? = nil, annotations: [Annotation]? = nil, editState: CaptureEditState? = nil) {
+    @discardableResult
+    func add(
+        image: NSImage,
+        rawImage: NSImage? = nil,
+        annotations: [Annotation]? = nil,
+        editState: CaptureEditState? = nil,
+        pixelWidth: Int? = nil,
+        pixelHeight: Int? = nil
+    ) -> String? {
         let max = maxEntries
-        guard max > 0 else { return }
+        guard max > 0 else { return nil }
 
         let id = UUID().uuidString
         let ext = "png"
@@ -115,8 +123,8 @@ class ScreenshotHistory {
             id: id,
             fileExtension: ext,
             timestamp: Date(),
-            pixelWidth: Int(size.width * scale),
-            pixelHeight: Int(size.height * scale),
+            pixelWidth: pixelWidth ?? Int(size.width * scale),
+            pixelHeight: pixelHeight ?? Int(size.height * scale),
             hasAnnotations: hasEditableData,
             thumbnail: NSImage(size: NSSize(width: 1, height: 1))
         )
@@ -198,6 +206,7 @@ class ScreenshotHistory {
                 }
             }
         }
+        return id
     }
 
     /// Update an existing history entry in-place (for "Done" in editor).


### PR DESCRIPTION
## Summary

First step for #318.

App Shot captures the frontmost window directly, without opening the area-selection overlay. It runs local Vision OCR and creates a Context Document with the application name, bundle ID, window title, capture time, and recognized text.

The action is available from the macshot menu and can be assigned a shortcut. It has no default shortcut. History, sound, and floating-thumbnail feedback appear as soon as the window image is available. OCR and Context Document generation then continue asynchronously.

The clipboard write is intentionally sequential: the window image is written first, followed by the Markdown/plain-text Context Document. Clipboard-history tools keep them as adjacent entries, with the text ready to paste by default.

## Why this first step is sandboxed

My personal fork also reads Accessibility content after permission is granted. That produces richer context than OCR alone. It defaults to a simultaneous left-Option plus right-Option trigger, so I can start an App Shot by pressing both Option keys at the same time.

The personal build runs Accessibility extraction and Vision OCR concurrently, then compacts and redacts their combined semantic context. If the required runtime boundary is accepted, I plan to propose that work as a focused follow-up. The passive two-Option trigger would remain a separate change because it requires Input Monitoring.

Those behaviors are intentionally outside this first upstream PR. Cross-process Accessibility extraction requires a separate security and architecture decision. This PR leaves the existing App Sandbox configuration unchanged, uses Vision OCR only, and leaves App Shot without a default shortcut. OCR and Context Document generation stay local, and nothing is uploaded or submitted automatically.

## Testing

- Focused tests pass for capture coordination, frontmost-window selection, Context Document generation, image pasteboard output, and image-then-text clipboard publication.
- The coordinator test verifies that image feedback is presented before OCR completes.
- Debug and universal Release builds pass with the macOS 12.3 deployment target.
- The new App Shot files add no warnings. Existing upstream warnings are unchanged.
- Physical single-monitor acceptance was repeated on the current PR head with ChatGPT as the frontmost window. No overlay appeared, the correct window was captured, and sound and thumbnail feedback appeared immediately.
- The repeated clipboard-history check passed: the window image and Context Document were adjacent, with the Context Document current/newest.
- Multi-monitor capture was not run because only one display was available during final QA.

## Not included

The richer Accessibility context and simultaneous Option-key trigger from my personal fork are not included. Unrelated refactoring is also outside this first step.
