### PR TITLE
Remember last-used export scale and quality

### DIFF
--- a/macshot/UI/Editor/VideoEditorWindowController.swift
+++ b/macshot/UI/Editor/VideoEditorWindowController.swift
@@ -147,11 +147,29 @@ private final class VideoEditorView: NSView {
     // Export dimensions
     private var originalWidth: Int = 0
     private var originalHeight: Int = 0
-    private var exportScale: CGFloat = 1.0  // 1.0 = original, 0.5 = 50%, etc.
+    // Persisted across exports: defaults to 1.0/.high on first use, then remembers
+    // whatever the user picked last via dimensionSelected/qualitySelected below.
+    private var exportScale: CGFloat = VideoEditorView.loadExportScale()
     private var dimensionsBtnRect: NSRect = .zero
 
     // Export quality (controls bitrate when re-encoding for MP4 export)
-    private var exportQuality: VideoQuality = .high
+    private var exportQuality: VideoQuality = VideoEditorView.loadExportQuality()
+
+    private static let exportScaleDefaultsKey = "lastExportScale"
+    private static let exportQualityDefaultsKey = "lastExportQuality"
+
+    private static func loadExportScale() -> CGFloat {
+        let stored = UserDefaults.standard.object(forKey: exportScaleDefaultsKey) as? Double ?? 1.0
+        return CGFloat(stored)
+    }
+
+    private static func loadExportQuality() -> VideoQuality {
+        guard let raw = UserDefaults.standard.string(forKey: exportQualityDefaultsKey),
+              let quality = VideoQuality(rawValue: raw) else {
+            return .high
+        }
+        return quality
+    }
     private var qualityBtnRect: NSRect = .zero
 
     // GIF export frame rate (5-30 fps), persisted across sessions
@@ -1871,6 +1889,7 @@ private final class VideoEditorView: NSView {
 
     @objc private func dimensionSelected(_ sender: NSMenuItem) {
         exportScale = CGFloat(sender.tag) / 100.0
+        UserDefaults.standard.set(Double(exportScale), forKey: Self.exportScaleDefaultsKey)
         savedURL = nil
         needsDisplay = true
     }
@@ -1990,6 +2009,7 @@ private final class VideoEditorView: NSView {
     @objc private func qualitySelected(_ sender: NSMenuItem) {
         if let raw = sender.representedObject as? String, let q = VideoQuality(rawValue: raw) {
             exportQuality = q
+            UserDefaults.standard.set(raw, forKey: Self.exportQualityDefaultsKey)
             savedURL = nil
             needsDisplay = true
         }


### PR DESCRIPTION
## What

Persists `exportScale` and `exportQuality` (the video editor's export panel) to `UserDefaults` so
they start at whatever the user picked last, instead of always resetting to 100%/High.

## Why

Both are currently hardcoded initial values on `VideoEditorView` (`exportScale = 1.0`,
`exportQuality = .high`). The picker to change them per-export already exists and stays fully
manual — this only changes what it opens at.

Same pattern already used elsewhere in Settings, e.g. `thumbnailScale`
(`SettingsWindowController.swift:835`) — a `UserDefaults`-backed value read into a control.

## Testing

No Xcode install on this machine, so I couldn't build and run the app to confirm end-to-end.
I did type-check the change against the full 106-file source tree with
`swiftc -typecheck` (all Swift files, project SDK) — 0 errors, same as main before the change.
That confirms the types/APIs are correct but doesn't replace an actual run. Happy to have this
verified in a real build before merging.

Addresses the second half of #363 (default export scale/quality).
