### PR TITLE
feat: support configured clipboard image formats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ TextEditingCanvas                — Coordinate transforms + annotation storage 
 - Output: `saveDirectory`, `autoCopyToClipboard`, `playCopySound`
 - Selection: `lastSelectionRect`, `lastSelectionScreenFrame`, `rememberLastSelection`
 - Thumbnails: `showFloatingThumbnail`, `thumbnailStacking`, `thumbnailAutoDismissSeconds`
-- Image: `imageFormat` (png/jpeg/heic/webp), `imageQuality` (0.0–1.0), `downscaleRetina` (bool)
+- Image: `imageFormat` (png/jpeg/heic/webp/avif), `imageQuality` (0.0–1.0), `downscaleRetina` (bool), `clipboardUsesImageFormat` (bool; default false preserves PNG clipboard compatibility)
 - Recording: `recordingFormat` (mp4/gif), `recordingFPS`, `recordingOnStop`
 - History: `historySize`
 - Tools: `enabledTools`, `knownToolRawValues`

--- a/macshot/Services/ClipboardBackingStore.swift
+++ b/macshot/Services/ClipboardBackingStore.swift
@@ -25,8 +25,8 @@ enum ClipboardBackingStore {
         return dir
     }()
 
-    static func writeImageData(_ data: Data) -> URL? {
-        let url = makeUniqueURL(fileExtension: "png")
+    static func writeImageData(_ data: Data, fileExtension: String) -> URL? {
+        let url = makeUniqueURL(fileExtension: fileExtension)
         do {
             try data.write(to: url, options: .atomic)
             return url

--- a/macshot/Services/ImageEncoder.swift
+++ b/macshot/Services/ImageEncoder.swift
@@ -29,6 +29,26 @@ enum ImageEncoder {
             case .avif: return "AVIF"
             }
         }
+
+        nonisolated var fileExtension: String {
+            switch self {
+            case .png: return "png"
+            case .jpeg: return "jpg"
+            case .heic: return "heic"
+            case .webp: return "webp"
+            case .avif: return "avif"
+            }
+        }
+
+        nonisolated var utType: UTType {
+            switch self {
+            case .png: return .png
+            case .jpeg: return .jpeg
+            case .heic: return .heic
+            case .webp: return .webP
+            case .avif: return UTType("public.avif") ?? .image
+            }
+        }
     }
 
     static var format: Format {
@@ -54,23 +74,11 @@ enum ImageEncoder {
     }
 
     static var fileExtension: String {
-        switch format {
-        case .png: return "png"
-        case .jpeg: return "jpg"
-        case .heic: return "heic"
-        case .webp: return "webp"
-        case .avif: return "avif"
-        }
+        format.fileExtension
     }
 
     static var utType: UTType {
-        switch format {
-        case .png: return .png
-        case .jpeg: return .jpeg
-        case .heic: return .heic
-        case .webp: return .webP
-        case .avif: return UTType("public.avif") ?? .image
-        }
+        format.utType
     }
 
     nonisolated static var availableFormats: [Format] {
@@ -97,7 +105,7 @@ enum ImageEncoder {
     /// This is the single conversion point — all encode paths go through here.
     /// Uses cgImage(forProposedRect:) instead of tiffRepresentation to preserve
     /// exact pixel data regardless of the current display's backing scale factor.
-    private static func makeBitmap(_ image: NSImage) -> NSBitmapImageRep? {
+    private static func makeBitmap(_ image: NSImage, downscaleRetina: Bool) -> NSBitmapImageRep? {
         guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             // Fallback for images without a CGImage backing (e.g. PDF/EPS vectors)
             guard let tiffData = image.tiffRepresentation,
@@ -137,8 +145,15 @@ enum ImageEncoder {
 
     /// Encode an NSImage to Data in the configured format.
     static func encode(_ image: NSImage) -> Data? {
-        guard let bitmap = makeBitmap(image) else { return nil }
+        let selectedFormat = format
+        let selectedQuality = quality
+        let shouldDownscale = downscaleRetina
+        guard let bitmap = makeBitmap(image, downscaleRetina: shouldDownscale) else { return nil }
 
+        return encode(bitmap, as: selectedFormat, quality: selectedQuality)
+    }
+
+    private static func encode(_ bitmap: NSBitmapImageRep, as format: Format, quality: CGFloat) -> Data? {
         switch format {
         case .png:
             return encodePNG(bitmap: bitmap)
@@ -224,20 +239,25 @@ enum ImageEncoder {
     private static let clipboardGenerationLock = NSLock()
     private static var clipboardGeneration = 0
 
-    /// Copy image to pasteboard as PNG.
-    /// Explicitly sets PNG data so receiving apps (browsers, editors) get
-    /// a lossless PNG instead of the TIFF that NSImage.writeObjects provides.
+    /// Copy image to pasteboard as PNG by default, or in the configured format
+    /// when opted in. Configured-format failures fall back to PNG compatibility.
     /// Also writes a retained backing file so Finder paste works and clipboard
     /// history tools do not keep references to deleted `/tmp` files.
     static func copyToClipboard(_ image: NSImage, sourceFileURL: URL? = nil) {
         let pasteboard = NSPasteboard.general
         let generation = beginClipboardCopy()
+        let usesConfiguredFormat = UserDefaults.standard.bool(forKey: "clipboardUsesImageFormat")
+        let selectedFormat = usesConfiguredFormat ? format : .png
+        let selectedQuality = quality
+        let shouldDownscale = downscaleRetina
 
         DispatchQueue.global(qos: .userInitiated).async {
-            let validSourceURL = reusableSourceURL(sourceFileURL)
-            guard let bitmap = makeBitmap(image),
-                  let pngData = bitmap.representation(using: .png, properties: [:]) else {
-                if let validSourceURL {
+            guard let bitmap = makeBitmap(image, downscaleRetina: shouldDownscale) else {
+                if let validSourceURL = reusableSourceURL(
+                    sourceFileURL,
+                    format: selectedFormat,
+                    downscaleRetina: shouldDownscale
+                ) {
                     DispatchQueue.main.async {
                         guard isCurrentClipboardCopy(generation) else { return }
                         pasteboard.clearContents()
@@ -247,15 +267,35 @@ enum ImageEncoder {
                 return
             }
 
-            let backingURL = validSourceURL ?? ClipboardBackingStore.writeImageData(pngData)
-            let tiffData = bitmap.representation(using: .tiff, properties: [:])
+            let output: (data: Data, format: Format, includeTIFF: Bool)
+            if usesConfiguredFormat,
+               let configuredData = encode(bitmap, as: selectedFormat, quality: selectedQuality) {
+                output = (configuredData, selectedFormat, false)
+            } else {
+                guard let pngData = bitmap.representation(using: .png, properties: [:]) else { return }
+                output = (pngData, .png, true)
+            }
+
+            let validSourceURL = reusableSourceURL(
+                sourceFileURL,
+                format: output.format,
+                downscaleRetina: shouldDownscale
+            )
+            let backingURL = validSourceURL ?? ClipboardBackingStore.writeImageData(
+                output.data,
+                fileExtension: output.format.fileExtension
+            )
+            let tiffData = output.includeTIFF
+                ? bitmap.representation(using: .tiff, properties: [:])
+                : nil
 
             DispatchQueue.main.async {
                 guard isCurrentClipboardCopy(generation) else { return }
                 writeImagePasteboard(
                     pasteboard,
                     backingURL: backingURL,
-                    pngData: pngData,
+                    imageData: output.data,
+                    imageType: NSPasteboard.PasteboardType(output.format.utType.identifier),
                     tiffData: tiffData
                 )
             }
@@ -275,10 +315,14 @@ enum ImageEncoder {
         return generation == clipboardGeneration
     }
 
-    private static func reusableSourceURL(_ url: URL?) -> URL? {
+    private static func reusableSourceURL(
+        _ url: URL?,
+        format: Format,
+        downscaleRetina: Bool
+    ) -> URL? {
         guard let url else { return nil }
         guard !downscaleRetina else { return nil }
-        guard url.pathExtension.lowercased() == "png" else { return nil }
+        guard url.pathExtension.lowercased() == format.fileExtension else { return nil }
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
         return url
     }
@@ -286,30 +330,31 @@ enum ImageEncoder {
     private static func writeImagePasteboard(
         _ pasteboard: NSPasteboard,
         backingURL: URL?,
-        pngData: Data,
+        imageData: Data,
+        imageType: NSPasteboard.PasteboardType,
         tiffData: Data?
     ) {
         pasteboard.clearContents()
 
         if let backingURL, pasteboard.writeObjects([backingURL as NSURL]) {
-            var extraTypes: [NSPasteboard.PasteboardType] = [.png]
+            var extraTypes: [NSPasteboard.PasteboardType] = [imageType]
             if tiffData != nil {
                 extraTypes.append(.tiff)
             }
             pasteboard.addTypes(extraTypes, owner: nil)
-            pasteboard.setData(pngData, forType: .png)
+            pasteboard.setData(imageData, forType: imageType)
             if let tiffData {
                 pasteboard.setData(tiffData, forType: .tiff)
             }
             return
         }
 
-        var types: [NSPasteboard.PasteboardType] = [.png]
+        var types: [NSPasteboard.PasteboardType] = [imageType]
         if tiffData != nil {
             types.append(.tiff)
         }
         pasteboard.declareTypes(types, owner: nil)
-        pasteboard.setData(pngData, forType: .png)
+        pasteboard.setData(imageData, forType: imageType)
         if let tiffData {
             pasteboard.setData(tiffData, forType: .tiff)
         }

--- a/macshot/UI/Windows/SettingsWindowController.swift
+++ b/macshot/UI/Windows/SettingsWindowController.swift
@@ -101,6 +101,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
     private var quickModePopup: NSPopUpButton!
     private var quickCaptureOpenEditorCheckbox: NSButton!
     private var imageFormatPopup: NSPopUpButton!
+    private var clipboardUsesImageFormatCheckbox: NSButton!
     private var qualitySlider: NSSlider!
     private var qualityLabel: NSTextField!
     private var qualityRowLabel: NSTextField!
@@ -916,6 +917,14 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         imageFormatPopup.action = #selector(imageFormatChanged(_:))
 
         stack.addArrangedSubview(labeledRow(L("Image format:"), controls: [imageFormatPopup]))
+        stack.setCustomSpacing(2, after: stack.arrangedSubviews.last!)
+
+        clipboardUsesImageFormatCheckbox = NSButton(
+            checkboxWithTitle: L("Use image format for clipboard copies"),
+            target: self,
+            action: #selector(clipboardUsesImageFormatChanged(_:))
+        )
+        stack.addArrangedSubview(indented(clipboardUsesImageFormatCheckbox))
         stack.setCustomSpacing(8, after: stack.arrangedSubviews.last!)
 
         // Quality (applies to lossy formats: JPEG, HEIC, WebP, AVIF)
@@ -2609,6 +2618,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         quickCaptureOpenEditorCheckbox.state = UserDefaults.standard.bool(forKey: "quickCaptureOpenEditor") ? .on : .off
 
         selectImageFormat(ImageEncoder.format)
+        clipboardUsesImageFormatCheckbox.state = UserDefaults.standard.bool(forKey: "clipboardUsesImageFormat") ? .on : .off
 
         let quality = Int(ImageEncoder.quality * 100)
         qualitySlider.integerValue = quality
@@ -2770,6 +2780,9 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSWindowD
         else { return }
         UserDefaults.standard.set(raw, forKey: "imageFormat")
         updateQualityVisibility()
+    }
+    @objc private func clipboardUsesImageFormatChanged(_ sender: NSButton) {
+        UserDefaults.standard.set(sender.state == .on, forKey: "clipboardUsesImageFormat")
     }
     @objc private func qualityChanged(_ sender: NSSlider) {
         qualityLabel.stringValue = String(format: L("%d%%"), sender.integerValue)

--- a/macshot/en.lproj/Localizable.strings
+++ b/macshot/en.lproj/Localizable.strings
@@ -240,6 +240,7 @@
 "Move down" = "Move down";
 "Output" = "Output";
 "Image format:" = "Image format:";
+"Use image format for clipboard copies" = "Use image format for clipboard copies";
 "Quality:" = "Quality:";
 "%d%%" = "%d%%";
 "Save at standard resolution (1x)" = "Save at standard resolution (1x)";


### PR DESCRIPTION
## Summary
- add an opt-in **Use image format for clipboard copies** setting under Output
- encode clipboard images using the configured format and quality, including AVIF
- publish the matching pasteboard type and retained backing-file extension
- preserve PNG + TIFF clipboard compatibility by default and fall back to PNG if configured encoding fails

## Compatibility

The new setting defaults to off, so existing users keep the intentional PNG clipboard behavior introduced in v3.5.1. Users who opt in get their selected image format without a PNG/TIFF representation silently overriding formats such as AVIF.

## Verification

- `xcodebuild -project macshot.xcodeproj -scheme macshot -configuration Debug -derivedDataPath /tmp/macshot-pr373-debug CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project macshot.xcodeproj -scheme macshot -configuration Release -derivedDataPath /tmp/macshot-pr373-release CODE_SIGNING_ALLOWED=NO build`
- `plutil -lint macshot/en.lproj/Localizable.strings`
- `git diff --check`
- fresh read-only review found no material issues

Closes #373
