### PR TITLE
Allow custom Google Drive destination folder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ TextEditingCanvas                — Coordinate transforms + annotation storage 
 - Tools: `enabledTools`, `knownToolRawValues`
 - Features: `imgbbAPIKey`, `beautifyEnabled`, `beautifyStyleIndex`, `beautifyMode`, `beautifyPadding`, `beautifyCornerRadius`, `beautifyShadowRadius`, `pencilSmoothEnabled`, `loupeSize`, `stampSize`, `translateTargetLang`
 - Styles: `currentLineStyle`, `currentArrowStyle`, `currentRectFillStyle`, `currentRectCornerRadius`
-- Upload: `uploadProvider` (imgbb/gdrive), `googleDriveRefreshToken`, `uploadConfirmEnabled`
+- Upload: `uploadProvider` (imgbb/gdrive), `googleDriveRefreshToken`, `gdriveFolderName` (Drive destination folder, defaults to "macshot"), `uploadConfirmEnabled`
 
 ### Threading Model
 - **Capture:** Async/await TaskGroup for concurrent multi-display capture

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ brew install --cask macshot
 
 ### Output & Upload
 - **Formats** — PNG, JPEG, HEIC, WebP, AVIF with quality slider
-- **Google Drive** — sign in once, uploads to a private "macshot" folder
+- **Google Drive** — sign in once, uploads to a private folder (defaults to "macshot", configurable in Settings)
 - **imgbb** — anonymous image hosting with shareable links
 - **S3-compatible** — upload to Cloudflare R2, AWS S3, MinIO, DigitalOcean Spaces, Backblaze B2, etc.
 - **Retina downscale** — optional 1x export for smaller files

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -115,6 +115,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     private var providerPopup: NSPopUpButton!
     private var gdriveSignInBtn: NSButton!
     private var gdriveStatusLabel: NSTextField!
+    private var gdriveFolderField: NSTextField!
     // S3 tab controls
     private var s3EndpointField: NSTextField!
     private var s3RegionField: NSTextField!
@@ -1894,9 +1895,18 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
 
         stack.addArrangedSubview(labeledRow(L("Account:"), controls: [gdriveStatusLabel]))
         stack.addArrangedSubview(indented(gdriveSignInBtn))
+        stack.setCustomSpacing(10, after: stack.arrangedSubviews.last!)
+
+        gdriveFolderField = NSTextField()
+        gdriveFolderField.placeholderString = "macshot"
+        gdriveFolderField.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        gdriveFolderField.stringValue = UserDefaults.standard.string(forKey: "gdriveFolderName") ?? ""
+        gdriveFolderField.target = self
+        gdriveFolderField.action = #selector(gdriveFolderChanged(_:))
+        stack.addArrangedSubview(labeledRow(L("Folder:"), controls: [gdriveFolderField]))
         stack.setCustomSpacing(4, after: stack.arrangedSubviews.last!)
 
-        let gdriveNote = NSTextField(wrappingLabelWithString: L("Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly."))
+        let gdriveNote = NSTextField(wrappingLabelWithString: L("Files are uploaded to the folder above in your Google Drive, created automatically if it doesn't exist. Leave empty to use \"macshot\". Everything stays private — nothing is shared publicly."))
         gdriveNote.font = NSFont.systemFont(ofSize: 10)
         gdriveNote.textColor = .secondaryLabelColor
         stack.addArrangedSubview(indented(gdriveNote))
@@ -2232,6 +2242,10 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
                 }
             }
         }
+    }
+
+    @objc private func gdriveFolderChanged(_ sender: NSTextField) {
+        UserDefaults.standard.set(gdriveFolderField.stringValue, forKey: "gdriveFolderName")
     }
 
     @objc private func s3FieldChanged(_ sender: NSTextField) {

--- a/macshot/Upload/GoogleDriveUploader.swift
+++ b/macshot/Upload/GoogleDriveUploader.swift
@@ -5,7 +5,8 @@ import CryptoKit
 import AuthenticationServices
 
 /// Google Drive uploader using OAuth2 with PKCE.
-/// Files are uploaded to a "macshot" folder in the user's Drive, kept private (not shared).
+/// Files are uploaded to a configurable folder (default "macshot") in the user's Drive,
+/// kept private (not shared).
 final class GoogleDriveUploader: NSObject, ASWebAuthenticationPresentationContextProviding {
 
     static let shared = GoogleDriveUploader()
@@ -22,7 +23,8 @@ final class GoogleDriveUploader: NSObject, ASWebAuthenticationPresentationContex
     private let uploadURL = "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart"
     private let filesURL = "https://www.googleapis.com/drive/v3/files"
 
-    private var macShotFolderID: String?
+    private var cachedFolderID: String?
+    private var cachedFolderName: String?
     private var authSession: ASWebAuthenticationSession?
     private weak var presentationWindow: NSWindow?
 
@@ -42,6 +44,13 @@ final class GoogleDriveUploader: NSObject, ASWebAuthenticationPresentationContex
 
     var userEmail: String? {
         UserDefaults.standard.string(forKey: "gdriveUserEmail")
+    }
+
+    /// User-configured destination folder name in Drive. Falls back to "macshot" when empty.
+    private var folderName: String {
+        let raw = UserDefaults.standard.string(forKey: "gdriveFolderName")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (raw?.isEmpty == false) ? raw! : "macshot"
     }
 
     /// Start the OAuth2 sign-in flow using ASWebAuthenticationSession.
@@ -92,20 +101,21 @@ final class GoogleDriveUploader: NSObject, ASWebAuthenticationPresentationContex
     func signOut() {
         deleteTokens()
         UserDefaults.standard.removeObject(forKey: "gdriveUserEmail")
-        macShotFolderID = nil
+        cachedFolderID = nil
+        cachedFolderName = nil
     }
 
     /// Progress callback: percentage 0.0–1.0
     var onProgress: ((Double) -> Void)?
 
-    /// Upload a file (image or video) to the macshot folder.
+    /// Upload a file (image or video) to the configured destination folder.
     func upload(data: Data, filename: String, mimeType: String, completion: @escaping (Result<String, Error>) -> Void) {
         ensureValidToken { [weak self] success in
             guard let self = self, success else {
                 completion(.failure(Self.error("Not signed in")))
                 return
             }
-            self.ensureMacShotFolder { result in
+            self.ensureDestinationFolder { result in
                 switch result {
                 case .success(let folderID):
                     self.uploadFile(data: data, filename: filename, mimeType: mimeType, folderID: folderID, completion: completion)
@@ -262,16 +272,17 @@ final class GoogleDriveUploader: NSObject, ASWebAuthenticationPresentationContex
 
     // MARK: - Drive Operations
 
-    private func ensureMacShotFolder(completion: @escaping (Result<String, Error>) -> Void) {
-        if let id = macShotFolderID { completion(.success(id)); return }
+    private func ensureDestinationFolder(completion: @escaping (Result<String, Error>) -> Void) {
+        let name = folderName
+        if let id = cachedFolderID, cachedFolderName == name { completion(.success(id)); return }
 
         guard let token = loadAccessToken() else {
             completion(.failure(Self.error("No access token")))
             return
         }
 
-        // Search for existing macshot folder
-        let query = "name='macshot' and mimeType='application/vnd.google-apps.folder' and trashed=false"
+        // Search for existing destination folder
+        let query = "name='\(escapeForDriveQuery(name))' and mimeType='application/vnd.google-apps.folder' and trashed=false"
         var searchURL = URLComponents(string: filesURL)!
         searchURL.queryItems = [URLQueryItem(name: "q", value: query), URLQueryItem(name: "fields", value: "files(id)")]
 
@@ -307,22 +318,23 @@ final class GoogleDriveUploader: NSObject, ASWebAuthenticationPresentationContex
             }
 
             if let existing = files.first, let id = existing["id"] as? String {
-                self.macShotFolderID = id
+                self.cachedFolderID = id
+                self.cachedFolderName = name
                 DispatchQueue.main.async { completion(.success(id)) }
             } else {
-                self.createMacShotFolder(token: token, completion: completion)
+                self.createDestinationFolder(name: name, token: token, completion: completion)
             }
         }.resume()
     }
 
-    private func createMacShotFolder(token: String, completion: @escaping (Result<String, Error>) -> Void) {
+    private func createDestinationFolder(name: String, token: String, completion: @escaping (Result<String, Error>) -> Void) {
         var request = URLRequest(url: URL(string: filesURL)!)
         request.httpMethod = "POST"
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let metadata: [String: Any] = [
-            "name": "macshot",
+            "name": name,
             "mimeType": "application/vnd.google-apps.folder",
         ]
         request.httpBody = try? JSONSerialization.data(withJSONObject: metadata)
@@ -353,7 +365,8 @@ final class GoogleDriveUploader: NSObject, ASWebAuthenticationPresentationContex
                 DispatchQueue.main.async { completion(.failure(Self.error("Create folder: missing folder ID in response (HTTP \(statusCode))"))) }
                 return
             }
-            self?.macShotFolderID = id
+            self?.cachedFolderID = id
+            self?.cachedFolderName = name
             DispatchQueue.main.async { completion(.success(id)) }
         }.resume()
     }
@@ -530,6 +543,12 @@ final class GoogleDriveUploader: NSObject, ASWebAuthenticationPresentationContex
     private func loadExpiry() -> Double? { loadTokens().expiry }
 
     // MARK: - Helpers
+
+    /// Escapes a value for safe interpolation into a Drive API `q` query string.
+    private func escapeForDriveQuery(_ value: String) -> String {
+        value.replacingOccurrences(of: "\\", with: "\\\\")
+             .replacingOccurrences(of: "'", with: "\\'")
+    }
 
     private static func error(_ msg: String) -> NSError {
         NSError(domain: "GoogleDriveUploader", code: 1, userInfo: [NSLocalizedDescriptionKey: msg])

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -347,6 +347,7 @@
 "Sign Out" = "Sign Out";
 "Signed in" = "Signed in";
 "Not signed in" = "Not signed in";
+"Folder:" = "Folder:";
 "Account:" = "Account:";
 "Test Connection" = "Test Connection";
 "Fill in endpoint, bucket, and credentials first" = "Fill in endpoint, bucket, and credentials first";
@@ -548,7 +549,7 @@
 "Clear History?" = "Clear History?";
 "This will permanently delete all screenshots from history." = "This will permanently delete all screenshots from history.";
 "Click \"Set\" and press a key combination with at least one modifier (⌘, ⌥, ⌃, ⇧) to set a shortcut." = "Click \"Set\" and press a key combination with at least one modifier (⌘, ⌥, ⌃, ⇧) to set a shortcut.";
-"Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly." = "Files are uploaded to a \"macshot\" folder in your Google Drive. Everything stays private — nothing is shared publicly.";
+"Files are uploaded to the folder above in your Google Drive, created automatically if it doesn't exist. Leave empty to use \"macshot\". Everything stays private — nothing is shared publicly." = "Files are uploaded to the folder above in your Google Drive, created automatically if it doesn't exist. Leave empty to use \"macshot\". Everything stays private — nothing is shared publicly.";
 
 "Pressure" = "Pressure";
 


### PR DESCRIPTION
## Summary
- Google Drive uploads were hardcoded to a "macshot" folder. Adds a **Folder** field in Settings > Uploads > Google Drive so users can pick a different destination folder; leaving it empty keeps the existing "macshot" default.
- `GoogleDriveUploader` now searches for (or creates) the configured folder, caches it alongside the folder name it was resolved for so a settings change is picked up on the next upload, and escapes the folder name when building the Drive API `q` query.

## Test plan
- [ ] Manual review of Settings UI wiring (field save/load, placeholder, note text)
- [ ] Manually verified in the running app: set a custom folder, upload an image, confirm it lands in the new Drive folder
- [ ] Manually verified leaving the field empty still uploads to "macshot" (existing behavior)
- [ ] Manually verified changing the folder mid-session (already signed in) uploads to the new folder without needing to sign out/in

No unit tests exist in this repo (per CONTRIBUTING.md), so this was verified by manual review only from my side — happy to test on-device if needed.